### PR TITLE
added support for useObjectId

### DIFF
--- a/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
@@ -684,6 +684,7 @@ mongoService.save("smartPeople", document, res -> {
   }
 
 });
+----
 
 Here's an example of inserting a base 64 encoded string, typing it as binary a binary field, and reading it back
 
@@ -773,7 +774,10 @@ The following configuration is supported by the mongo client:
 
 
 `db_name`:: Name of the database in the mongoDB instance to use. Defaults to `default_db`
-`useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. Defaults to `false`.
+`useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true', hex-strings will
+be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
+time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false' for other types of your choosing.
+Defaults to `false`.
 
 The mongo client tries to support most options that are allowed by the driver. There are two ways to configure mongo
 for use by the driver, either by a connection string or by separate configuration options.

--- a/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
@@ -777,6 +777,7 @@ The following configuration is supported by the mongo client:
 `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true', hex-strings will
 be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
 time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false' for other types of your choosing.
+If set to false, or left to default, hex strings will be generated as the document _id if the _id is omitted from the document.
 Defaults to `false`.
 
 The mongo client tries to support most options that are allowed by the driver. There are two ways to configure mongo

--- a/vertx-mongo-client/src/main/asciidoc/java/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/java/index.adoc
@@ -647,6 +647,7 @@ The following configuration is supported by the mongo client:
 `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true', hex-strings will
 be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
 time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false' for other types of your choosing.
+If set to false, or left to default, hex strings will be generated as the document _id if the _id is omitted from the document.
 Defaults to `false`.
 
 The mongo client tries to support most options that are allowed by the driver. There are two ways to configure mongo

--- a/vertx-mongo-client/src/main/asciidoc/java/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/java/index.adoc
@@ -571,6 +571,7 @@ mongoService.save("smartPeople", document, res -> {
   }
 
 });
+----
 
 Here's an example of inserting a base 64 encoded string, typing it as binary a binary field, and reading it back
 
@@ -643,7 +644,10 @@ The following configuration is supported by the mongo client:
 
 
 `db_name`:: Name of the database in the mongoDB instance to use. Defaults to `default_db`
-`useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. Defaults to `false`.
+`useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true', hex-strings will
+be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
+time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false' for other types of your choosing.
+Defaults to `false`.
 
 The mongo client tries to support most options that are allowed by the driver. There are two ways to configure mongo
 for use by the driver, either by a connection string or by separate configuration options.

--- a/vertx-mongo-client/src/main/asciidoc/js/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/js/index.adoc
@@ -778,6 +778,7 @@ The following configuration is supported by the mongo client:
 `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true', hex-strings will
 be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
 time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false' for other types of your choosing.
+If set to false, or left to default, hex strings will be generated as the document _id if the _id is omitted from the document.
 Defaults to `false`.
 
 The mongo client tries to support most options that are allowed by the driver. There are two ways to configure mongo

--- a/vertx-mongo-client/src/main/asciidoc/js/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/js/index.adoc
@@ -685,6 +685,7 @@ mongoService.save("smartPeople", document, res -> {
   }
 
 });
+----
 
 Here's an example of inserting a base 64 encoded string, typing it as binary a binary field, and reading it back
 
@@ -774,7 +775,10 @@ The following configuration is supported by the mongo client:
 
 
 `db_name`:: Name of the database in the mongoDB instance to use. Defaults to `default_db`
-`useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. Defaults to `false`.
+`useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true', hex-strings will
+be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
+time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false' for other types of your choosing.
+Defaults to `false`.
 
 The mongo client tries to support most options that are allowed by the driver. There are two ways to configure mongo
 for use by the driver, either by a connection string or by separate configuration options.

--- a/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
@@ -687,6 +687,7 @@ mongoService.save("smartPeople", document, res -> {
   }
 
 });
+----
 
 Here's an example of inserting a base 64 encoded string, typing it as binary a binary field, and reading it back
 
@@ -776,7 +777,10 @@ The following configuration is supported by the mongo client:
 
 
 `db_name`:: Name of the database in the mongoDB instance to use. Defaults to `default_db`
-`useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. Defaults to `false`.
+`useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true', hex-strings will
+be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
+time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false' for other types of your choosing.
+Defaults to `false`.
 
 The mongo client tries to support most options that are allowed by the driver. There are two ways to configure mongo
 for use by the driver, either by a connection string or by separate configuration options.

--- a/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
@@ -780,6 +780,7 @@ The following configuration is supported by the mongo client:
 `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true', hex-strings will
 be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
 time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false' for other types of your choosing.
+If set to false, or left to default, hex strings will be generated as the document _id if the _id is omitted from the document.
 Defaults to `false`.
 
 The mongo client tries to support most options that are allowed by the driver. There are two ways to configure mongo

--- a/vertx-mongo-client/src/main/groovy/io/vertx/groovy/ext/mongo/MongoClient.groovy
+++ b/vertx-mongo-client/src/main/groovy/io/vertx/groovy/ext/mongo/MongoClient.groovy
@@ -17,7 +17,6 @@
 package io.vertx.groovy.ext.mongo;
 import groovy.transform.CompileStatic
 import io.vertx.lang.groovy.InternalHelper
-import io.vertx.core.json.JsonObject
 import java.util.List
 import io.vertx.ext.mongo.WriteOption
 import io.vertx.groovy.core.Vertx

--- a/vertx-mongo-client/src/main/groovy/io/vertx/groovy/ext/mongo/MongoClient.groovy
+++ b/vertx-mongo-client/src/main/groovy/io/vertx/groovy/ext/mongo/MongoClient.groovy
@@ -17,6 +17,7 @@
 package io.vertx.groovy.ext.mongo;
 import groovy.transform.CompileStatic
 import io.vertx.lang.groovy.InternalHelper
+import io.vertx.core.json.JsonObject
 import java.util.List
 import io.vertx.ext.mongo.WriteOption
 import io.vertx.groovy.core.Vertx

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -96,10 +96,10 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
       coll.insertOne(document, convertCallback(resultHandler, wr -> useObjectId ? document.getJsonObject(ID_FIELD).getString(JsonObjectCodec.OID_FIELD) : document.getString(ID_FIELD)));
     } else {
       JsonObject filter = new JsonObject();
-      encodeKeyWhenUseObjectId(document);
-      filter.put(ID_FIELD, document.getValue(ID_FIELD));
+      JsonObject encodedDocument = encodeKeyWhenUseObjectId(document);
+      filter.put(ID_FIELD, encodedDocument.getValue(ID_FIELD));
 
-      coll.replaceOne(wrap(filter), document, convertCallback(resultHandler, result -> null));
+      coll.replaceOne(wrap(filter), encodedDocument, convertCallback(resultHandler, result -> null));
     }
     return this;
   }
@@ -118,15 +118,15 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
 
     boolean id = document.containsKey(ID_FIELD);
 
-    encodeKeyWhenUseObjectId(document);
+    JsonObject encodedDocument = encodeKeyWhenUseObjectId(document);
 
     MongoCollection<JsonObject> coll = getCollection(collection, writeOption);
-    coll.insertOne(document, convertCallback(resultHandler, wr -> {
+    coll.insertOne(encodedDocument, convertCallback(resultHandler, wr -> {
       if (id) {
         return null;
       } else {
-        decodeKeyWhenUseObjectId(document);
-        return document.getString(ID_FIELD);
+        JsonObject decodedDocument = decodeKeyWhenUseObjectId(encodedDocument);
+        return decodedDocument.getString(ID_FIELD);
       }
     }));
     return this;
@@ -172,7 +172,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     requireNonNull(resultHandler, "resultHandler cannot be null");
 
     boolean id = query.containsKey(ID_FIELD);
-    encodeKeyWhenUseObjectId(query);
+    query = encodeKeyWhenUseObjectId(query);
 
     MongoCollection<JsonObject> coll = getCollection(collection, options.getWriteOption());
     Bson bquery = wrap(query);
@@ -204,7 +204,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     requireNonNull(query, "query cannot be null");
     requireNonNull(resultHandler, "resultHandler cannot be null");
 
-    encodeKeyWhenUseObjectId(query);
+    query = encodeKeyWhenUseObjectId(query);
 
     Bson bquery = wrap(query);
     Bson bfields = wrap(fields);

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -34,6 +34,7 @@ import io.vertx.core.shareddata.Shareable;
 import io.vertx.ext.mongo.FindOptions;
 import io.vertx.ext.mongo.UpdateOptions;
 import io.vertx.ext.mongo.WriteOption;
+import io.vertx.ext.mongo.impl.codec.json.JsonObjectCodec;
 import io.vertx.ext.mongo.impl.config.MongoClientOptionsParser;
 import org.bson.conversions.Bson;
 
@@ -54,7 +55,6 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
   private static final UpdateOptions DEFAULT_UPDATE_OPTIONS = new UpdateOptions();
   private static final FindOptions DEFAULT_FIND_OPTIONS = new FindOptions();
   private static final String ID_FIELD = "_id";
-  private static final String OID_FIELD = "$oid";
 
   private static final String DS_LOCAL_MAP_NAME = "__vertx.MongoClient.datasources";
 
@@ -93,7 +93,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     MongoCollection<JsonObject> coll = getCollection(collection, writeOption);
     Object id = document.getValue(ID_FIELD);
     if (id == null) {
-      coll.insertOne(document, convertCallback(resultHandler, wr -> useObjectId ? document.getJsonObject(ID_FIELD).getString(OID_FIELD) : document.getString(ID_FIELD)));
+      coll.insertOne(document, convertCallback(resultHandler, wr -> useObjectId ? document.getJsonObject(ID_FIELD).getString(JsonObjectCodec.OID_FIELD) : document.getString(ID_FIELD)));
     } else {
       JsonObject filter = new JsonObject();
       encodeKeyWhenUseObjectId(document);
@@ -320,14 +320,14 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
 
   private JsonObject encodeKeyWhenUseObjectId(JsonObject json) {
     if (useObjectId && json.containsKey(ID_FIELD) && json.getValue(ID_FIELD) instanceof String) {
-      json.put(ID_FIELD, new JsonObject().put(OID_FIELD, json.getString(ID_FIELD)));
+      json.put(ID_FIELD, new JsonObject().put(JsonObjectCodec.OID_FIELD, json.getString(ID_FIELD)));
     }
     return json;
   }
 
   private JsonObject decodeKeyWhenUseObjectId(JsonObject json) {
     if (useObjectId && json.containsKey(ID_FIELD)) {
-      json.put(ID_FIELD, json.getJsonObject(ID_FIELD).getString(OID_FIELD));
+      json.put(ID_FIELD, json.getJsonObject(ID_FIELD).getString(JsonObjectCodec.OID_FIELD));
     }
     return json;
   }

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/VertxCodecRegistry.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/VertxCodecRegistry.java
@@ -25,7 +25,11 @@ import org.bson.codecs.configuration.CodecRegistry;
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
 public class VertxCodecRegistry implements CodecRegistry {
-  private Codec<JsonObject> jsonObjectCodec = new JsonObjectCodec();
+  private Codec<JsonObject> jsonObjectCodec;
+
+  public VertxCodecRegistry(JsonObject config) {
+    jsonObjectCodec = new JsonObjectCodec(config);
+  }
 
   @Override
   @SuppressWarnings("unchecked")

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
@@ -25,12 +25,20 @@ public class JsonObjectCodec extends AbstractJsonCodec<JsonObject, JsonArray> im
   public static final String BINARY_FIELD = "$binary";
   public static final String OID_FIELD = "$oid";
 
+  private boolean useObjectId = false;
+
+  public JsonObjectCodec(JsonObject config) {
+    useObjectId = config.getBoolean("useObjectId", false);
+  }
+
   @Override
   public JsonObject generateIdIfAbsentFromDocument(JsonObject json) {
-    //TODO: Is this faster/better then Java UUID ?
+
     if (!documentHasId(json)) {
       ObjectId id = new ObjectId();
-      json.put(ID_FIELD, id.toHexString());
+
+      if (useObjectId) json.put(ID_FIELD, new JsonObject().put("$oid", id.toHexString()));
+      else json.put(ID_FIELD, id.toHexString());
     }
     return json;
   }
@@ -157,11 +165,9 @@ public class JsonObjectCodec extends AbstractJsonCodec<JsonObject, JsonArray> im
 
   @Override
   protected Object readObjectId(BsonReader reader, DecoderContext ctx) {
-    //return reader.readObjectId().toHexString();
 
-    final JsonObject result = new JsonObject();
-    result.put(OID_FIELD, reader.readObjectId().toHexString());
-    return  result;
+    if (reader.getCurrentName().equals(ID_FIELD)) return reader.readObjectId().toHexString();
+    return  new JsonObject().put(OID_FIELD, reader.readObjectId().toHexString());
   }
 
   @Override

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
@@ -166,7 +166,9 @@ public class JsonObjectCodec extends AbstractJsonCodec<JsonObject, JsonArray> im
   @Override
   protected Object readObjectId(BsonReader reader, DecoderContext ctx) {
 
-    if (reader.getCurrentName().equals(ID_FIELD)) return reader.readObjectId().toHexString();
+    if (reader.getCurrentName().equals(ID_FIELD)) {
+      return reader.readObjectId().toHexString();
+    }
     return  new JsonObject().put(OID_FIELD, reader.readObjectId().toHexString());
   }
 

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParser.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParser.java
@@ -23,7 +23,7 @@ public class MongoClientOptionsParser {
     Objects.requireNonNull(config);
 
     MongoClientSettings.Builder options = MongoClientSettings.builder();
-    options.codecRegistry(new VertxCodecRegistry());
+    options.codecRegistry(new VertxCodecRegistry(config));
 
     // All parsers should support connection_string first
     String cs = config.getString("connection_string");

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
@@ -351,7 +351,10 @@
  *
  *
  * `db_name`:: Name of the database in the mongoDB instance to use. Defaults to `default_db`
- * `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. Defaults to `false`.
+ * `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true', hex-strings will
+ * be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
+ * time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false' for other types of your choosing.
+ * Defaults to `false`.
  *
  * The mongo client tries to support most options that are allowed by the driver. There are two ways to configure mongo
  * for use by the driver, either by a connection string or by separate configuration options.

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
@@ -354,6 +354,7 @@
  * `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true', hex-strings will
  * be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
  * time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false' for other types of your choosing.
+ * If set to false, or left to default, hex strings will be generated as the document _id if the _id is omitted from the document.
  * Defaults to `false`.
  *
  * The mongo client tries to support most options that are allowed by the driver. There are two ways to configure mongo

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
@@ -7,6 +7,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.TestUtils;
 import org.bson.types.ObjectId;
+import org.jruby.RubyProcess;
 import org.junit.Test;
 
 import java.io.*;
@@ -627,7 +628,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     await();
   }
 
-  //@Test
+  @Test
   public void testReplace() {
     String collection = randomCollection();
     JsonObject doc = createDoc();
@@ -652,7 +653,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     await();
   }
 
-  //@Test
+  @Test
   public void testReplaceUpsert() {
     String collection = randomCollection();
     JsonObject doc = createDoc();
@@ -679,7 +680,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     await();
   }
 
-  //@Test
+  @Test
   public void testReplaceUpsert2() {
     String collection = randomCollection();
     JsonObject doc = createDoc();
@@ -713,7 +714,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     }));
   }
 
-  //@Test
+  @Test
   public void testUpdateOne() throws Exception {
     int num = 1;
     doTestUpdate(num, new JsonObject().put("num", 123), new JsonObject().put("$set", new JsonObject().put("foo", "fooed")), new UpdateOptions(), results -> {
@@ -726,7 +727,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     });
   }
 
-  //@Test
+  @Test
   public void testUpdateAll() throws Exception {
     int num = 10;
     doTestUpdate(num, new JsonObject().put("num", 123), new JsonObject().put("$set", new JsonObject().put("foo", "fooed")), new UpdateOptions(false, true), results -> {

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
@@ -7,7 +7,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.TestUtils;
 import org.bson.types.ObjectId;
-import org.jruby.RubyProcess;
 import org.junit.Test;
 
 import java.io.*;

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
@@ -18,8 +18,6 @@ import java.util.function.Consumer;
 
 import static io.vertx.ext.mongo.WriteOption.ACKNOWLEDGED;
 import static io.vertx.ext.mongo.WriteOption.UNACKNOWLEDGED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -147,7 +145,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     String collection = randomCollection();
     mongoClient.createCollection(collection, onSuccess(res -> {
       JsonObject doc = createDoc();
-      String genID  = TestUtils.randomAlphaString(100);
+      String genID = TestUtils.randomAlphaString(100);
       doc.put("_id", genID);
       mongoClient.insert(collection, doc, onSuccess(id -> {
         assertNull(id);
@@ -162,7 +160,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     String collection = randomCollection();
     mongoClient.createCollection(collection, onSuccess(res -> {
       JsonObject doc = createDoc();
-      Long genID  = TestUtils.randomLong();
+      Long genID = TestUtils.randomLong();
       doc.put("_id", genID);
       mongoClient.insertWithOptions(collection, doc, ACKNOWLEDGED, onSuccess(id -> {
         assertNull(id);
@@ -177,7 +175,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     String collection = randomCollection();
     mongoClient.createCollection(collection, onSuccess(res -> {
       JsonObject doc = createDoc();
-      Long genID  = TestUtils.randomLong();
+      Long genID = TestUtils.randomLong();
       doc.put("_id", genID);
       mongoClient.saveWithOptions(collection, doc, ACKNOWLEDGED, onSuccess(id -> {
         assertNull(id);
@@ -192,7 +190,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     String collection = randomCollection();
     mongoClient.createCollection(collection, onSuccess(res -> {
       JsonObject doc = createDoc();
-      JsonObject genID  = new JsonObject().put("id", TestUtils.randomAlphaString(100));
+      JsonObject genID = new JsonObject().put("id", TestUtils.randomAlphaString(100));
       doc.put("_id", genID);
       mongoClient.insertWithOptions(collection, doc, ACKNOWLEDGED, onSuccess(id -> {
         assertNull(id);
@@ -629,7 +627,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     await();
   }
 
-  @Test
+  //@Test
   public void testReplace() {
     String collection = randomCollection();
     JsonObject doc = createDoc();
@@ -654,7 +652,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     await();
   }
 
-  @Test
+  //@Test
   public void testReplaceUpsert() {
     String collection = randomCollection();
     JsonObject doc = createDoc();
@@ -681,7 +679,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     await();
   }
 
-  @Test
+  //@Test
   public void testReplaceUpsert2() {
     String collection = randomCollection();
     JsonObject doc = createDoc();
@@ -715,7 +713,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     }));
   }
 
-  @Test
+  //@Test
   public void testUpdateOne() throws Exception {
     int num = 1;
     doTestUpdate(num, new JsonObject().put("num", 123), new JsonObject().put("$set", new JsonObject().put("foo", "fooed")), new UpdateOptions(), results -> {
@@ -728,7 +726,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     });
   }
 
-  @Test
+  //@Test
   public void testUpdateAll() throws Exception {
     int num = 10;
     doTestUpdate(num, new JsonObject().put("num", 123), new JsonObject().put("$set", new JsonObject().put("foo", "fooed")), new UpdateOptions(false, true), results -> {
@@ -822,7 +820,6 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     document.put("foo", "bar");
 
     mongoClient.insert(collection, document, onSuccess(id -> {
-      System.out.println("Inserted with id " + id);
       mongoClient.findOne(collection, new JsonObject(), null, onSuccess(retrieved -> {
         assertEquals(document, retrieved);
         testComplete();
@@ -831,7 +828,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     await();
   }
 
-  private JsonObject createDoc() {
+  protected JsonObject createDoc() {
     return new JsonObject().put("foo", "bar").put("num", 123).put("big", true).putNull("nullentry").
       put("arr", new JsonArray().add("x").add(true).add(12).add(1.23).addNull().add(new JsonObject().put("wib", "wob"))).
       put("date", new JsonObject().put("$date", "2015-05-30T22:50:02Z")).
@@ -840,7 +837,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
         new JsonArray().add("blah").add(true).add(312)));
   }
 
-  private JsonObject createDoc(int num) {
+  protected JsonObject createDoc(int num) {
     return new JsonObject().put("foo", "bar" + (num != -1 ? num : "")).put("num", 123).put("big", true).putNull("nullentry").
       put("arr", new JsonArray().add("x").add(true).add(12).add(1.23).addNull().add(new JsonObject().put("wib", "wob"))).
       put("date", new JsonObject().put("$date", "2015-05-30T22:50:02Z")).
@@ -900,7 +897,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
   }
 
 
-  private String randomCollection() {
+  protected String randomCollection() {
     return "ext-mongo" + TestUtils.randomAlphaString(20);
   }
 

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientWithObjectIdTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientWithObjectIdTest.java
@@ -1,0 +1,158 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import org.bson.types.ObjectId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+import static io.vertx.ext.mongo.WriteOption.ACKNOWLEDGED;
+
+public class MongoClientWithObjectIdTest extends MongoClientTestBase {
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    JsonObject config = getConfig();
+    config.put("useObjectId", true);
+    mongoClient = MongoClient.createNonShared(vertx, config);
+    CountDownLatch latch = new CountDownLatch(1);
+    dropCollections(latch);
+    awaitLatch(latch);
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    mongoClient.close();
+    super.tearDown();
+  }
+
+  protected void assertEquals(JsonObject expected, JsonObject actual) {
+
+    //Test cases will fail unless we map the $oid first
+    if (actual.containsKey("_id")) {
+      if (actual.getValue("_id") instanceof String) {
+        actual.put("_id", new JsonObject().put("$oid", actual.getString("_id")));
+      }
+    }
+    super.assertEquals(expected, actual);
+
+  }
+
+  @Test
+  @Override
+  public void testSavePreexistingLongID() throws Exception {
+    //Override this test as it does not make sense for useObjectId = true
+    assertTrue(true);
+    testComplete();
+    await();
+  }
+
+  @Test
+  public void testFindOneReturnsStringId() throws Exception {
+    String collection = randomCollection();
+    mongoClient.createCollection(collection, onSuccess(res -> {
+      JsonObject orig = createDoc();
+      JsonObject doc = orig.copy();
+      mongoClient.insert(collection, doc, onSuccess(id -> {
+        assertNotNull(id);
+        mongoClient.findOne(collection, new JsonObject().put("foo", "bar"), null, onSuccess(obj -> {
+          assertTrue(obj.getValue("_id") instanceof String);
+          assertTrue(obj.containsKey("_id"));
+          obj.remove("_id");
+          assertEquals(orig, obj);
+          testComplete();
+        }));
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  @Override
+  public void testInsertPreexistingObjectID() throws Exception {
+    String collection = randomCollection();
+    mongoClient.createCollection(collection, onSuccess(res -> {
+      JsonObject doc = createDoc();
+      //Changed to hex string as a random string will not be valid for useObjectId = true
+      doc.put("_id", new ObjectId().toHexString());
+      mongoClient.insertWithOptions(collection, doc, ACKNOWLEDGED, onSuccess(id -> {
+        assertNull(id);
+        testComplete();
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  @Override
+  public void testInsertPreexistingID() throws Exception {
+    String collection = randomCollection();
+    mongoClient.createCollection(collection, onSuccess(res -> {
+      JsonObject doc = createDoc();
+      //Changed to hex string as a random string will not be valid for useObjectId = true
+      doc.put("_id", new ObjectId().toHexString());
+      mongoClient.insert(collection, doc, onSuccess(id -> {
+        assertNull(id);
+        testComplete();
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  @Override
+  public void testInsertRetrieve() throws Exception {
+    String collection = randomCollection();
+    mongoClient.createCollection(collection, onSuccess(res -> {
+      JsonObject doc = createDoc();
+      //Changed to hex string as a random string will not be valid for useObjectId = true
+      doc.put("_id", new ObjectId().toHexString());
+      mongoClient.insert(collection, doc, onSuccess(id -> {
+        assertNull(id);
+        mongoClient.findOne(collection, new JsonObject(), null, onSuccess(retrieved -> {
+          assertEquals(doc, retrieved);
+          testComplete();
+        }));
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  @Override
+  public void testSavePreexistingObjectID() throws Exception {
+    String collection = randomCollection();
+    mongoClient.createCollection(collection, onSuccess(res -> {
+      JsonObject doc = createDoc();
+      //Changed to hex string as a random string will not be valid for useObjectId = true
+      doc.put("_id", new ObjectId().toHexString());
+      mongoClient.saveWithOptions(collection, doc, ACKNOWLEDGED, onSuccess(id -> {
+        assertNull(id);
+        testComplete();
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  public void testInsertAlreadyExists() throws Exception {
+    String collection = randomCollection();
+    mongoClient.createCollection(collection, onSuccess(res -> {
+      JsonObject doc = createDoc();
+      mongoClient.insert(collection, doc, onSuccess(id -> {
+        assertNotNull(id);
+        System.out.println("Existing ID: " + id);
+        doc.put("_id", id);
+        mongoClient.insert(collection, doc, response -> {
+          System.out.println("Succeeded: " + response.succeeded());
+          System.out.println("Result: " + response.result());
+              assertFalse(response.succeeded());
+              testComplete();
+        });
+      }));
+    }));
+    await();
+  }
+}

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodecTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodecTest.java
@@ -14,6 +14,7 @@ import java.time.ZoneOffset;
 
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -21,9 +22,11 @@ import static org.junit.Assert.assertTrue;
  */
 public class JsonObjectCodecTest {
 
+  private JsonObject options = new JsonObject();
+
   @Test
   public void getBsonType_returnsDateTimeType_WhenValueIsJsonObjectAndContainsDateField() {
-    JsonObjectCodec codec = new JsonObjectCodec();
+    JsonObjectCodec codec = new JsonObjectCodec(options);
 
     JsonObject value = new JsonObject();
     value.put(JsonObjectCodec.DATE_FIELD, "2015-05-30T22:50:02+02:00");
@@ -33,7 +36,7 @@ public class JsonObjectCodecTest {
 
   @Test
   public void writeDocument_supportBsonDateTime() {
-    JsonObjectCodec codec = new JsonObjectCodec();
+    JsonObjectCodec codec = new JsonObjectCodec(options);
 
     OffsetDateTime now = OffsetDateTime.now();
     JsonObject dateValue = new JsonObject();
@@ -53,7 +56,7 @@ public class JsonObjectCodecTest {
 
   @Test
   public void readDocument_supportBsonDateTime() {
-    JsonObjectCodec codec = new JsonObjectCodec();
+    JsonObjectCodec codec = new JsonObjectCodec(options);
 
     Instant now = Instant.now();
     BsonDocument bson = new BsonDocument();
@@ -69,7 +72,7 @@ public class JsonObjectCodecTest {
 
   @Test
   public void writeDocument_supportBsonDateTimeWithMillis() {
-    JsonObjectCodec codec = new JsonObjectCodec();
+    JsonObjectCodec codec = new JsonObjectCodec(options);
 
     JsonObject dateValue = new JsonObject();
     dateValue.put(JsonObjectCodec.DATE_FIELD, "2011-12-03T10:15:30.500+01:00");
@@ -96,7 +99,7 @@ public class JsonObjectCodecTest {
 
   @Test
   public void writeDocument_supportBsonBinary() {
-    JsonObjectCodec codec = new JsonObjectCodec();
+    JsonObjectCodec codec = new JsonObjectCodec(options);
 
     OffsetDateTime now = OffsetDateTime.now();
 
@@ -135,7 +138,7 @@ public class JsonObjectCodecTest {
 
   @Test
   public void readDocument_supportBsonBinary() {
-    JsonObjectCodec codec = new JsonObjectCodec();
+    JsonObjectCodec codec = new JsonObjectCodec(options);
 
     Instant now = Instant.now();
     BsonDocument bson = new BsonDocument();
@@ -168,7 +171,7 @@ public class JsonObjectCodecTest {
   }
   @Test
   public void readDocument_supportObjectId() {
-    JsonObjectCodec codec = new JsonObjectCodec();
+    JsonObjectCodec codec = new JsonObjectCodec(options);
 
     BsonDocument bson = new BsonDocument();
 
@@ -186,7 +189,7 @@ public class JsonObjectCodecTest {
 
   @Test
   public void writeDocument_supportObjectId() {
-    JsonObjectCodec codec = new JsonObjectCodec();
+    JsonObjectCodec codec = new JsonObjectCodec(options);
 
     ObjectId objectId = new ObjectId();
     JsonObject oidJson = new JsonObject();
@@ -205,6 +208,47 @@ public class JsonObjectCodecTest {
     BsonObjectId bsonObjectId = resultValue.asObjectId();
 
     assertEquals(objectId.toHexString(), bsonObjectId.getValue().toHexString());
+
+  }
+
+  @Test
+  public void hexStringAsKeyDefault() {
+
+    JsonObject document = new JsonObject();
+
+    JsonObjectCodec codec = new JsonObjectCodec(options);
+    document = codec.generateIdIfAbsentFromDocument(document);
+
+    assertTrue(document.containsKey("_id"));
+    assertTrue(document.getValue("_id") instanceof String);
+
+  }
+
+  @Test
+  public void objectIdAsKeySpecified() {
+
+    JsonObject customOptions = new JsonObject().put("useObjectId", false);
+    JsonObject document = new JsonObject();
+
+    JsonObjectCodec codec = new JsonObjectCodec(customOptions);
+    document = codec.generateIdIfAbsentFromDocument(document);
+
+    assertTrue(document.containsKey("_id"));
+    assertTrue(document.getValue("_id") instanceof String);
+
+  }
+
+  @Test
+  public void objectIdAsKey() {
+
+    JsonObject customOptions = new JsonObject().put("useObjectId", true);
+    JsonObject document = new JsonObject();
+
+    JsonObjectCodec codec = new JsonObjectCodec(customOptions);
+    document = codec.generateIdIfAbsentFromDocument(document);
+
+    assertTrue(document.containsKey("_id"));
+    assertTrue(document.getValue("_id") instanceof JsonObject);
 
   }
 


### PR DESCRIPTION
Fixed issue 36 to add support for useObjectId in the configuration. If set to true, the _id field will be saved as an ObjectId in native MongoDB format. When read, it will be returned to the reader as a hex string rather than a compound $oid field. If the _id is set by the user prior to insert, it should be as a valid hex string.

I suggest merging sooner rather than later. It's a fairly core change and should be tested well prior to release in 3.1 I'm using the 3.1 SNAPSHOT with this change in an important project and it seems to be fine so far.