### PR TITLE
Improve ObjectId support

### DIFF
--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/AbstractJsonCodec.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/AbstractJsonCodec.java
@@ -148,8 +148,7 @@ public abstract class AbstractJsonCodec<O, A> implements Codec<O> {
   protected BsonType getBsonType(Object value) {
     if (value == null) {
       return BsonType.NULL;
-    } else
-    if (value instanceof Boolean) {
+    } else if (value instanceof Boolean) {
       return BsonType.BOOLEAN;
     } else if (value instanceof Double) {
       return BsonType.DOUBLE;
@@ -159,6 +158,8 @@ public abstract class AbstractJsonCodec<O, A> implements Codec<O> {
       return BsonType.INT64;
     } else if (value instanceof String) {
       return BsonType.STRING;
+    } else if (isObjectIdInstance(value)) {
+      return BsonType.OBJECT_ID;
     } else if (isObjectInstance(value)) {
       return BsonType.DOCUMENT;
     } else if (isArrayInstance(value)) {
@@ -218,6 +219,8 @@ public abstract class AbstractJsonCodec<O, A> implements Codec<O> {
   protected void writeString(BsonWriter writer, String name, Object value, EncoderContext ctx) {
     writer.writeString((String) value);
   }
+
+  protected abstract boolean isObjectIdInstance(Object instance);
 
   //-------------- JSON Object
 

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
@@ -1,5 +1,6 @@
 package io.vertx.ext.mongo.impl.codec.json;
 
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.bson.*;
@@ -37,7 +38,7 @@ public class JsonObjectCodec extends AbstractJsonCodec<JsonObject, JsonArray> im
     if (!documentHasId(json)) {
       ObjectId id = new ObjectId();
 
-      if (useObjectId) json.put(ID_FIELD, new JsonObject().put("$oid", id.toHexString()));
+      if (useObjectId) json.put(ID_FIELD, new JsonObject().put(OID_FIELD, id.toHexString()));
       else json.put(ID_FIELD, id.toHexString());
     }
     return json;
@@ -71,6 +72,14 @@ public class JsonObjectCodec extends AbstractJsonCodec<JsonObject, JsonArray> im
   @Override
   public Class<JsonObject> getEncoderClass() {
     return JsonObject.class;
+  }
+
+  @Override
+  protected boolean isObjectIdInstance(Object instance) {
+    if (instance instanceof JsonObject && ((JsonObject) instance).containsKey(OID_FIELD)) {
+      return true;
+    }
+    return false;
   }
 
   @Override
@@ -165,11 +174,7 @@ public class JsonObjectCodec extends AbstractJsonCodec<JsonObject, JsonArray> im
 
   @Override
   protected Object readObjectId(BsonReader reader, DecoderContext ctx) {
-
-    if (reader.getCurrentName().equals(ID_FIELD)) {
-      return reader.readObjectId().toHexString();
-    }
-    return  new JsonObject().put(OID_FIELD, reader.readObjectId().toHexString());
+    return new JsonObject().put(OID_FIELD, reader.readObjectId().toHexString());
   }
 
   @Override

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
@@ -640,7 +640,12 @@ public abstract class MongoClientTestBase extends MongoTestBase {
           assertNotNull(list);
           assertEquals(1, list.size());
           JsonObject result = list.get(0);
-          assertEquals(id, result.getString("_id"));
+          Object id_value = result.getValue("_id");
+          if (id_value instanceof JsonObject) {
+            assertEquals(id, ((JsonObject) id_value).getString("$oid"));
+          } else {
+            assertEquals(id, (String) id_value);
+          }
           result.remove("_id");
           replacement.remove("_id"); // id won't be there for event bus
           assertEquals(replacement, result);
@@ -691,7 +696,12 @@ public abstract class MongoClientTestBase extends MongoTestBase {
         mongoClient.find(collection, new JsonObject(), onSuccess(list -> {
           assertNotNull(list);
           assertEquals(1, list.size());
-          assertEquals(id, list.get(0).getString("_id"));
+          Object id_value = list.get(0).getValue("_id");
+          if (id_value instanceof JsonObject) {
+            assertEquals(id, ((JsonObject) id_value).getString("$oid"));
+          } else {
+            assertEquals(id, (String) id_value);
+          }
           testComplete();
         }));
       }));
@@ -721,7 +731,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
       for (JsonObject doc : results) {
         assertEquals(9, doc.size());
         assertEquals("fooed", doc.getString("foo"));
-        assertNotNull(doc.getString("_id"));
+        assertNotNull(doc.getValue("_id"));
       }
     });
   }
@@ -734,7 +744,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
       for (JsonObject doc : results) {
         assertEquals(9, doc.size());
         assertEquals("fooed", doc.getString("foo"));
-        assertNotNull(doc.getString("_id"));
+        assertNotNull(doc.getValue("_id"));
       }
     });
   }

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientWithObjectIdTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientWithObjectIdTest.java
@@ -58,8 +58,9 @@ public class MongoClientWithObjectIdTest extends MongoClientTestBase {
       mongoClient.insert(collection, doc, onSuccess(id -> {
         assertNotNull(id);
         mongoClient.findOne(collection, new JsonObject().put("foo", "bar"), null, onSuccess(obj -> {
-          assertTrue(obj.getValue("_id") instanceof String);
           assertTrue(obj.containsKey("_id"));
+          assertTrue(obj.getValue("_id") instanceof JsonObject);
+          assertTrue(((JsonObject) obj.getValue("_id")).containsKey("$oid"));
           obj.remove("_id");
           assertEquals(orig, obj);
           testComplete();

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/codec/json/AbstractJsonCodecTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/codec/json/AbstractJsonCodecTest.java
@@ -21,6 +21,11 @@ public class AbstractJsonCodecTest {
   private AbstractJsonCodec getCodec() {
     return new AbstractJsonCodec() {
       @Override
+      protected boolean isObjectIdInstance(Object instance) {
+        return false;
+      }
+
+      @Override
       protected Object newObject() {
         return null;
       }

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodecTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodecTest.java
@@ -235,7 +235,6 @@ public class JsonObjectCodecTest {
 
     assertTrue(document.containsKey("_id"));
     assertTrue(document.getValue("_id") instanceof String);
-
   }
 
   @Test
@@ -249,7 +248,7 @@ public class JsonObjectCodecTest {
 
     assertTrue(document.containsKey("_id"));
     assertTrue(document.getValue("_id") instanceof JsonObject);
-
+    assertTrue(document.getJsonObject("_id").containsKey(JsonObjectCodec.OID_FIELD));
   }
 
 }


### PR DESCRIPTION
Improve the ObjectId support in read/write object id from JsonObject. Also it adds protection if the "_id" field provided is not a valid ObjectId string.