### PR TITLE
Added new find method with batchCursor

### DIFF
--- a/vertx-mongo-client/src/main/java/examples/Examples.java
+++ b/vertx-mongo-client/src/main/java/examples/Examples.java
@@ -258,6 +258,25 @@ public class Examples {
 
   }
 
+  public void example9_1(MongoClient mongoClient) {
+
+    // will match all Tolkien books
+    JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
+
+    mongoClient.findBatch("book", query, res -> {
+      if (res.succeeded()) {
+
+        System.out.println(res.result().encodePrettily());
+
+      } else {
+
+        res.cause().printStackTrace();
+
+      }
+    });
+  }
+
+
   public void example10(MongoClient mongoClient) {
 
     JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -163,6 +163,17 @@ public interface MongoClient {
   MongoClient find(String collection, JsonObject query, Handler<AsyncResult<List<JsonObject>>> resultHandler);
 
   /**
+   * Find matching documents in the specified collection.
+   * This method use batchCursor for returning each found document.
+   *
+   * @param collection  the collection
+   * @param query  query used to match documents
+   * @param resultHandler  will be provided with each found document
+   */
+  @Fluent
+  MongoClient findBatch(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  /**
    * Find matching documents in the specified collection, specifying options
    *
    * @param collection  the collection
@@ -172,6 +183,18 @@ public interface MongoClient {
    */
   @Fluent
   MongoClient findWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<List<JsonObject>>> resultHandler);
+
+  /**
+   * Find matching documents in the specified collection, specifying options.
+   * This method use batchCursor for returning each found document.
+   *
+   * @param collection  the collection
+   * @param query  query used to match documents
+   * @param options options to configure the find
+   * @param resultHandler  will be provided with each found document
+   */
+  @Fluent
+  MongoClient findBatchWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<JsonObject>> resultHandler);
 
   /**
    * Find a single matching document in the specified collection

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -214,11 +214,9 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
 
     FindIterable<JsonObject> view = doFind(collection, query, options);
     Block<JsonObject> documentBlock = document -> wrapCallback(resultHandler).onResult(document, null);
-    SingleResultCallback<Void> callbackWhenFinished = (result, t) -> {
-      if (t != null) {
-        resultHandler.handle(Future.failedFuture(t));
-      } else {
-        resultHandler.handle(Future.succeededFuture());
+    SingleResultCallback<Void> callbackWhenFinished = (result, throwable) -> {
+      if (throwable != null) {
+        resultHandler.handle(Future.failedFuture(throwable));
       }
     };
     view.forEach(documentBlock, callbackWhenFinished);

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
@@ -231,6 +231,12 @@
  * `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
  * `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
  *
+ *  * ----
+ * {@link examples.Examples#example9_1}
+ * ----
+ *
+ * The matching document are returned unitary in the result handler.
+ *
  * === Finding a single document
  *
  * To find a single document you use {@link io.vertx.ext.mongo.MongoClient#findOne}.

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
@@ -235,7 +235,7 @@
  * {@link examples.Examples#example9_1}
  * ----
  *
- * The matching document are returned unitary in the result handler.
+ * The matching documents are returned unitary in the result handler.
  *
  * === Finding a single document
  *

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
@@ -557,6 +557,23 @@ public abstract class MongoClientTestBase extends MongoTestBase {
   }
 
   @Test
+  public void testFindBatch() throws Exception {
+    int numDocs = 200;
+
+    String collection = randomCollection();
+    CountDownLatch latch = new CountDownLatch(numDocs);
+    mongoClient.createCollection(collection, onSuccess(res -> {
+      insertDocs(collection, numDocs, onSuccess(res2 -> {
+        mongoClient.findBatchWithOptions(collection, new JsonObject(), new FindOptions(), onSuccess(result -> {
+          assertNotNull(result);
+          latch.countDown();
+        }));
+      }));
+    }));
+    awaitLatch(latch);
+  }
+
+  @Test
   public void testFindWithFields() throws Exception {
     int num = 10;
     doTestFind(num, new JsonObject(), new FindOptions().setFields(new JsonObject().put("num", true)), results -> {

--- a/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/MongoService.java
+++ b/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/MongoService.java
@@ -69,7 +69,15 @@ public interface MongoService extends MongoClient {
 
   @Override
   @Fluent
+  MongoService findBatch(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  @Override
+  @Fluent
   MongoService findWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<List<JsonObject>>> resultHandler);
+
+  @Override
+  @Fluent
+  MongoService findBatchWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<JsonObject>> resultHandler);
 
   @Override
   @Fluent

--- a/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/impl/MongoServiceImpl.java
+++ b/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/impl/MongoServiceImpl.java
@@ -83,9 +83,21 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
+  public MongoService findBatch(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler) {
+    client.findBatch(collection, query, resultHandler);
+    return this;
+  }
+
+  @Override
   @Fluent
   public MongoService findWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<List<JsonObject>>> resultHandler) {
     client.findWithOptions(collection, query, options, resultHandler);
+    return this;
+  }
+
+  @Override
+  public MongoService findBatchWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<JsonObject>> resultHandler) {
+    client.findBatchWithOptions(collection, query, options, resultHandler);
     return this;
   }
 


### PR DESCRIPTION
Hello, 
This PR extends find method with batch cursor (cf. issue #33), avoiding acumulation of all results in a list and memory problems with not so huge collections. 
I uses it in another projet to pump a complete mongo collections like this:
```
            FindOptions options = new FindOptions();
            mongoClient.findBatchWithOptions("Articles", new JsonObject(), options, result -> {
                vertx.eventBus().send(MLVerticle.ML_RECEIVER_ADD, result.result());
            });
```
It push on event bus a complete collection of 100000 docs without problem.