### PR TITLE
squid:S1602 -  Lamdbas containing only one statement should not nest this statement in a block

### DIFF
--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -298,15 +298,15 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     requireNonNull(resultHandler, "resultHandler cannot be null");
     List<String> names = new ArrayList<>();
     Context context = vertx.getOrCreateContext();
-    holder.db.listCollectionNames().into(names, (res, error) -> {
+    holder.db.listCollectionNames().into(names, (res, error) ->
       context.runOnContext(v -> {
         if (error != null) {
           resultHandler.handle(Future.failedFuture(error));
         } else {
           resultHandler.handle(Future.succeededFuture(names));
         }
-      });
-    });
+      })
+    );
     return this;
   }
 
@@ -351,15 +351,15 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
       List results = new ArrayList();
       try {
         Context context = vertx.getOrCreateContext();
-        distinctValues.into(results, (result, throwable) -> {
+        distinctValues.into(results, (result, throwable) ->
           context.runOnContext(v -> {
             if (throwable != null) {
               resultHandler.handle(Future.failedFuture(throwable));
             } else {
               resultHandler.handle(Future.succeededFuture(new JsonArray((List) result)));
             }
-          });
-        });
+          })
+        );
       } catch (Exception unhandledEx) {
         resultHandler.handle(Future.failedFuture(unhandledEx));
       }
@@ -373,13 +373,12 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
 
     if (distinctValues != null) {
       Context context = vertx.getOrCreateContext();
-      Block valueBlock = value -> {
+      Block valueBlock = value ->
         context.runOnContext(v -> {
           Map mapValue = new HashMap();
           mapValue.put(fieldName, value);
           resultHandler.handle(Future.succeededFuture(new JsonObject(mapValue)));
         });
-      };
       SingleResultCallback<Void> callbackWhenFinished = (result, throwable) -> {
         if (throwable != null) {
           resultHandler.handle(Future.failedFuture(throwable));
@@ -446,7 +445,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
 
   private <T> SingleResultCallback<T> wrapCallback(Handler<AsyncResult<T>> resultHandler) {
     Context context = vertx.getOrCreateContext();
-    return (result, error) -> {
+    return (result, error) ->
       context.runOnContext(v -> {
         if (error != null) {
           resultHandler.handle(Future.failedFuture(error));
@@ -454,7 +453,6 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
           resultHandler.handle(Future.succeededFuture(result));
         }
       });
-    };
   }
 
   private FindIterable<JsonObject> doFind(String collection, JsonObject query, FindOptions options) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1602 -  Lamdbas containing only one statement should not nest this statement in a block.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1602
Please let me know if you have any questions.
George Kankava