### PR TITLE
Multiple code improvements - squid:UselessParenthesesCheck, squid:S1226, squid:LowerCaseLongSuffixCheck

### DIFF
--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -173,10 +173,10 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     requireNonNull(resultHandler, "resultHandler cannot be null");
 
     boolean id = query.containsKey(ID_FIELD);
-    query = encodeKeyWhenUseObjectId(query);
+    JsonObject encodedQuery = encodeKeyWhenUseObjectId(query);
 
     MongoCollection<JsonObject> coll = getCollection(collection, options.getWriteOption());
-    Bson bquery = wrap(query);
+    Bson bquery = wrap(encodedQuery);
     coll.replaceOne(bquery, replace, mongoUpdateOptions(options), convertCallback(resultHandler, result -> null));
     return this;
   }
@@ -228,9 +228,9 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     requireNonNull(query, "query cannot be null");
     requireNonNull(resultHandler, "resultHandler cannot be null");
 
-    query = encodeKeyWhenUseObjectId(query);
+    JsonObject encodedQuery = encodeKeyWhenUseObjectId(query);
 
-    Bson bquery = wrap(query);
+    Bson bquery = wrap(encodedQuery);
     Bson bfields = wrap(fields);
     getCollection(collection).find(bquery).projection(bfields).first(wrapCallback(resultHandler));
     return this;

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/WriteConcernParser.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/WriteConcernParser.java
@@ -55,7 +55,7 @@ class WriteConcernParser {
         }
 
       } else if (safe != null) {
-        wc = (safe) ? WriteConcern.ACKNOWLEDGED : WriteConcern.UNACKNOWLEDGED;
+        wc = safe ? WriteConcern.ACKNOWLEDGED : WriteConcern.UNACKNOWLEDGED;
       } else {
         wc = null; // no write concern
       }

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodecTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodecTest.java
@@ -84,14 +84,14 @@ public class JsonObjectCodecTest {
 
     codec.writeDocument(writer, "", value, EncoderContext.builder().build());
 
-    long millis = 1322903730500l;
+    long millis = 1322903730500L;
 
     BsonValue resultValue = bsonResult.get("test");
     assertEquals(BsonType.DATE_TIME, resultValue.getBsonType());
     assertEquals(millis, resultValue.asDateTime().getValue());
 
     String back =
-        OffsetDateTime.ofInstant(Instant.ofEpochMilli(1322903730500l), ZoneOffset.UTC).format(ISO_OFFSET_DATE_TIME);
+        OffsetDateTime.ofInstant(Instant.ofEpochMilli(1322903730500L), ZoneOffset.UTC).format(ISO_OFFSET_DATE_TIME);
 
     // we encode always in UTC
     assertEquals("2011-12-03T09:15:30.5Z", back);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1226 - Method parameters, caught exceptions and foreach variables should not be reassigned.
squid:LowerCaseLongSuffixCheck - Long suffix "L" should be upper case.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1226
https://dev.eclipse.org/sonar/rules/show/squid:LowerCaseLongSuffixCheck
Please let me know if you have any questions.
George Kankava