### PR TITLE
Multiple code improvements - squid:S134, squid:UselessParenthesesCheck, squid:CommentedOutCodeLine

### DIFF
--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
@@ -147,25 +147,6 @@ public class JsonObjectCodec extends AbstractJsonCodec<JsonObject, JsonArray> im
       } else if (obj.containsKey(BINARY_FIELD)) {
         return BsonType.BINARY;
       }
-      //not supported yet
-      /*
-      else if (obj.containsKey("$maxKey")) {
-        return BsonType.MAX_KEY;
-      } else if (obj.containsKey("$minKey")) {
-        return BsonType.MIN_KEY;
-      } else if (obj.containsKey("$regex")) {
-        return BsonType.REGULAR_EXPRESSION;
-      } else if (obj.containsKey("$symbol")) {
-        return BsonType.SYMBOL;
-      } else if (obj.containsKey("$timestamp")) {
-        return BsonType.TIMESTAMP;
-      } else if (obj.containsKey("$undefined")) {
-        return BsonType.UNDEFINED;
-      } else if (obj.containsKey("$numberLong")) {
-        return BsonType.INT64;
-      } else if (obj.containsKey("$code")) {
-        return JAVASCRIPT or JAVASCRIPT_WITH_SCOPE;
-      } */
     }
     return type;
   }

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/CredentialListParser.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/CredentialListParser.java
@@ -39,11 +39,7 @@ class CredentialListParser {
         AuthenticationMechanism mechanism = null;
         String authMechanism = config.getString("authMechanism");
         if (authMechanism != null) {
-          try {
-            mechanism = AuthenticationMechanism.fromMechanismName(authMechanism);
-          } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Invalid authMechanism '" + authMechanism + "'");
-          }
+          mechanism = getAuthenticationMechanism(authMechanism);
         }
 
         // MongoCredential
@@ -51,9 +47,7 @@ class CredentialListParser {
         MongoCredential credential;
         if (mechanism == GSSAPI) {
           credential = MongoCredential.createGSSAPICredential(username);
-          if (gssapiServiceName != null) {
-            credential = credential.withMechanismProperty("SERVICE_NAME", gssapiServiceName);
-          }
+          credential = getMongoCredential(gssapiServiceName, credential);
         } else if (mechanism == PLAIN) {
           credential = MongoCredential.createPlainCredential(username, authSource, password);
         } else if (mechanism == MONGODB_CR) {
@@ -71,6 +65,23 @@ class CredentialListParser {
         credentials.add(credential);
       }
     }
+  }
+
+  private MongoCredential getMongoCredential(String gssapiServiceName, MongoCredential credential) {
+    if (gssapiServiceName != null) {
+      credential = credential.withMechanismProperty("SERVICE_NAME", gssapiServiceName);
+    }
+    return credential;
+  }
+
+  private AuthenticationMechanism getAuthenticationMechanism(String authMechanism) {
+    AuthenticationMechanism mechanism;
+    try {
+      mechanism = AuthenticationMechanism.fromMechanismName(authMechanism);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid authMechanism '" + authMechanism + "'");
+    }
+    return mechanism;
   }
 
   public List<MongoCredential> credentials() {

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/WriteConcernParser.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/WriteConcernParser.java
@@ -35,13 +35,7 @@ class WriteConcernParser {
         if (w == null) {
           wc = new WriteConcern(1);
         } else {
-          if (w instanceof String) {
-            wc = new WriteConcern((String) w);
-          } else if (w instanceof Integer) {
-            wc = new WriteConcern((int) w);
-          } else {
-            throw new IllegalArgumentException("Invalid type " + w.getClass() + " for w of WriteConcern");
-          }
+          wc = getWriteConcern(w);
         }
 
         if (wtimeout != null) {
@@ -55,13 +49,25 @@ class WriteConcernParser {
         }
 
       } else if (safe != null) {
-        wc = (safe) ? WriteConcern.ACKNOWLEDGED : WriteConcern.UNACKNOWLEDGED;
+        wc = safe ? WriteConcern.ACKNOWLEDGED : WriteConcern.UNACKNOWLEDGED;
       } else {
         wc = null; // no write concern
       }
     }
 
     writeConcern = wc;
+  }
+
+  private WriteConcern getWriteConcern(Object w) {
+    WriteConcern wc;
+    if (w instanceof String) {
+      wc = new WriteConcern((String) w);
+    } else if (w instanceof Integer) {
+      wc = new WriteConcern((int) w);
+    } else {
+      throw new IllegalArgumentException("Invalid type " + w.getClass() + " for w of WriteConcern");
+    }
+    return wc;
   }
 
   public WriteConcern writeConcern() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S134 - Control flow statements "if", "for", "while", "switch" and "try" should not be nested too deeply.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S134
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
Please let me know if you have any questions.
George Kankava