### PR TITLE
added just released bnd maven plugin 3.2.0

### DIFF
--- a/vertx-mongo-client/pom.xml
+++ b/vertx-mongo-client/pom.xml
@@ -32,4 +32,48 @@
     <doc.skip>false</doc.skip>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <useDefaultManifestFile>true</useDefaultManifestFile>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>default-bnd-process</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bnd><![CDATA[
+          Import-Package: \
+            groovy.lang.*;resolution:=optional,\
+            org.codehaus.groovy.*;resolution:=optional,\
+            io.vertx.groovy.*;resolution:=optional,\
+            io.vertx.ext.auth.*;resolution:=optional,\
+            io.vertx.lang.rxjava.*;resolution:=optional,\
+            io.vertx.lang.groovy.*;resolution:=optional,\
+            io.vertx.codegen.annotations;resolution:=optional,\
+            io.vertx.rx.java;resolution:=optional,\
+            io.vertx.rxjava.core.*;resolution:=optional,\
+            io.vertx.rxjava.ext.auth.*;resolution:=optional,\
+            rx.*;resolution:=optional,\
+            *
+          -exportcontents: !*impl, !examples, *
+          ]]></bnd>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+    
 </project>

--- a/vertx-mongo-service/pom.xml
+++ b/vertx-mongo-service/pom.xml
@@ -32,6 +32,39 @@
       <artifactId>vertx-service-proxy</artifactId>
     </dependency>
   </dependencies>
-
-
+  <build>
+    <plugins>
+      <plugin>
+          <groupId>biz.aQute.bnd</groupId>
+          <artifactId>bnd-maven-plugin</artifactId>
+          <version>3.2.0</version>
+          <executions>
+            <execution>
+              <id>default-bnd-process</id>
+              <goals>
+                <goal>bnd-process</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <bnd><![CDATA[
+            Import-Package: \
+              groovy.lang.*;resolution:=optional,\
+              org.codehaus.groovy.*;resolution:=optional,\
+              io.vertx.groovy.*;resolution:=optional,\
+              io.vertx.ext.auth.*;resolution:=optional,\
+              io.vertx.lang.rxjava.*;resolution:=optional,\
+              io.vertx.lang.groovy.*;resolution:=optional,\
+              io.vertx.codegen.annotations;resolution:=optional,\
+              io.vertx.rx.java;resolution:=optional,\
+              io.vertx.rxjava.core.*;resolution:=optional,\
+              io.vertx.rxjava.ext.auth.*;resolution:=optional,\
+              rx.*;resolution:=optional,\
+              *
+            -exportcontents: !*impl, !examples, *
+            ]]></bnd>
+          </configuration>
+        </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
The bnd-maven-plugin 3.2.0 is just released. This PR adds the plugin to generate OSGi metadata.