### PR TITLE
support findOneAndX

### DIFF
--- a/vertx-mongo-client/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/dataobjects.adoc
@@ -175,6 +175,10 @@ Get the document id that's upserted
 +++
 Set whether multi is enabled
 +++
+|[[returningNewDocument]]`returningNewDocument`|`Boolean`|
++++
+Set whether new document property is enabled. Valid only on findOneAnd* methods.
++++
 |[[upsert]]`upsert`|`Boolean`|
 +++
 Set whether upsert is enabled

--- a/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
@@ -446,9 +446,18 @@ def query = [
 ]
 
 mongoClient.findBatch("book", query, { res ->
+
   if (res.succeeded()) {
 
-    println(groovy.json.JsonOutput.toJson(res.result()))
+    if (res.result() == null) {
+
+      println("End of research")
+
+    } else {
+
+      println("Found doc: ${groovy.json.JsonOutput.toJson(res.result())}")
+
+    }
 
   } else {
 
@@ -456,6 +465,7 @@ mongoClient.findBatch("book", query, { res ->
 
   }
 })
+
 
 ----
 

--- a/vertx-mongo-client/src/main/asciidoc/java/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/java/index.adoc
@@ -360,9 +360,18 @@ This has the following fields:
 JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
 
 mongoClient.findBatch("book", query, res -> {
+
   if (res.succeeded()) {
 
-    System.out.println(res.result().encodePrettily());
+    if (res.result() == null) {
+
+      System.out.println("End of research");
+
+    } else {
+
+      System.out.println("Found doc: " + res.result().encodePrettily());
+
+    }
 
   } else {
 

--- a/vertx-mongo-client/src/main/asciidoc/js/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/js/index.adoc
@@ -447,9 +447,18 @@ var query = {
 };
 
 mongoClient.findBatch("book", query, function (res, res_err) {
+
   if (res_err == null) {
 
-    console.log(JSON.stringify(res));
+    if (res === null) {
+
+      console.log("End of research");
+
+    } else {
+
+      console.log("Found doc: " + JSON.stringify(res));
+
+    }
 
   } else {
 
@@ -457,6 +466,7 @@ mongoClient.findBatch("book", query, function (res, res_err) {
 
   }
 });
+
 
 ----
 

--- a/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
@@ -450,9 +450,18 @@ query = {
 }
 
 mongoClient.find_batch("book", query) { |res_err,res|
+
   if (res_err == nil)
 
-    puts JSON.generate(res)
+    if (res == nil)
+
+      puts "End of research"
+
+    else
+
+      puts "Found doc: #{JSON.generate(res)}"
+
+    end
 
   else
 
@@ -460,6 +469,7 @@ mongoClient.find_batch("book", query) { |res_err,res|
 
   end
 }
+
 
 ----
 

--- a/vertx-mongo-client/src/main/generated/io/vertx/rxjava/ext/mongo/MongoClient.java
+++ b/vertx-mongo-client/src/main/generated/io/vertx/rxjava/ext/mongo/MongoClient.java
@@ -562,6 +562,192 @@ public class MongoClient {
   }
 
   /**
+   * Find a single matching document in the specified collection and update it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param update used to describe how the documents will be updated
+   * @param resultHandler will be provided with the document, if any
+   * @return 
+   */
+  public MongoClient findOneAndUpdate(String collection, JsonObject query, JsonObject update, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    delegate.findOneAndUpdate(collection, query, update, resultHandler);
+    return this;
+  }
+
+  /**
+   * Find a single matching document in the specified collection and update it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param update used to describe how the documents will be updated
+   * @return 
+   */
+  public Observable<JsonObject> findOneAndUpdateObservable(String collection, JsonObject query, JsonObject update) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndUpdate(collection, query, update, resultHandler.toHandler());
+    return resultHandler;
+  }
+
+  /**
+   * Find a single matching document in the specified collection and update it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param update used to describe how the documents will be updated
+   * @param findOptions options to configure the find
+   * @param updateOptions options to configure the update
+   * @param resultHandler will be provided with the document, if any
+   * @return 
+   */
+  public MongoClient findOneAndUpdateWithOptions(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    delegate.findOneAndUpdateWithOptions(collection, query, update, findOptions, updateOptions, resultHandler);
+    return this;
+  }
+
+  /**
+   * Find a single matching document in the specified collection and update it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param update used to describe how the documents will be updated
+   * @param findOptions options to configure the find
+   * @param updateOptions options to configure the update
+   * @return 
+   */
+  public Observable<JsonObject> findOneAndUpdateWithOptionsObservable(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndUpdateWithOptions(collection, query, update, findOptions, updateOptions, resultHandler.toHandler());
+    return resultHandler;
+  }
+
+  /**
+   * Find a single matching document in the specified collection and replace it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param replace the replacement document
+   * @param resultHandler will be provided with the document, if any
+   * @return 
+   */
+  public MongoClient findOneAndReplace(String collection, JsonObject query, JsonObject replace, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    delegate.findOneAndReplace(collection, query, replace, resultHandler);
+    return this;
+  }
+
+  /**
+   * Find a single matching document in the specified collection and replace it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param replace the replacement document
+   * @return 
+   */
+  public Observable<JsonObject> findOneAndReplaceObservable(String collection, JsonObject query, JsonObject replace) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndReplace(collection, query, replace, resultHandler.toHandler());
+    return resultHandler;
+  }
+
+  /**
+   * Find a single matching document in the specified collection and replace it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param replace the replacement document
+   * @param findOptions options to configure the find
+   * @param updateOptions options to configure the update
+   * @param resultHandler will be provided with the document, if any
+   * @return 
+   */
+  public MongoClient findOneAndReplaceWithOptions(String collection, JsonObject query, JsonObject replace, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    delegate.findOneAndReplaceWithOptions(collection, query, replace, findOptions, updateOptions, resultHandler);
+    return this;
+  }
+
+  /**
+   * Find a single matching document in the specified collection and replace it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param replace the replacement document
+   * @param findOptions options to configure the find
+   * @param updateOptions options to configure the update
+   * @return 
+   */
+  public Observable<JsonObject> findOneAndReplaceWithOptionsObservable(String collection, JsonObject query, JsonObject replace, FindOptions findOptions, UpdateOptions updateOptions) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndReplaceWithOptions(collection, query, replace, findOptions, updateOptions, resultHandler.toHandler());
+    return resultHandler;
+  }
+
+  /**
+   * Find a single matching document in the specified collection and delete it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param resultHandler will be provided with the deleted document, if any
+   * @return 
+   */
+  public MongoClient findOneAndDelete(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    delegate.findOneAndDelete(collection, query, resultHandler);
+    return this;
+  }
+
+  /**
+   * Find a single matching document in the specified collection and delete it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @return 
+   */
+  public Observable<JsonObject> findOneAndDeleteObservable(String collection, JsonObject query) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndDelete(collection, query, resultHandler.toHandler());
+    return resultHandler;
+  }
+
+  /**
+   * Find a single matching document in the specified collection and delete it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param findOptions options to configure the find
+   * @param resultHandler will be provided with the deleted document, if any
+   * @return 
+   */
+  public MongoClient findOneAndDeleteWithOptions(String collection, JsonObject query, FindOptions findOptions, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    delegate.findOneAndDeleteWithOptions(collection, query, findOptions, resultHandler);
+    return this;
+  }
+
+  /**
+   * Find a single matching document in the specified collection and delete it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param findOptions options to configure the find
+   * @return 
+   */
+  public Observable<JsonObject> findOneAndDeleteWithOptionsObservable(String collection, JsonObject query, FindOptions findOptions) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndDeleteWithOptions(collection, query, findOptions, resultHandler.toHandler());
+    return resultHandler;
+  }
+
+  /**
    * Count matching documents in a collection.
    * @param collection the collection
    * @param query query used to match documents

--- a/vertx-mongo-client/src/main/groovy/io/vertx/groovy/ext/mongo/MongoClient.groovy
+++ b/vertx-mongo-client/src/main/groovy/io/vertx/groovy/ext/mongo/MongoClient.groovy
@@ -369,6 +369,141 @@ public class MongoClient {
     return this;
   }
   /**
+   * Find a single matching document in the specified collection and update it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param update used to describe how the documents will be updated
+   * @param resultHandler will be provided with the document, if any
+   * @return 
+   */
+  public MongoClient findOneAndUpdate(String collection, Map<String, Object> query, Map<String, Object> update, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    delegate.findOneAndUpdate(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, update != null ? new io.vertx.core.json.JsonObject(update) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
+  /**
+   * Find a single matching document in the specified collection and update it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param update used to describe how the documents will be updated
+   * @param findOptions options to configure the find (see <a href="../../../../../../../cheatsheet/FindOptions.html">FindOptions</a>)
+   * @param updateOptions options to configure the update (see <a href="../../../../../../../cheatsheet/UpdateOptions.html">UpdateOptions</a>)
+   * @param resultHandler will be provided with the document, if any
+   * @return 
+   */
+  public MongoClient findOneAndUpdateWithOptions(String collection, Map<String, Object> query, Map<String, Object> update, Map<String, Object> findOptions, Map<String, Object> updateOptions, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    delegate.findOneAndUpdateWithOptions(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, update != null ? new io.vertx.core.json.JsonObject(update) : null, findOptions != null ? new io.vertx.ext.mongo.FindOptions(io.vertx.lang.groovy.InternalHelper.toJsonObject(findOptions)) : null, updateOptions != null ? new io.vertx.ext.mongo.UpdateOptions(io.vertx.lang.groovy.InternalHelper.toJsonObject(updateOptions)) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
+  /**
+   * Find a single matching document in the specified collection and replace it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param replace the replacement document
+   * @param resultHandler will be provided with the document, if any
+   * @return 
+   */
+  public MongoClient findOneAndReplace(String collection, Map<String, Object> query, Map<String, Object> replace, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    delegate.findOneAndReplace(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, replace != null ? new io.vertx.core.json.JsonObject(replace) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
+  /**
+   * Find a single matching document in the specified collection and replace it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param replace the replacement document
+   * @param findOptions options to configure the find (see <a href="../../../../../../../cheatsheet/FindOptions.html">FindOptions</a>)
+   * @param updateOptions options to configure the update (see <a href="../../../../../../../cheatsheet/UpdateOptions.html">UpdateOptions</a>)
+   * @param resultHandler will be provided with the document, if any
+   * @return 
+   */
+  public MongoClient findOneAndReplaceWithOptions(String collection, Map<String, Object> query, Map<String, Object> replace, Map<String, Object> findOptions, Map<String, Object> updateOptions, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    delegate.findOneAndReplaceWithOptions(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, replace != null ? new io.vertx.core.json.JsonObject(replace) : null, findOptions != null ? new io.vertx.ext.mongo.FindOptions(io.vertx.lang.groovy.InternalHelper.toJsonObject(findOptions)) : null, updateOptions != null ? new io.vertx.ext.mongo.UpdateOptions(io.vertx.lang.groovy.InternalHelper.toJsonObject(updateOptions)) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
+  /**
+   * Find a single matching document in the specified collection and delete it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param resultHandler will be provided with the deleted document, if any
+   * @return 
+   */
+  public MongoClient findOneAndDelete(String collection, Map<String, Object> query, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    delegate.findOneAndDelete(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
+  /**
+   * Find a single matching document in the specified collection and delete it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   * @param collection the collection
+   * @param query the query used to match the document
+   * @param findOptions options to configure the find (see <a href="../../../../../../../cheatsheet/FindOptions.html">FindOptions</a>)
+   * @param resultHandler will be provided with the deleted document, if any
+   * @return 
+   */
+  public MongoClient findOneAndDeleteWithOptions(String collection, Map<String, Object> query, Map<String, Object> findOptions, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    delegate.findOneAndDeleteWithOptions(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, findOptions != null ? new io.vertx.ext.mongo.FindOptions(io.vertx.lang.groovy.InternalHelper.toJsonObject(findOptions)) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
+  /**
    * Count matching documents in a collection.
    * @param collection the collection
    * @param query query used to match documents

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -1,5 +1,8 @@
 package io.vertx.ext.mongo;
 
+import java.util.List;
+import java.util.UUID;
+
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
@@ -8,9 +11,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.impl.MongoClientImpl;
-
-import java.util.List;
-import java.util.UUID;
 
 /**
  * A Vert.x service used to interact with MongoDB server instances.
@@ -271,6 +271,87 @@ public interface MongoClient {
    */
   @Fluent
   MongoClient findOne(String collection, JsonObject query, JsonObject fields, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  /**
+   * Find a single matching document in the specified collection and update it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   *
+   * @param collection  the collection
+   * @param query  the query used to match the document
+   * @param update used to describe how the documents will be updated
+   * @param resultHandler will be provided with the document, if any
+   */
+  @Fluent
+  MongoClient findOneAndUpdate(String collection, JsonObject query, JsonObject update, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  /**
+   * Find a single matching document in the specified collection and update it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   *
+   * @param collection  the collection
+   * @param query  the query used to match the document
+   * @param update used to describe how the documents will be updated
+   * @param findOptions options to configure the find
+   * @param updateOptions options to configure the update
+   * @param resultHandler will be provided with the document, if any
+   */
+  @Fluent
+  MongoClient findOneAndUpdateWithOptions(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  /**
+   * Find a single matching document in the specified collection and replace it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   *
+   * @param collection  the collection
+   * @param query  the query used to match the document
+   * @param replace  the replacement document
+   * @param resultHandler will be provided with the document, if any
+   */
+  @Fluent
+  MongoClient findOneAndReplace(String collection, JsonObject query, JsonObject replace, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  /**
+   * Find a single matching document in the specified collection and replace it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   *
+   * @param collection  the collection
+   * @param query  the query used to match the document
+   * @param replace  the replacement document
+   * @param findOptions options to configure the find
+   * @param updateOptions options to configure the update
+   * @param resultHandler will be provided with the document, if any
+   */
+  @Fluent
+  MongoClient findOneAndReplaceWithOptions(String collection, JsonObject query, JsonObject replace, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  /**
+   * Find a single matching document in the specified collection and delete it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   *
+   * @param collection  the collection
+   * @param query  the query used to match the document
+   * @param resultHandler will be provided with the deleted document, if any
+   */
+  @Fluent
+  MongoClient findOneAndDelete(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  /**
+   * Find a single matching document in the specified collection and delete it.
+   * <p>
+   * This operation might change <i>_id</i> field of <i>query</i> parameter
+   *
+   * @param collection  the collection
+   * @param query  the query used to match the document
+   * @param findOptions options to configure the find
+   * @param resultHandler will be provided with the deleted document, if any
+   */
+  @Fluent
+  MongoClient findOneAndDeleteWithOptions(String collection, JsonObject query, FindOptions findOptions, Handler<AsyncResult<JsonObject>> resultHandler);
 
   /**
    * Count matching documents in a collection.

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/UpdateOptions.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/UpdateOptions.java
@@ -21,9 +21,15 @@ public class UpdateOptions {
    */
   public static final boolean DEFAULT_MULTI = false;
 
+  /**
+   * The default value of returning new document = false
+   */
+  public static final boolean DEFAULT_RETURN_NEW_DOCUMENT = false;
+
   private WriteOption writeOption;
   private boolean upsert;
   private boolean multi;
+  private boolean returnNewDocument; // uniquely valid on findOneAnd* methods
 
   /**
    * Default constructor
@@ -31,6 +37,7 @@ public class UpdateOptions {
   public UpdateOptions() {
     this.upsert = DEFAULT_UPSERT;
     this.multi = DEFAULT_MULTI;
+    this.returnNewDocument = DEFAULT_RETURN_NEW_DOCUMENT;
   }
 
   /**
@@ -40,6 +47,7 @@ public class UpdateOptions {
   public UpdateOptions(boolean upsert) {
     this.upsert = upsert;
     this.multi = DEFAULT_MULTI;
+    this.returnNewDocument = DEFAULT_RETURN_NEW_DOCUMENT;
   }
 
   /**
@@ -60,6 +68,7 @@ public class UpdateOptions {
     this.writeOption = other.writeOption;
     this.upsert = other.upsert;
     this.multi = other.multi;
+    this.returnNewDocument = other.returnNewDocument;
   }
 
   /**
@@ -74,6 +83,7 @@ public class UpdateOptions {
     }
     upsert = json.getBoolean("upsert", DEFAULT_UPSERT);
     multi = json.getBoolean("multi", DEFAULT_MULTI);
+    returnNewDocument = json.getBoolean("return_new_document", DEFAULT_RETURN_NEW_DOCUMENT);
   }
 
   /**
@@ -116,6 +126,27 @@ public class UpdateOptions {
   }
 
   /**
+   * Get whether returning new document property is enabled. Valid only on findOneAnd* methods.
+   *
+   * @return new document property is enabled?
+   */
+  public boolean isReturningNewDocument() {
+    return returnNewDocument;
+  }
+
+  /**
+   * Set whether new document property is enabled. Valid only on findOneAnd* methods.
+   *
+   * @param returnNewDocument  true if enabled
+   *
+   * @return reference to this, for fluency
+   */
+  public UpdateOptions setReturningNewDocument(boolean returnNewDocument) {
+    this.returnNewDocument = returnNewDocument;
+    return this;
+  }
+
+  /**
    * Get whether multi is enabled. Multi means more than one document can be updated.
    *
    * @return multi is enabled?
@@ -146,6 +177,9 @@ public class UpdateOptions {
     if (multi) {
       json.put("multi", true);
     }
+    if (returnNewDocument) {
+      json.put("return_new_document", true);
+    }
 
     return json;
   }
@@ -160,6 +194,7 @@ public class UpdateOptions {
     if (multi != options.multi) return false;
     if (upsert != options.upsert) return false;
     if (writeOption != options.writeOption) return false;
+    if (returnNewDocument != options.returnNewDocument) return false;
 
     return true;
   }
@@ -169,6 +204,7 @@ public class UpdateOptions {
     int result = writeOption != null ? writeOption.hashCode() : 0;
     result = 31 * result + (upsert ? 1 : 0);
     result = 31 * result + (multi ? 1 : 0);
+    result = 31 * result + (returnNewDocument ? 1 : 0);
     return result;
   }
 }

--- a/vertx-mongo-client/src/main/resources/vertx-mongo-js/mongo_client.js
+++ b/vertx-mongo-client/src/main/resources/vertx-mongo-js/mongo_client.js
@@ -462,6 +462,165 @@ var MongoClient = function(j_val) {
   };
 
   /**
+   Find a single matching document in the specified collection and update it.
+   <p>
+   This operation might change <i>_id</i> field of <i>query</i> parameter
+
+   @public
+   @param collection {string} the collection 
+   @param query {Object} the query used to match the document 
+   @param update {Object} used to describe how the documents will be updated 
+   @param resultHandler {function} will be provided with the document, if any 
+   @return {MongoClient}
+   */
+  this.findOneAndUpdate = function(collection, query, update, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 4 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && (typeof __args[2] === 'object' && __args[2] != null) && typeof __args[3] === 'function') {
+      j_mongoClient["findOneAndUpdate(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.core.json.JsonObject,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), utils.convParamJsonObject(update), function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Find a single matching document in the specified collection and update it.
+   <p>
+   This operation might change <i>_id</i> field of <i>query</i> parameter
+
+   @public
+   @param collection {string} the collection 
+   @param query {Object} the query used to match the document 
+   @param update {Object} used to describe how the documents will be updated 
+   @param findOptions {Object} options to configure the find 
+   @param updateOptions {Object} options to configure the update 
+   @param resultHandler {function} will be provided with the document, if any 
+   @return {MongoClient}
+   */
+  this.findOneAndUpdateWithOptions = function(collection, query, update, findOptions, updateOptions, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 6 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && (typeof __args[2] === 'object' && __args[2] != null) && (typeof __args[3] === 'object' && __args[3] != null) && (typeof __args[4] === 'object' && __args[4] != null) && typeof __args[5] === 'function') {
+      j_mongoClient["findOneAndUpdateWithOptions(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.core.json.JsonObject,io.vertx.ext.mongo.FindOptions,io.vertx.ext.mongo.UpdateOptions,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), utils.convParamJsonObject(update), findOptions != null ? new FindOptions(new JsonObject(JSON.stringify(findOptions))) : null, updateOptions != null ? new UpdateOptions(new JsonObject(JSON.stringify(updateOptions))) : null, function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Find a single matching document in the specified collection and replace it.
+   <p>
+   This operation might change <i>_id</i> field of <i>query</i> parameter
+
+   @public
+   @param collection {string} the collection 
+   @param query {Object} the query used to match the document 
+   @param replace {Object} the replacement document 
+   @param resultHandler {function} will be provided with the document, if any 
+   @return {MongoClient}
+   */
+  this.findOneAndReplace = function(collection, query, replace, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 4 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && (typeof __args[2] === 'object' && __args[2] != null) && typeof __args[3] === 'function') {
+      j_mongoClient["findOneAndReplace(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.core.json.JsonObject,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), utils.convParamJsonObject(replace), function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Find a single matching document in the specified collection and replace it.
+   <p>
+   This operation might change <i>_id</i> field of <i>query</i> parameter
+
+   @public
+   @param collection {string} the collection 
+   @param query {Object} the query used to match the document 
+   @param replace {Object} the replacement document 
+   @param findOptions {Object} options to configure the find 
+   @param updateOptions {Object} options to configure the update 
+   @param resultHandler {function} will be provided with the document, if any 
+   @return {MongoClient}
+   */
+  this.findOneAndReplaceWithOptions = function(collection, query, replace, findOptions, updateOptions, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 6 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && (typeof __args[2] === 'object' && __args[2] != null) && (typeof __args[3] === 'object' && __args[3] != null) && (typeof __args[4] === 'object' && __args[4] != null) && typeof __args[5] === 'function') {
+      j_mongoClient["findOneAndReplaceWithOptions(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.core.json.JsonObject,io.vertx.ext.mongo.FindOptions,io.vertx.ext.mongo.UpdateOptions,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), utils.convParamJsonObject(replace), findOptions != null ? new FindOptions(new JsonObject(JSON.stringify(findOptions))) : null, updateOptions != null ? new UpdateOptions(new JsonObject(JSON.stringify(updateOptions))) : null, function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Find a single matching document in the specified collection and delete it.
+   <p>
+   This operation might change <i>_id</i> field of <i>query</i> parameter
+
+   @public
+   @param collection {string} the collection 
+   @param query {Object} the query used to match the document 
+   @param resultHandler {function} will be provided with the deleted document, if any 
+   @return {MongoClient}
+   */
+  this.findOneAndDelete = function(collection, query, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 3 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && typeof __args[2] === 'function') {
+      j_mongoClient["findOneAndDelete(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Find a single matching document in the specified collection and delete it.
+   <p>
+   This operation might change <i>_id</i> field of <i>query</i> parameter
+
+   @public
+   @param collection {string} the collection 
+   @param query {Object} the query used to match the document 
+   @param findOptions {Object} options to configure the find 
+   @param resultHandler {function} will be provided with the deleted document, if any 
+   @return {MongoClient}
+   */
+  this.findOneAndDeleteWithOptions = function(collection, query, findOptions, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 4 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && (typeof __args[2] === 'object' && __args[2] != null) && typeof __args[3] === 'function') {
+      j_mongoClient["findOneAndDeleteWithOptions(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.ext.mongo.FindOptions,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), findOptions != null ? new FindOptions(new JsonObject(JSON.stringify(findOptions))) : null, function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
    Count matching documents in a collection.
 
    @public

--- a/vertx-mongo-client/src/main/resources/vertx-mongo/mongo_client.rb
+++ b/vertx-mongo-client/src/main/resources/vertx-mongo/mongo_client.rb
@@ -277,6 +277,99 @@ module VertxMongo
       end
       raise ArgumentError, "Invalid arguments when calling find_one(collection,query,fields)"
     end
+    #  Find a single matching document in the specified collection and update it.
+    #  <p>
+    #  This operation might change <i>_id</i> field of <i>query</i> parameter
+    # @param [String] collection the collection
+    # @param [Hash{String => Object}] query the query used to match the document
+    # @param [Hash{String => Object}] update used to describe how the documents will be updated
+    # @yield will be provided with the document, if any
+    # @return [self]
+    def find_one_and_update(collection=nil,query=nil,update=nil)
+      if collection.class == String && query.class == Hash && update.class == Hash && block_given?
+        @j_del.java_method(:findOneAndUpdate, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),::Vertx::Util::Utils.to_json_object(update),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_update(collection,query,update)"
+    end
+    #  Find a single matching document in the specified collection and update it.
+    #  <p>
+    #  This operation might change <i>_id</i> field of <i>query</i> parameter
+    # @param [String] collection the collection
+    # @param [Hash{String => Object}] query the query used to match the document
+    # @param [Hash{String => Object}] update used to describe how the documents will be updated
+    # @param [Hash] findOptions options to configure the find
+    # @param [Hash] updateOptions options to configure the update
+    # @yield will be provided with the document, if any
+    # @return [self]
+    def find_one_and_update_with_options(collection=nil,query=nil,update=nil,findOptions=nil,updateOptions=nil)
+      if collection.class == String && query.class == Hash && update.class == Hash && findOptions.class == Hash && updateOptions.class == Hash && block_given?
+        @j_del.java_method(:findOneAndUpdateWithOptions, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxExtMongo::FindOptions.java_class,Java::IoVertxExtMongo::UpdateOptions.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),::Vertx::Util::Utils.to_json_object(update),Java::IoVertxExtMongo::FindOptions.new(::Vertx::Util::Utils.to_json_object(findOptions)),Java::IoVertxExtMongo::UpdateOptions.new(::Vertx::Util::Utils.to_json_object(updateOptions)),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_update_with_options(collection,query,update,findOptions,updateOptions)"
+    end
+    #  Find a single matching document in the specified collection and replace it.
+    #  <p>
+    #  This operation might change <i>_id</i> field of <i>query</i> parameter
+    # @param [String] collection the collection
+    # @param [Hash{String => Object}] query the query used to match the document
+    # @param [Hash{String => Object}] replace the replacement document
+    # @yield will be provided with the document, if any
+    # @return [self]
+    def find_one_and_replace(collection=nil,query=nil,replace=nil)
+      if collection.class == String && query.class == Hash && replace.class == Hash && block_given?
+        @j_del.java_method(:findOneAndReplace, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),::Vertx::Util::Utils.to_json_object(replace),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_replace(collection,query,replace)"
+    end
+    #  Find a single matching document in the specified collection and replace it.
+    #  <p>
+    #  This operation might change <i>_id</i> field of <i>query</i> parameter
+    # @param [String] collection the collection
+    # @param [Hash{String => Object}] query the query used to match the document
+    # @param [Hash{String => Object}] replace the replacement document
+    # @param [Hash] findOptions options to configure the find
+    # @param [Hash] updateOptions options to configure the update
+    # @yield will be provided with the document, if any
+    # @return [self]
+    def find_one_and_replace_with_options(collection=nil,query=nil,replace=nil,findOptions=nil,updateOptions=nil)
+      if collection.class == String && query.class == Hash && replace.class == Hash && findOptions.class == Hash && updateOptions.class == Hash && block_given?
+        @j_del.java_method(:findOneAndReplaceWithOptions, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxExtMongo::FindOptions.java_class,Java::IoVertxExtMongo::UpdateOptions.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),::Vertx::Util::Utils.to_json_object(replace),Java::IoVertxExtMongo::FindOptions.new(::Vertx::Util::Utils.to_json_object(findOptions)),Java::IoVertxExtMongo::UpdateOptions.new(::Vertx::Util::Utils.to_json_object(updateOptions)),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_replace_with_options(collection,query,replace,findOptions,updateOptions)"
+    end
+    #  Find a single matching document in the specified collection and delete it.
+    #  <p>
+    #  This operation might change <i>_id</i> field of <i>query</i> parameter
+    # @param [String] collection the collection
+    # @param [Hash{String => Object}] query the query used to match the document
+    # @yield will be provided with the deleted document, if any
+    # @return [self]
+    def find_one_and_delete(collection=nil,query=nil)
+      if collection.class == String && query.class == Hash && block_given?
+        @j_del.java_method(:findOneAndDelete, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_delete(collection,query)"
+    end
+    #  Find a single matching document in the specified collection and delete it.
+    #  <p>
+    #  This operation might change <i>_id</i> field of <i>query</i> parameter
+    # @param [String] collection the collection
+    # @param [Hash{String => Object}] query the query used to match the document
+    # @param [Hash] findOptions options to configure the find
+    # @yield will be provided with the deleted document, if any
+    # @return [self]
+    def find_one_and_delete_with_options(collection=nil,query=nil,findOptions=nil)
+      if collection.class == String && query.class == Hash && findOptions.class == Hash && block_given?
+        @j_del.java_method(:findOneAndDeleteWithOptions, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxExtMongo::FindOptions.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),Java::IoVertxExtMongo::FindOptions.new(::Vertx::Util::Utils.to_json_object(findOptions)),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_delete_with_options(collection,query,findOptions)"
+    end
     #  Count matching documents in a collection.
     # @param [String] collection the collection
     # @param [Hash{String => Object}] query query used to match documents

--- a/vertx-mongo-service/src/main/generated/io/vertx/ext/mongo/MongoServiceVertxEBProxy.java
+++ b/vertx-mongo-service/src/main/generated/io/vertx/ext/mongo/MongoServiceVertxEBProxy.java
@@ -429,6 +429,135 @@ public class MongoServiceVertxEBProxy implements MongoService {
     return this;
   }
 
+  public MongoService findOneAndUpdate(String collection, JsonObject query, JsonObject update, Handler<AsyncResult<JsonObject>> resultHandler) {
+    if (closed) {
+      resultHandler.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));
+      return this;
+    }
+    JsonObject _json = new JsonObject();
+    _json.put("collection", collection);
+    _json.put("query", query);
+    _json.put("update", update);
+    DeliveryOptions _deliveryOptions = (_options != null) ? new DeliveryOptions(_options) : new DeliveryOptions();
+    _deliveryOptions.addHeader("action", "findOneAndUpdate");
+    _vertx.eventBus().<JsonObject>send(_address, _json, _deliveryOptions, res -> {
+      if (res.failed()) {
+        resultHandler.handle(Future.failedFuture(res.cause()));
+      } else {
+        resultHandler.handle(Future.succeededFuture(res.result().body()));
+      }
+    });
+    return this;
+  }
+
+  public MongoService findOneAndUpdateWithOptions(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler) {
+    if (closed) {
+      resultHandler.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));
+      return this;
+    }
+    JsonObject _json = new JsonObject();
+    _json.put("collection", collection);
+    _json.put("query", query);
+    _json.put("update", update);
+    _json.put("findOptions", findOptions == null ? null : findOptions.toJson());
+    _json.put("updateOptions", updateOptions == null ? null : updateOptions.toJson());
+    DeliveryOptions _deliveryOptions = (_options != null) ? new DeliveryOptions(_options) : new DeliveryOptions();
+    _deliveryOptions.addHeader("action", "findOneAndUpdateWithOptions");
+    _vertx.eventBus().<JsonObject>send(_address, _json, _deliveryOptions, res -> {
+      if (res.failed()) {
+        resultHandler.handle(Future.failedFuture(res.cause()));
+      } else {
+        resultHandler.handle(Future.succeededFuture(res.result().body()));
+      }
+    });
+    return this;
+  }
+
+  public MongoService findOneAndReplace(String collection, JsonObject query, JsonObject replace, Handler<AsyncResult<JsonObject>> resultHandler) {
+    if (closed) {
+      resultHandler.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));
+      return this;
+    }
+    JsonObject _json = new JsonObject();
+    _json.put("collection", collection);
+    _json.put("query", query);
+    _json.put("replace", replace);
+    DeliveryOptions _deliveryOptions = (_options != null) ? new DeliveryOptions(_options) : new DeliveryOptions();
+    _deliveryOptions.addHeader("action", "findOneAndReplace");
+    _vertx.eventBus().<JsonObject>send(_address, _json, _deliveryOptions, res -> {
+      if (res.failed()) {
+        resultHandler.handle(Future.failedFuture(res.cause()));
+      } else {
+        resultHandler.handle(Future.succeededFuture(res.result().body()));
+      }
+    });
+    return this;
+  }
+
+  public MongoService findOneAndReplaceWithOptions(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler) {
+    if (closed) {
+      resultHandler.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));
+      return this;
+    }
+    JsonObject _json = new JsonObject();
+    _json.put("collection", collection);
+    _json.put("query", query);
+    _json.put("update", update);
+    _json.put("findOptions", findOptions == null ? null : findOptions.toJson());
+    _json.put("updateOptions", updateOptions == null ? null : updateOptions.toJson());
+    DeliveryOptions _deliveryOptions = (_options != null) ? new DeliveryOptions(_options) : new DeliveryOptions();
+    _deliveryOptions.addHeader("action", "findOneAndReplaceWithOptions");
+    _vertx.eventBus().<JsonObject>send(_address, _json, _deliveryOptions, res -> {
+      if (res.failed()) {
+        resultHandler.handle(Future.failedFuture(res.cause()));
+      } else {
+        resultHandler.handle(Future.succeededFuture(res.result().body()));
+      }
+    });
+    return this;
+  }
+
+  public MongoService findOneAndDelete(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler) {
+    if (closed) {
+      resultHandler.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));
+      return this;
+    }
+    JsonObject _json = new JsonObject();
+    _json.put("collection", collection);
+    _json.put("query", query);
+    DeliveryOptions _deliveryOptions = (_options != null) ? new DeliveryOptions(_options) : new DeliveryOptions();
+    _deliveryOptions.addHeader("action", "findOneAndDelete");
+    _vertx.eventBus().<JsonObject>send(_address, _json, _deliveryOptions, res -> {
+      if (res.failed()) {
+        resultHandler.handle(Future.failedFuture(res.cause()));
+      } else {
+        resultHandler.handle(Future.succeededFuture(res.result().body()));
+      }
+    });
+    return this;
+  }
+
+  public MongoService findOneAndDeleteWithOptions(String collection, JsonObject query, FindOptions findOptions, Handler<AsyncResult<JsonObject>> resultHandler) {
+    if (closed) {
+      resultHandler.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));
+      return this;
+    }
+    JsonObject _json = new JsonObject();
+    _json.put("collection", collection);
+    _json.put("query", query);
+    _json.put("findOptions", findOptions == null ? null : findOptions.toJson());
+    DeliveryOptions _deliveryOptions = (_options != null) ? new DeliveryOptions(_options) : new DeliveryOptions();
+    _deliveryOptions.addHeader("action", "findOneAndDeleteWithOptions");
+    _vertx.eventBus().<JsonObject>send(_address, _json, _deliveryOptions, res -> {
+      if (res.failed()) {
+        resultHandler.handle(Future.failedFuture(res.cause()));
+      } else {
+        resultHandler.handle(Future.succeededFuture(res.result().body()));
+      }
+    });
+    return this;
+  }
+
   public MongoService count(String collection, JsonObject query, Handler<AsyncResult<Long>> resultHandler) {
     if (closed) {
       resultHandler.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));

--- a/vertx-mongo-service/src/main/generated/io/vertx/ext/mongo/MongoServiceVertxProxyHandler.java
+++ b/vertx-mongo-service/src/main/generated/io/vertx/ext/mongo/MongoServiceVertxProxyHandler.java
@@ -239,6 +239,30 @@ public class MongoServiceVertxProxyHandler extends ProxyHandler {
           service.findOne((java.lang.String)json.getValue("collection"), (io.vertx.core.json.JsonObject)json.getValue("query"), (io.vertx.core.json.JsonObject)json.getValue("fields"), createHandler(msg));
           break;
         }
+        case "findOneAndUpdate": {
+          service.findOneAndUpdate((java.lang.String)json.getValue("collection"), (io.vertx.core.json.JsonObject)json.getValue("query"), (io.vertx.core.json.JsonObject)json.getValue("update"), createHandler(msg));
+          break;
+        }
+        case "findOneAndUpdateWithOptions": {
+          service.findOneAndUpdateWithOptions((java.lang.String)json.getValue("collection"), (io.vertx.core.json.JsonObject)json.getValue("query"), (io.vertx.core.json.JsonObject)json.getValue("update"), json.getJsonObject("findOptions") == null ? null : new io.vertx.ext.mongo.FindOptions(json.getJsonObject("findOptions")), json.getJsonObject("updateOptions") == null ? null : new io.vertx.ext.mongo.UpdateOptions(json.getJsonObject("updateOptions")), createHandler(msg));
+          break;
+        }
+        case "findOneAndReplace": {
+          service.findOneAndReplace((java.lang.String)json.getValue("collection"), (io.vertx.core.json.JsonObject)json.getValue("query"), (io.vertx.core.json.JsonObject)json.getValue("replace"), createHandler(msg));
+          break;
+        }
+        case "findOneAndReplaceWithOptions": {
+          service.findOneAndReplaceWithOptions((java.lang.String)json.getValue("collection"), (io.vertx.core.json.JsonObject)json.getValue("query"), (io.vertx.core.json.JsonObject)json.getValue("update"), json.getJsonObject("findOptions") == null ? null : new io.vertx.ext.mongo.FindOptions(json.getJsonObject("findOptions")), json.getJsonObject("updateOptions") == null ? null : new io.vertx.ext.mongo.UpdateOptions(json.getJsonObject("updateOptions")), createHandler(msg));
+          break;
+        }
+        case "findOneAndDelete": {
+          service.findOneAndDelete((java.lang.String)json.getValue("collection"), (io.vertx.core.json.JsonObject)json.getValue("query"), createHandler(msg));
+          break;
+        }
+        case "findOneAndDeleteWithOptions": {
+          service.findOneAndDeleteWithOptions((java.lang.String)json.getValue("collection"), (io.vertx.core.json.JsonObject)json.getValue("query"), json.getJsonObject("findOptions") == null ? null : new io.vertx.ext.mongo.FindOptions(json.getJsonObject("findOptions")), createHandler(msg));
+          break;
+        }
         case "count": {
           service.count((java.lang.String)json.getValue("collection"), (io.vertx.core.json.JsonObject)json.getValue("query"), createHandler(msg));
           break;

--- a/vertx-mongo-service/src/main/generated/io/vertx/rxjava/ext/mongo/MongoService.java
+++ b/vertx-mongo-service/src/main/generated/io/vertx/rxjava/ext/mongo/MongoService.java
@@ -249,6 +249,72 @@ public class MongoService extends MongoClient {
     return resultHandler;
   }
 
+  public MongoService findOneAndUpdate(String collection, JsonObject query, JsonObject update, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndUpdate(collection, query, update, resultHandler);
+    return this;
+  }
+
+  public Observable<JsonObject> findOneAndUpdateObservable(String collection, JsonObject query, JsonObject update) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndUpdate(collection, query, update, resultHandler.toHandler());
+    return resultHandler;
+  }
+
+  public MongoService findOneAndUpdateWithOptions(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndUpdateWithOptions(collection, query, update, findOptions, updateOptions, resultHandler);
+    return this;
+  }
+
+  public Observable<JsonObject> findOneAndUpdateWithOptionsObservable(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndUpdateWithOptions(collection, query, update, findOptions, updateOptions, resultHandler.toHandler());
+    return resultHandler;
+  }
+
+  public MongoService findOneAndReplace(String collection, JsonObject query, JsonObject replace, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndReplace(collection, query, replace, resultHandler);
+    return this;
+  }
+
+  public Observable<JsonObject> findOneAndReplaceObservable(String collection, JsonObject query, JsonObject replace) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndReplace(collection, query, replace, resultHandler.toHandler());
+    return resultHandler;
+  }
+
+  public MongoService findOneAndReplaceWithOptions(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndReplaceWithOptions(collection, query, update, findOptions, updateOptions, resultHandler);
+    return this;
+  }
+
+  public Observable<JsonObject> findOneAndReplaceWithOptionsObservable(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndReplaceWithOptions(collection, query, update, findOptions, updateOptions, resultHandler.toHandler());
+    return resultHandler;
+  }
+
+  public MongoService findOneAndDelete(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndDelete(collection, query, resultHandler);
+    return this;
+  }
+
+  public Observable<JsonObject> findOneAndDeleteObservable(String collection, JsonObject query) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndDelete(collection, query, resultHandler.toHandler());
+    return resultHandler;
+  }
+
+  public MongoService findOneAndDeleteWithOptions(String collection, JsonObject query, FindOptions findOptions, Handler<AsyncResult<JsonObject>> resultHandler) { 
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndDeleteWithOptions(collection, query, findOptions, resultHandler);
+    return this;
+  }
+
+  public Observable<JsonObject> findOneAndDeleteWithOptionsObservable(String collection, JsonObject query, FindOptions findOptions) { 
+    io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
+    findOneAndDeleteWithOptions(collection, query, findOptions, resultHandler.toHandler());
+    return resultHandler;
+  }
+
   public MongoService count(String collection, JsonObject query, Handler<AsyncResult<Long>> resultHandler) { 
     ((io.vertx.ext.mongo.MongoClient) delegate).count(collection, query, resultHandler);
     return this;

--- a/vertx-mongo-service/src/main/groovy/io/vertx/groovy/ext/mongo/MongoService.groovy
+++ b/vertx-mongo-service/src/main/groovy/io/vertx/groovy/ext/mongo/MongoService.groovy
@@ -193,6 +193,78 @@ public class MongoService extends MongoClient {
     } : null);
     return this;
   }
+  public MongoService findOneAndUpdate(String collection, Map<String, Object> query, Map<String, Object> update, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndUpdate(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, update != null ? new io.vertx.core.json.JsonObject(update) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
+  public MongoService findOneAndUpdateWithOptions(String collection, Map<String, Object> query, Map<String, Object> update, Map<String, Object> findOptions, Map<String, Object> updateOptions, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndUpdateWithOptions(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, update != null ? new io.vertx.core.json.JsonObject(update) : null, findOptions != null ? new io.vertx.ext.mongo.FindOptions(io.vertx.lang.groovy.InternalHelper.toJsonObject(findOptions)) : null, updateOptions != null ? new io.vertx.ext.mongo.UpdateOptions(io.vertx.lang.groovy.InternalHelper.toJsonObject(updateOptions)) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
+  public MongoService findOneAndReplace(String collection, Map<String, Object> query, Map<String, Object> replace, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndReplace(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, replace != null ? new io.vertx.core.json.JsonObject(replace) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
+  public MongoService findOneAndReplaceWithOptions(String collection, Map<String, Object> query, Map<String, Object> update, Map<String, Object> findOptions, Map<String, Object> updateOptions, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndReplaceWithOptions(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, update != null ? new io.vertx.core.json.JsonObject(update) : null, findOptions != null ? new io.vertx.ext.mongo.FindOptions(io.vertx.lang.groovy.InternalHelper.toJsonObject(findOptions)) : null, updateOptions != null ? new io.vertx.ext.mongo.UpdateOptions(io.vertx.lang.groovy.InternalHelper.toJsonObject(updateOptions)) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
+  public MongoService findOneAndDelete(String collection, Map<String, Object> query, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndDelete(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
+  public MongoService findOneAndDeleteWithOptions(String collection, Map<String, Object> query, Map<String, Object> findOptions, Handler<AsyncResult<Map<String, Object>>> resultHandler) {
+    ((io.vertx.ext.mongo.MongoClient) delegate).findOneAndDeleteWithOptions(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, findOptions != null ? new io.vertx.ext.mongo.FindOptions(io.vertx.lang.groovy.InternalHelper.toJsonObject(findOptions)) : null, resultHandler != null ? new Handler<AsyncResult<io.vertx.core.json.JsonObject>>() {
+      public void handle(AsyncResult<io.vertx.core.json.JsonObject> ar) {
+        if (ar.succeeded()) {
+          resultHandler.handle(io.vertx.core.Future.succeededFuture((Map<String, Object>)InternalHelper.wrapObject(ar.result())));
+        } else {
+          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
+        }
+      }
+    } : null);
+    return this;
+  }
   public MongoService count(String collection, Map<String, Object> query, Handler<AsyncResult<Long>> resultHandler) {
     ((io.vertx.ext.mongo.MongoClient) delegate).count(collection, query != null ? new io.vertx.core.json.JsonObject(query) : null, resultHandler);
     return this;

--- a/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/MongoService.java
+++ b/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/MongoService.java
@@ -1,5 +1,7 @@
 package io.vertx.ext.mongo;
 
+import java.util.List;
+
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.ProxyIgnore;
@@ -10,8 +12,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.ProxyHelper;
-
-import java.util.List;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -103,6 +103,30 @@ public interface MongoService extends MongoClient {
   @Override
   @Fluent
   MongoService findOne(String collection, JsonObject query, JsonObject fields, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  @Override
+  @Fluent
+  MongoService findOneAndUpdate(String collection, JsonObject query, JsonObject update, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  @Override
+  @Fluent
+  MongoService findOneAndUpdateWithOptions(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  @Override
+  @Fluent
+  MongoService findOneAndReplace(String collection, JsonObject query, JsonObject replace, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  @Override
+  @Fluent
+  MongoService findOneAndReplaceWithOptions(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  @Override
+  @Fluent
+  MongoService findOneAndDelete(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  @Override
+  @Fluent
+  MongoService findOneAndDeleteWithOptions(String collection, JsonObject query, FindOptions findOptions, Handler<AsyncResult<JsonObject>> resultHandler);
 
   @Override
   @Fluent

--- a/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/impl/MongoServiceImpl.java
+++ b/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/impl/MongoServiceImpl.java
@@ -1,13 +1,20 @@
 package io.vertx.ext.mongo.impl;
 
+import java.util.List;
+
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.mongo.*;
-
-import java.util.List;
+import io.vertx.ext.mongo.FindOptions;
+import io.vertx.ext.mongo.IndexOptions;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.mongo.MongoClientDeleteResult;
+import io.vertx.ext.mongo.MongoClientUpdateResult;
+import io.vertx.ext.mongo.MongoService;
+import io.vertx.ext.mongo.UpdateOptions;
+import io.vertx.ext.mongo.WriteOption;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -138,6 +145,48 @@ public class MongoServiceImpl implements MongoService {
   @Fluent
   public MongoService findOne(String collection, JsonObject query, JsonObject fields, Handler<AsyncResult<JsonObject>> resultHandler) {
     client.findOne(collection, query, fields, resultHandler);
+    return this;
+  }
+
+  @Override
+  @Fluent
+  public MongoService findOneAndUpdate(String collection, JsonObject query, JsonObject update, Handler<AsyncResult<JsonObject>> resultHandler) {
+    client.findOneAndUpdate(collection, query, update, resultHandler);
+    return this;
+  }
+
+  @Override
+  @Fluent
+  public MongoService findOneAndUpdateWithOptions(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler) {
+    client.findOneAndUpdateWithOptions(collection, query, update, findOptions, updateOptions, resultHandler);
+    return this;
+  }
+
+  @Override
+  @Fluent
+  public MongoService findOneAndReplace(String collection, JsonObject query, JsonObject replace, Handler<AsyncResult<JsonObject>> resultHandler) {
+    client.findOneAndReplace(collection, query, replace, resultHandler);
+    return this;
+  }
+
+  @Override
+  @Fluent
+  public MongoService findOneAndReplaceWithOptions(String collection, JsonObject query, JsonObject update, FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler) {
+    client.findOneAndReplaceWithOptions(collection, query, update, findOptions, updateOptions, resultHandler);
+    return this;
+  }
+
+  @Override
+  @Fluent
+  public MongoService findOneAndDelete(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler) {
+    client.findOneAndDelete(collection, query, resultHandler);
+    return this;
+  }
+
+  @Override
+  @Fluent
+  public MongoService findOneAndDeleteWithOptions(String collection, JsonObject query, FindOptions findOptions, Handler<AsyncResult<JsonObject>> resultHandler) {
+    client.findOneAndDeleteWithOptions(collection, query, findOptions, resultHandler);
     return this;
   }
 

--- a/vertx-mongo-service/src/main/resources/vertx-mongo-js/mongo_service.js
+++ b/vertx-mongo-service/src/main/resources/vertx-mongo-js/mongo_service.js
@@ -434,6 +434,147 @@ var MongoService = function(j_val) {
    @public
    @param collection {string} 
    @param query {Object} 
+   @param update {Object} 
+   @param resultHandler {function} 
+   @return {MongoService}
+   */
+  this.findOneAndUpdate = function(collection, query, update, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 4 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && (typeof __args[2] === 'object' && __args[2] != null) && typeof __args[3] === 'function') {
+      j_mongoService["findOneAndUpdate(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.core.json.JsonObject,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), utils.convParamJsonObject(update), function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param collection {string} 
+   @param query {Object} 
+   @param update {Object} 
+   @param findOptions {Object} 
+   @param updateOptions {Object} 
+   @param resultHandler {function} 
+   @return {MongoService}
+   */
+  this.findOneAndUpdateWithOptions = function(collection, query, update, findOptions, updateOptions, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 6 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && (typeof __args[2] === 'object' && __args[2] != null) && (typeof __args[3] === 'object' && __args[3] != null) && (typeof __args[4] === 'object' && __args[4] != null) && typeof __args[5] === 'function') {
+      j_mongoService["findOneAndUpdateWithOptions(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.core.json.JsonObject,io.vertx.ext.mongo.FindOptions,io.vertx.ext.mongo.UpdateOptions,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), utils.convParamJsonObject(update), findOptions != null ? new FindOptions(new JsonObject(JSON.stringify(findOptions))) : null, updateOptions != null ? new UpdateOptions(new JsonObject(JSON.stringify(updateOptions))) : null, function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param collection {string} 
+   @param query {Object} 
+   @param replace {Object} 
+   @param resultHandler {function} 
+   @return {MongoService}
+   */
+  this.findOneAndReplace = function(collection, query, replace, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 4 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && (typeof __args[2] === 'object' && __args[2] != null) && typeof __args[3] === 'function') {
+      j_mongoService["findOneAndReplace(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.core.json.JsonObject,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), utils.convParamJsonObject(replace), function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param collection {string} 
+   @param query {Object} 
+   @param update {Object} 
+   @param findOptions {Object} 
+   @param updateOptions {Object} 
+   @param resultHandler {function} 
+   @return {MongoService}
+   */
+  this.findOneAndReplaceWithOptions = function(collection, query, update, findOptions, updateOptions, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 6 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && (typeof __args[2] === 'object' && __args[2] != null) && (typeof __args[3] === 'object' && __args[3] != null) && (typeof __args[4] === 'object' && __args[4] != null) && typeof __args[5] === 'function') {
+      j_mongoService["findOneAndReplaceWithOptions(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.core.json.JsonObject,io.vertx.ext.mongo.FindOptions,io.vertx.ext.mongo.UpdateOptions,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), utils.convParamJsonObject(update), findOptions != null ? new FindOptions(new JsonObject(JSON.stringify(findOptions))) : null, updateOptions != null ? new UpdateOptions(new JsonObject(JSON.stringify(updateOptions))) : null, function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param collection {string} 
+   @param query {Object} 
+   @param resultHandler {function} 
+   @return {MongoService}
+   */
+  this.findOneAndDelete = function(collection, query, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 3 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && typeof __args[2] === 'function') {
+      j_mongoService["findOneAndDelete(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param collection {string} 
+   @param query {Object} 
+   @param findOptions {Object} 
+   @param resultHandler {function} 
+   @return {MongoService}
+   */
+  this.findOneAndDeleteWithOptions = function(collection, query, findOptions, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 4 && typeof __args[0] === 'string' && (typeof __args[1] === 'object' && __args[1] != null) && (typeof __args[2] === 'object' && __args[2] != null) && typeof __args[3] === 'function') {
+      j_mongoService["findOneAndDeleteWithOptions(java.lang.String,io.vertx.core.json.JsonObject,io.vertx.ext.mongo.FindOptions,io.vertx.core.Handler)"](collection, utils.convParamJsonObject(query), findOptions != null ? new FindOptions(new JsonObject(JSON.stringify(findOptions))) : null, function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param collection {string} 
+   @param query {Object} 
    @param resultHandler {function} 
    @return {MongoService}
    */

--- a/vertx-mongo-service/src/main/resources/vertx-mongo/mongo_service.rb
+++ b/vertx-mongo-service/src/main/resources/vertx-mongo/mongo_service.rb
@@ -232,6 +232,81 @@ module VertxMongo
     end
     # @param [String] collection 
     # @param [Hash{String => Object}] query 
+    # @param [Hash{String => Object}] update 
+    # @yield 
+    # @return [self]
+    def find_one_and_update(collection=nil,query=nil,update=nil)
+      if collection.class == String && query.class == Hash && update.class == Hash && block_given?
+        @j_del.java_method(:findOneAndUpdate, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),::Vertx::Util::Utils.to_json_object(update),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_update(collection,query,update)"
+    end
+    # @param [String] collection 
+    # @param [Hash{String => Object}] query 
+    # @param [Hash{String => Object}] update 
+    # @param [Hash] findOptions 
+    # @param [Hash] updateOptions 
+    # @yield 
+    # @return [self]
+    def find_one_and_update_with_options(collection=nil,query=nil,update=nil,findOptions=nil,updateOptions=nil)
+      if collection.class == String && query.class == Hash && update.class == Hash && findOptions.class == Hash && updateOptions.class == Hash && block_given?
+        @j_del.java_method(:findOneAndUpdateWithOptions, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxExtMongo::FindOptions.java_class,Java::IoVertxExtMongo::UpdateOptions.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),::Vertx::Util::Utils.to_json_object(update),Java::IoVertxExtMongo::FindOptions.new(::Vertx::Util::Utils.to_json_object(findOptions)),Java::IoVertxExtMongo::UpdateOptions.new(::Vertx::Util::Utils.to_json_object(updateOptions)),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_update_with_options(collection,query,update,findOptions,updateOptions)"
+    end
+    # @param [String] collection 
+    # @param [Hash{String => Object}] query 
+    # @param [Hash{String => Object}] replace 
+    # @yield 
+    # @return [self]
+    def find_one_and_replace(collection=nil,query=nil,replace=nil)
+      if collection.class == String && query.class == Hash && replace.class == Hash && block_given?
+        @j_del.java_method(:findOneAndReplace, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),::Vertx::Util::Utils.to_json_object(replace),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_replace(collection,query,replace)"
+    end
+    # @param [String] collection 
+    # @param [Hash{String => Object}] query 
+    # @param [Hash{String => Object}] update 
+    # @param [Hash] findOptions 
+    # @param [Hash] updateOptions 
+    # @yield 
+    # @return [self]
+    def find_one_and_replace_with_options(collection=nil,query=nil,update=nil,findOptions=nil,updateOptions=nil)
+      if collection.class == String && query.class == Hash && update.class == Hash && findOptions.class == Hash && updateOptions.class == Hash && block_given?
+        @j_del.java_method(:findOneAndReplaceWithOptions, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxExtMongo::FindOptions.java_class,Java::IoVertxExtMongo::UpdateOptions.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),::Vertx::Util::Utils.to_json_object(update),Java::IoVertxExtMongo::FindOptions.new(::Vertx::Util::Utils.to_json_object(findOptions)),Java::IoVertxExtMongo::UpdateOptions.new(::Vertx::Util::Utils.to_json_object(updateOptions)),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_replace_with_options(collection,query,update,findOptions,updateOptions)"
+    end
+    # @param [String] collection 
+    # @param [Hash{String => Object}] query 
+    # @yield 
+    # @return [self]
+    def find_one_and_delete(collection=nil,query=nil)
+      if collection.class == String && query.class == Hash && block_given?
+        @j_del.java_method(:findOneAndDelete, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_delete(collection,query)"
+    end
+    # @param [String] collection 
+    # @param [Hash{String => Object}] query 
+    # @param [Hash] findOptions 
+    # @yield 
+    # @return [self]
+    def find_one_and_delete_with_options(collection=nil,query=nil,findOptions=nil)
+      if collection.class == String && query.class == Hash && findOptions.class == Hash && block_given?
+        @j_del.java_method(:findOneAndDeleteWithOptions, [Java::java.lang.String.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::IoVertxExtMongo::FindOptions.java_class,Java::IoVertxCore::Handler.java_class]).call(collection,::Vertx::Util::Utils.to_json_object(query),Java::IoVertxExtMongo::FindOptions.new(::Vertx::Util::Utils.to_json_object(findOptions)),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling find_one_and_delete_with_options(collection,query,findOptions)"
+    end
+    # @param [String] collection 
+    # @param [Hash{String => Object}] query 
     # @yield 
     # @return [self]
     def count(collection=nil,query=nil)


### PR DESCRIPTION
support findOneAndX #82

Wrap findOneAndUpdate, findOneAndReplace and findOneAndDelete with corresponding "WithOptions" alternatives.
This is mostly the same code for those three mongo calls, can you rename the issue to reflect this PR?