### PR TITLE
add serverSelectionTimeout to ClusterSettingsParser

### DIFF
--- a/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
@@ -841,7 +841,7 @@ For more information on the format of the connection string please consult the d
 ----
 {
   // Single Cluster Settings
-  "host" : "17.0.0.1", // string
+  "host" : "127.0.0.1", // string
   "port" : 27017,      // int
 
   // Multiple Cluster Settings
@@ -856,7 +856,8 @@ For more information on the format of the connection string please consult the d
     },
     ...
   ],
-  "replicaSet" :  "foo"    // string
+  "replicaSet" :  "foo",    // string
+  "serverSelectionTimeoutMS" : 30000, // long
 
   // Connection Pool Settings
   "maxPoolSize" : 50,                // int
@@ -906,6 +907,7 @@ For more information on the format of the connection string please consult the d
 `host`:: A host in the cluster
 `port`:: The port a host in the cluster is listening on
 `replicaSet`:: The name of the replica set, if the mongoDB instance is a member of a replica set
+`serverSelectionTimeoutMS`:: The time in milliseconds that the mongo driver will wait to select a server for an operation before raising an error.
 `maxPoolSize`:: The maximum number of connections in the connection pool. The default value is `100`
 `minPoolSize`:: The minimum number of connections in the connection pool. The default value is `0`
 `maxIdleTimeMS`:: The maximum idle time of a pooled connection. The default value is `0` which means there is no limit

--- a/vertx-mongo-client/src/main/asciidoc/java/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/java/index.adoc
@@ -733,7 +733,7 @@ For more information on the format of the connection string please consult the d
 ----
 {
   // Single Cluster Settings
-  "host" : "17.0.0.1", // string
+  "host" : "127.0.0.1", // string
   "port" : 27017,      // int
 
   // Multiple Cluster Settings
@@ -748,7 +748,8 @@ For more information on the format of the connection string please consult the d
     },
     ...
   ],
-  "replicaSet" :  "foo"    // string
+  "replicaSet" :  "foo",    // string
+  "serverSelectionTimeoutMS" : 30000, // long
 
   // Connection Pool Settings
   "maxPoolSize" : 50,                // int
@@ -798,6 +799,7 @@ For more information on the format of the connection string please consult the d
 `host`:: A host in the cluster
 `port`:: The port a host in the cluster is listening on
 `replicaSet`:: The name of the replica set, if the mongoDB instance is a member of a replica set
+`serverSelectionTimeoutMS`:: The time in milliseconds that the mongo driver will wait to select a server for an operation before raising an error.
 `maxPoolSize`:: The maximum number of connections in the connection pool. The default value is `100`
 `minPoolSize`:: The minimum number of connections in the connection pool. The default value is `0`
 `maxIdleTimeMS`:: The maximum idle time of a pooled connection. The default value is `0` which means there is no limit

--- a/vertx-mongo-client/src/main/asciidoc/js/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/js/index.adoc
@@ -842,7 +842,7 @@ For more information on the format of the connection string please consult the d
 ----
 {
   // Single Cluster Settings
-  "host" : "17.0.0.1", // string
+  "host" : "127.0.0.1", // string
   "port" : 27017,      // int
 
   // Multiple Cluster Settings
@@ -857,7 +857,8 @@ For more information on the format of the connection string please consult the d
     },
     ...
   ],
-  "replicaSet" :  "foo"    // string
+  "replicaSet" :  "foo",    // string
+  "serverSelectionTimeoutMS" : 30000, // long
 
   // Connection Pool Settings
   "maxPoolSize" : 50,                // int
@@ -907,6 +908,7 @@ For more information on the format of the connection string please consult the d
 `host`:: A host in the cluster
 `port`:: The port a host in the cluster is listening on
 `replicaSet`:: The name of the replica set, if the mongoDB instance is a member of a replica set
+`serverSelectionTimeoutMS`:: The time in milliseconds that the mongo driver will wait to select a server for an operation before raising an error.
 `maxPoolSize`:: The maximum number of connections in the connection pool. The default value is `100`
 `minPoolSize`:: The minimum number of connections in the connection pool. The default value is `0`
 `maxIdleTimeMS`:: The maximum idle time of a pooled connection. The default value is `0` which means there is no limit

--- a/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
@@ -845,7 +845,7 @@ For more information on the format of the connection string please consult the d
 ----
 {
   // Single Cluster Settings
-  "host" : "17.0.0.1", // string
+  "host" : "127.0.0.1", // string
   "port" : 27017,      // int
 
   // Multiple Cluster Settings
@@ -860,7 +860,8 @@ For more information on the format of the connection string please consult the d
     },
     ...
   ],
-  "replicaSet" :  "foo"    // string
+  "replicaSet" :  "foo",    // string
+  "serverSelectionTimeoutMS" : 30000, // long
 
   // Connection Pool Settings
   "maxPoolSize" : 50,                // int
@@ -910,6 +911,7 @@ For more information on the format of the connection string please consult the d
 `host`:: A host in the cluster
 `port`:: The port a host in the cluster is listening on
 `replicaSet`:: The name of the replica set, if the mongoDB instance is a member of a replica set
+`serverSelectionTimeoutMS`:: The time in milliseconds that the mongo driver will wait to select a server for an operation before raising an error.
 `maxPoolSize`:: The maximum number of connections in the connection pool. The default value is `100`
 `minPoolSize`:: The minimum number of connections in the connection pool. The default value is `0`
 `maxIdleTimeMS`:: The maximum idle time of a pooled connection. The default value is `0` which means there is no limit

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/ClusterSettingsParser.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/ClusterSettingsParser.java
@@ -11,6 +11,8 @@ import io.vertx.core.json.JsonObject;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
@@ -37,6 +39,12 @@ class ClusterSettingsParser {
       }
       if (replicaSet != null) {
         settings.requiredReplicaSetName(replicaSet);
+      }
+
+      // serverSelectionTimeoutMS
+      Long serverSelectionTimeoutMS = config.getLong("serverSelectionTimeoutMS");
+      if(serverSelectionTimeoutMS != null) {
+        settings.serverSelectionTimeout(serverSelectionTimeoutMS, MILLISECONDS);
       }
     }
 

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
@@ -391,7 +391,7 @@
  * ----
  * {
  *   // Single Cluster Settings
- *   "host" : "17.0.0.1", // string
+ *   "host" : "127.0.0.1", // string
  *   "port" : 27017,      // int
  *
  *   // Multiple Cluster Settings
@@ -406,7 +406,8 @@
  *     },
  *     ...
  *   ],
- *   "replicaSet" :  "foo"    // string
+ *   "replicaSet" :  "foo",    // string
+ *   "serverSelectionTimeoutMS" : 30000, // long
  *
  *   // Connection Pool Settings
  *   "maxPoolSize" : 50,                // int
@@ -456,6 +457,7 @@
  * `host`:: A host in the cluster
  * `port`:: The port a host in the cluster is listening on
  * `replicaSet`:: The name of the replica set, if the mongoDB instance is a member of a replica set
+ * `serverSelectionTimeoutMS`:: The time in milliseconds that the mongo driver will wait to select a server for an operation before raising an error.
  * `maxPoolSize`:: The maximum number of connections in the connection pool. The default value is `100`
  * `minPoolSize`:: The minimum number of connections in the connection pool. The default value is `0`
  * `maxIdleTimeMS`:: The maximum idle time of a pooled connection. The default value is `0` which means there is no limit

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/config/ClusterSettingsParserTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/config/ClusterSettingsParserTest.java
@@ -8,6 +8,7 @@ import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
@@ -43,6 +44,13 @@ public class ClusterSettingsParserTest {
     ClusterSettings settings = settings(multipleHosts().put("replicaSet", "foobar"));
     assertMultipleHosts(settings);
     assertEquals("foobar", settings.getRequiredReplicaSetName());
+  }
+
+  @Test
+  public void testServerSelectionTimeoutMS() {
+    ClusterSettings settings = settings(multipleHosts().put("serverSelectionTimeoutMS", 7533L));
+    assertMultipleHosts(settings);
+    assertEquals(7533L, settings.getServerSelectionTimeout(TimeUnit.MILLISECONDS));
   }
 
   private static void assertSingleHost(ClusterConnectionMode mode, ClusterSettings settings) {


### PR DESCRIPTION
Allow configuration of the serverSelectionTimeout. This is currently not exposed in the vertx-mongo-client.