### PR TITLE
binary extended json format with type definition

### DIFF
--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
@@ -189,19 +189,19 @@ public class JsonObjectCodec extends AbstractJsonCodec<JsonObject, JsonArray> im
   @Override
   protected Object readBinary(BsonReader reader, DecoderContext ctx) {
     final JsonObject result = new JsonObject();
-    BsonBinary tmpObj = reader.readBinaryData();
-    result.put(BINARY_FIELD, tmpObj.getData())
-        .put(TYPE_FIELD, tmpObj.getType());
+    BsonBinary bsonBinary = reader.readBinaryData();
+    result.put(BINARY_FIELD, bsonBinary.getData())
+        .put(TYPE_FIELD, bsonBinary.getType());
     return result;
   }
 
   @Override
   protected void writeBinary(BsonWriter writer, String name, Object value, EncoderContext ctx) {
-    JsonObject tmpObj = (JsonObject) value;
-    byte type = Optional.ofNullable(tmpObj.getInteger(TYPE_FIELD))
+    JsonObject binaryJsonObject = (JsonObject) value;
+    byte type = Optional.ofNullable(binaryJsonObject.getInteger(TYPE_FIELD))
         .map(Integer::byteValue)
         .orElse(BsonBinarySubType.BINARY.getValue());
-    final BsonBinary bson = new BsonBinary(type, tmpObj.getBinary(BINARY_FIELD));
+    final BsonBinary bson = new BsonBinary(type, binaryJsonObject.getBinary(BINARY_FIELD));
     writer.writeBinaryData(bson);
   }
 

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
@@ -201,7 +201,7 @@ public class JsonObjectCodec extends AbstractJsonCodec<JsonObject, JsonArray> im
     byte type = Optional.ofNullable(tmpObj.getInteger(TYPE_FIELD))
         .map(Integer::byteValue)
         .orElse(BsonBinarySubType.BINARY.getValue());
-    final BsonBinary bson = new BsonBinary(type ,tmpObj.getBinary(BINARY_FIELD));
+    final BsonBinary bson = new BsonBinary(type, tmpObj.getBinary(BINARY_FIELD));
     writer.writeBinaryData(bson);
   }
 

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/codec/json/JsonObjectCodec.java
@@ -198,8 +198,8 @@ public class JsonObjectCodec extends AbstractJsonCodec<JsonObject, JsonArray> im
   @Override
   protected void writeBinary(BsonWriter writer, String name, Object value, EncoderContext ctx) {
     JsonObject tmpObj = (JsonObject) value;
-    byte type = Optional.ofNullable(tmpObj.getBinary(TYPE_FIELD))
-        .map(b -> b[0])
+    byte type = Optional.ofNullable(tmpObj.getInteger(TYPE_FIELD))
+        .map(Integer::byteValue)
         .orElse(BsonBinarySubType.BINARY.getValue());
     final BsonBinary bson = new BsonBinary(type ,tmpObj.getBinary(BINARY_FIELD));
     writer.writeBinaryData(bson);


### PR DESCRIPTION
Extend $binary to handle optional $type field. If $type is not defined use default BsonBinarySubType.BINARY.