### PR TITLE
Fix ClusterSettings.maxWaitQueueSize not being set

### DIFF
--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/ClusterSettingsParser.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/ClusterSettingsParser.java
@@ -19,6 +19,10 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 class ClusterSettingsParser {
 
   private final ClusterSettings settings;
+  /*
+  * The Default Mongo Driver maxWaitQueueSize @see <a href="https://github.com/mongodb/mongo-java-driver/blob/master/driver-core/src/main/com/mongodb/connection/ClusterSettings.java">maxWaitQueueSize</a>
+  */
+  private final Integer DEFAULT_MONGO_DRIVER_WAIT_Q_SIZE = 500;
 
   public ClusterSettingsParser(ConnectionString connectionString, JsonObject config) {
     ClusterSettings.Builder settings = ClusterSettings.builder();
@@ -45,6 +49,12 @@ class ClusterSettingsParser {
       Long serverSelectionTimeoutMS = config.getLong("serverSelectionTimeoutMS");
       if(serverSelectionTimeoutMS != null) {
         settings.serverSelectionTimeout(serverSelectionTimeoutMS, MILLISECONDS);
+      }
+
+      Integer waitQueueMultiple = config.getInteger("waitQueueMultiple");
+      if (waitQueueMultiple != null) {
+        Integer waitQueueSize = waitQueueMultiple * DEFAULT_MONGO_DRIVER_WAIT_Q_SIZE;
+        settings.maxWaitQueueSize(waitQueueSize);
       }
     }
 

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/ClusterSettingsParser.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/ClusterSettingsParser.java
@@ -22,7 +22,7 @@ class ClusterSettingsParser {
   /*
   * The Default Mongo Driver maxWaitQueueSize @see <a href="https://github.com/mongodb/mongo-java-driver/blob/master/driver-core/src/main/com/mongodb/connection/ClusterSettings.java">maxWaitQueueSize</a>
   */
-  private final Integer DEFAULT_MONGO_DRIVER_WAIT_Q_SIZE = 500;
+  public static final Integer DEFAULT_MONGO_DRIVER_WAIT_Q_SIZE = 500;
 
   public ClusterSettingsParser(ConnectionString connectionString, JsonObject config) {
     ClusterSettings.Builder settings = ClusterSettings.builder();

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/config/ClusterSettingsParserTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/config/ClusterSettingsParserTest.java
@@ -53,6 +53,13 @@ public class ClusterSettingsParserTest {
     assertEquals(7533L, settings.getServerSelectionTimeout(TimeUnit.MILLISECONDS));
   }
 
+  @Test
+  public void testMaxWaitQueueSize() {
+    ClusterSettings settings = settings(multipleHosts().put("waitQueueMultiple", 10));
+    assertEquals(ClusterSettingsParser.DEFAULT_MONGO_DRIVER_WAIT_Q_SIZE * 10, settings.getMaxWaitQueueSize());
+  }
+
+
   private static void assertSingleHost(ClusterConnectionMode mode, ClusterSettings settings) {
     List<ServerAddress> hosts = settings.getHosts();
     assertNotNull(hosts);


### PR DESCRIPTION
Fix issue reported at:

https://github.com/vert-x3/issues/issues/287


ClusterSettings.maxWaitQueueSize has been set to the same value as ConnectionPoolSettings.maxWaitQueueSize. From the mongo docs:

```
ClusterSettings.maxWaitQueueSize: This is the maximum number of concurrent operations allowed to wait for a server to become available. All further operations will get an exception immediately
```
```
ConnectionPoolSettings.maxWaitQueueSize: This is the maximum number of operations that may be waiting for a connection to become available from the pool. All further operations will get an exception immediately.
```

I would guess people would want these to be the same value, if we want them as different values I will change the config value.