### PR TITLE
RxJava support for batching methods

### DIFF
--- a/vertx-mongo-client/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/dataobjects.adoc
@@ -68,6 +68,10 @@ Set the write option
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
+|[[batchSize]]`batchSize`|`Number (int)`|
++++
+Set the batch size for methods loading found data in batches.
++++
 |[[fields]]`fields`|`Json object`|
 +++
 Set the fields

--- a/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
@@ -359,13 +359,14 @@ This has the following fields:
 `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
 `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
 
-=== Find in batches
+=== Finding documents in batches
 
 When dealing with large data sets, it is not advised to use the
 `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#find-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[find]` and
 `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.FindOptions-io.vertx.core.Handler-[findWithOptions]` methods.
 In order to avoid inflating the whole response into memory, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findBatch-java.lang.String-io.vertx.core.json.JsonObject-[findBatch]`:
 
+[source,groovy]
 ----
 // will match all Tolkien books
 def query = [
@@ -382,6 +383,29 @@ mongoClient.findBatch("book", query).exceptionHandler({ throwable ->
 ----
 
 The matching documents are emitted one by one by the `link:../../apidocs/io/vertx/core/streams/ReadStream.html[ReadStream]` handler.
+
+`link:../../apidocs/io/vertx/ext/mongo/FindOptions.html[FindOptions]` has an extra parameter `batchSize` which you can use to set the number of documents to load at once:
+
+[source,groovy]
+----
+// will match all Tolkien books
+def query = [
+  author:"J. R. R. Tolkien"
+]
+def options = [
+  batchSize:100
+]
+mongoClient.findBatchWithOptions("book", query, options).exceptionHandler({ throwable ->
+  throwable.printStackTrace()
+}).endHandler({ v ->
+  println("End of research")
+}).handler({ doc ->
+  println("Found doc: ${groovy.json.JsonOutput.toJson(doc)}")
+})
+
+----
+
+By default, `batchSize` is set to 20.
 
 === Finding a single document
 
@@ -754,6 +778,7 @@ For more information on the format of the connection string please consult the d
 
 *Specific driver configuration options*
 
+[source,js]
 ----
 {
   // Single Cluster Settings

--- a/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
@@ -453,27 +453,13 @@ def query = [
   author:"J. R. R. Tolkien"
 ]
 
-mongoClient.findBatch("book", query, { res ->
-
-  if (res.succeeded()) {
-
-    if (res.result() == null) {
-
-      println("End of research")
-
-    } else {
-
-      println("Found doc: ${groovy.json.JsonOutput.toJson(res.result())}")
-
-    }
-
-  } else {
-
-    res.cause().printStackTrace()
-
-  }
+mongoClient.findBatch("book", query).exceptionHandler({ throwable ->
+  throwable.printStackTrace()
+}).endHandler({ v ->
+  println("End of research")
+}).handler({ doc ->
+  println("Found doc: ${groovy.json.JsonOutput.toJson(doc)}")
 })
-
 
 ----
 
@@ -844,8 +830,8 @@ mongoClient.save("books", document, { res ->
 
   if (res.succeeded()) {
 
-    mongoClient.distinctBatch("books", "title", java.lang.String.class.getName(), { res2 ->
-      println("Title is : ${res2.result().title}")
+    mongoClient.distinctBatch("books", "title", java.lang.String.class.getName()).handler({ book ->
+      println("Title is : ${book.title}")
     })
 
   } else {
@@ -905,9 +891,10 @@ def query = [
 mongoClient.save("books", document, { res ->
   if (res.succeeded()) {
 
-    mongoClient.distinctBatchWithQuery("books", "title", java.lang.String.class.getName(), query, { res2 ->
-      println("Title is : ${res2.result().title}")
+    mongoClient.distinctBatchWithQuery("books", "title", java.lang.String.class.getName(), query).handler({ book ->
+      println("Title is : ${book.title}")
     })
+
   }
 
 })

--- a/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
@@ -53,9 +53,7 @@ The simplest way to do this is as follows:
 
 [source,groovy]
 ----
-
 def client = MongoClient.createShared(vertx, config)
-
 
 ----
 
@@ -70,9 +68,7 @@ You can create a client specifying a pool source name as follows
 
 [source,groovy]
 ----
-
 def client = MongoClient.createShared(vertx, config, "MyPoolName")
-
 
 ----
 
@@ -96,9 +92,7 @@ In that case you can use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html
 
 [source,groovy]
 ----
-
 def client = MongoClient.createNonShared(vertx, config)
-
 
 ----
 
@@ -114,8 +108,8 @@ The client API is represented by `link:../../apidocs/io/vertx/ext/mongo/MongoCli
 
 To save a document you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#save-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[save]`.
 
-If the document has no `\_id` field, it is inserted, otherwise, it is _upserted_. Upserted means it is inserted
-if it doesn't already exist, otherwise it is updated.
+If the document has no `\_id` field, it is inserted, otherwise, it is __upserted__.
+Upserted means it is inserted if it doesn't already exist, otherwise it is updated.
 
 If the document is inserted and has no id, then the id field generated will be returned to the result handler.
 
@@ -123,26 +117,18 @@ Here's an example of saving a document and getting the id back
 
 [source,groovy]
 ----
-
 // Document has no id
-
 def document = [
   title:"The Hobbit"
 ]
-
 mongoClient.save("books", document, { res ->
-
   if (res.succeeded()) {
-
     def id = res.result()
     println("Saved book with id ${id}")
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
@@ -150,26 +136,18 @@ And here's an example of saving a document which already has an id.
 
 [source,groovy]
 ----
-
 // Document has an id already
-
 def document = [
   title:"The Hobbit",
   _id:"123244"
 ]
-
 mongoClient.save("books", document, { res ->
-
   if (res.succeeded()) {
-
     // ...
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
@@ -181,64 +159,48 @@ If the document is inserted and has no id, then the id field generated will be r
 
 [source,groovy]
 ----
-
 // Document has an id already
-
 def document = [
   title:"The Hobbit"
 ]
-
 mongoClient.insert("books", document, { res ->
-
   if (res.succeeded()) {
-
     def id = res.result()
     println("Inserted book with id ${id}")
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
-If a document is inserted with an id, and a document with that id already eists, the insert will fail:
+If a document is inserted with an id, and a document with that id already exists, the insert will fail:
 
 [source,groovy]
 ----
-
 // Document has an id already
-
 def document = [
   title:"The Hobbit",
   _id:"123244"
 ]
-
 mongoClient.insert("books", document, { res ->
-
   if (res.succeeded()) {
-
     //...
-
   } else {
-
     // Will fail if the book with that id already exists.
   }
-
 })
-
 
 ----
 
 === Updating documents
 
-To update a documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#update-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[update]`.
+To update a documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#updateCollection-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[updateCollection]`.
 
-This updates one or multiple documents in a collection. The json object that is passed in the `update`
-parameter must contain http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators] and determines
-how the object is updated.
+This updates one or multiple documents in a collection.
+The json object that is passed in the `updateCollection` parameter must contain
+http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators]
+and determines how the object is updated.
 
 The json object specified in the query parameter determines which documents in the collection will be updated.
 
@@ -246,36 +208,28 @@ Here's an example of updating a document in the books collection:
 
 [source,groovy]
 ----
-
 // Match any documents with title=The Hobbit
 def query = [
   title:"The Hobbit"
 ]
-
 // Set the author field
 def update = [
   $set:[
     author:"J. R. R. Tolkien"
   ]
 ]
-
-mongoClient.update("books", query, update, { res ->
-
+mongoClient.updateCollection("books", query, update, { res ->
   if (res.succeeded()) {
-
     println("Book updated !")
-
   } else {
-
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
-To specify if the update should upsert or update multiple documents, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#updateWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.UpdateOptions-io.vertx.core.Handler-[updateWithOptions]`
+To specify if the update should upsert or update multiple documents, use
+`link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#updateCollectionWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.UpdateOptions-io.vertx.core.Handler-[updateCollectionWithOptions]`
 and pass in an instance of `link:../../apidocs/io/vertx/ext/mongo/UpdateOptions.html[UpdateOptions]`.
 
 This has the following fields:
@@ -286,74 +240,54 @@ This has the following fields:
 
 [source,groovy]
 ----
-
 // Match any documents with title=The Hobbit
 def query = [
   title:"The Hobbit"
 ]
-
 // Set the author field
 def update = [
   $set:[
     author:"J. R. R. Tolkien"
   ]
 ]
-
 def options = [
   multi:true
 ]
-
-mongoClient.updateWithOptions("books", query, update, options, { res ->
-
+mongoClient.updateCollectionWithOptions("books", query, update, options, { res ->
   if (res.succeeded()) {
-
     println("Book updated !")
-
   } else {
-
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
 === Replacing documents
 
-To replace documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#replace-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[replace]`.
+To replace documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#replaceDocuments-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[replaceDocuments]`.
 
-This is similar to the update operation, however it does not take any update operators like `update`.
+This is similar to the update operation, however it does not take any operator.
 Instead it replaces the entire document with the one provided.
 
 Here's an example of replacing a document in the books collection
 
 [source,groovy]
 ----
-
 def query = [
   title:"The Hobbit"
 ]
-
 def replace = [
   title:"The Lord of the Rings",
   author:"J. R. R. Tolkien"
 ]
-
-mongoClient.replace("books", query, replace, { res ->
-
+mongoClient.replaceDocuments("books", query, replace, { res ->
   if (res.succeeded()) {
-
     println("Book replaced !")
-
   } else {
-
     res.cause().printStackTrace()
-
   }
-
 })
-
 
 ----
 
@@ -361,12 +295,13 @@ mongoClient.replace("books", query, replace, { res ->
 
 To execute multiple insert, update, replace, or delete operations at once, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#bulkWrite-java.lang.String-java.util.List-io.vertx.core.Handler-[bulkWrite]`.
 
-You can pass a list of `link:../../apidocs/io/vertx/ext/mongo/BulkOperation.html[BulkOperations]`, with each working similiar to the matching single operations.
+You can pass a list of `link:../../apidocs/io/vertx/ext/mongo/BulkOperation.html[BulkOperations]`, with each working similar to the matching single operation.
 You can pass as many operations, even of the same type, as you wish.
 
 To specify if the bulk operation should be executed in order, and with what write option, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#bulkWriteWithOptions-java.lang.String-java.util.List-io.vertx.ext.mongo.BulkWriteOptions-io.vertx.core.Handler-[bulkWriteWithOptions]`
 and pass an instance of `link:../../apidocs/io/vertx/ext/mongo/BulkWriteOptions.html[BulkWriteOptions]`.
-For more explanation what ordered means, see https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations
+For more explanation what ordered means, see
+https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations[Execution of Operations].
 
 === Finding documents
 
@@ -378,28 +313,17 @@ Here's a simple example with an empty query that will match all books:
 
 [source,groovy]
 ----
-
 // empty query = match any
 def query = [:]
-
 mongoClient.find("books", query, { res ->
-
   if (res.succeeded()) {
-
     res.result().each { json ->
-
       println(groovy.json.JsonOutput.toJson(json))
-
     }
-
   } else {
-
     res.cause().printStackTrace()
-
   }
-
 })
-
 
 ----
 
@@ -407,30 +331,19 @@ Here's another example that will match all books by Tolkien:
 
 [source,groovy]
 ----
-
 // will match all Tolkien books
 def query = [
   author:"J. R. R. Tolkien"
 ]
-
 mongoClient.find("books", query, { res ->
-
   if (res.succeeded()) {
-
     res.result().each { json ->
-
       println(groovy.json.JsonOutput.toJson(json))
-
     }
-
   } else {
-
     res.cause().printStackTrace()
-
   }
-
 })
-
 
 ----
 
@@ -446,13 +359,18 @@ This has the following fields:
 `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
 `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
 
-----
+=== Find in batches
 
+When dealing with large data sets, it is not advised to use the
+`link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#find-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[find]` and
+`link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.FindOptions-io.vertx.core.Handler-[findWithOptions]` methods.
+In order to avoid inflating the whole response into memory, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findBatch-java.lang.String-io.vertx.core.json.JsonObject-[findBatch]`:
+
+----
 // will match all Tolkien books
 def query = [
   author:"J. R. R. Tolkien"
 ]
-
 mongoClient.findBatch("book", query).exceptionHandler({ throwable ->
   throwable.printStackTrace()
 }).endHandler({ v ->
@@ -463,7 +381,7 @@ mongoClient.findBatch("book", query).exceptionHandler({ throwable ->
 
 ----
 
-The matching documents are returned unitary in the result handler.
+The matching documents are emitted one by one by the `link:../../apidocs/io/vertx/core/streams/ReadStream.html[ReadStream]` handler.
 
 === Finding a single document
 
@@ -481,24 +399,16 @@ Here's an example of removing all Tolkien books:
 
 [source,groovy]
 ----
-
 def query = [
   author:"J. R. R. Tolkien"
 ]
-
-mongoClient.remove("books", query, { res ->
-
+mongoClient.removeDocuments("books", query, { res ->
   if (res.succeeded()) {
-
     println("Never much liked Tolkien stuff!")
-
   } else {
-
     res.cause().printStackTrace()
-
   }
 })
-
 
 ----
 
@@ -516,24 +426,16 @@ Here's an example that counts the number of Tolkien books. The number is passed 
 
 [source,groovy]
 ----
-
 def query = [
   author:"J. R. R. Tolkien"
 ]
-
 mongoClient.count("books", query, { res ->
-
   if (res.succeeded()) {
-
     def num = res.result()
-
   } else {
-
     res.cause().printStackTrace()
-
   }
 })
-
 
 ----
 
@@ -545,20 +447,13 @@ To get a list of all collections you can use `link:../../apidocs/io/vertx/ext/mo
 
 [source,groovy]
 ----
-
 mongoClient.getCollections({ res ->
-
   if (res.succeeded()) {
-
     def collections = res.result()
-
   } else {
-
     res.cause().printStackTrace()
-
   }
 })
-
 
 ----
 
@@ -566,20 +461,13 @@ To create a new collection you can use `link:../../apidocs/io/vertx/ext/mongo/Mo
 
 [source,groovy]
 ----
-
 mongoClient.createCollection("mynewcollectionr", { res ->
-
   if (res.succeeded()) {
-
     // Created ok!
-
   } else {
-
     res.cause().printStackTrace()
-
   }
 })
-
 
 ----
 
@@ -589,20 +477,13 @@ NOTE: Dropping a collection will delete all documents within it!
 
 [source,groovy]
 ----
-
 mongoClient.dropCollection("mynewcollectionr", { res ->
-
   if (res.succeeded()) {
-
     // Dropped ok!
-
   } else {
-
     res.cause().printStackTrace()
-
   }
 })
-
 
 ----
 
@@ -611,7 +492,7 @@ mongoClient.dropCollection("mynewcollectionr", { res ->
 
 You can run arbitrary MongoDB commands with `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#runCommand-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[runCommand]`.
 
-Commands can be used to run more advanced mongoDB features, such as using MapReduce.
+Commands can be used to run more advanced MongoDB features, such as using MapReduce.
 For more information see the mongo docs for supported http://docs.mongodb.org/manual/reference/command[Commands].
 
 Here's an example of running an aggregate command. Note that the command name must be specified as a parameter
@@ -621,13 +502,11 @@ of the entries in the JSON is the command name it must be specified as a paramet
 
 [source,groovy]
 ----
-
 def command = [
   aggregate:"collection_name",
   pipeline:[
   ]
 ]
-
 mongoClient.runCommand("aggregate", command, { res ->
   if (res.succeeded()) {
     def resArr = res.result().result
@@ -637,49 +516,39 @@ mongoClient.runCommand("aggregate", command, { res ->
   }
 })
 
-
 ----
 
 === MongoDB Extended JSON support
 
-For now, only date, oid and binary types are supported (cf http://docs.mongodb.org/manual/reference/mongodb-extended-json )
+For now, only `date`, `oid` and `binary` types are supported
+(see http://docs.mongodb.org/manual/reference/mongodb-extended-json[MongoDB Extended JSON]).
 
-Here's an example of inserting a document with a date field
+Here's an example of inserting a document with a `date` field:
 
 [source,groovy]
 ----
-
 def document = [
   title:"The Hobbit",
   publicationDate:[
     $date:"1937-09-21T00:00:00+00:00"
   ]
 ]
-
 mongoService.save("publishedBooks", document, { res ->
-
   if (res.succeeded()) {
-
     def id = res.result()
-
     mongoService.findOne("publishedBooks", [
       _id:id
     ], null, { res2 ->
       if (res2.succeeded()) {
-
         println("To retrieve ISO-8601 date : ${res2.result().publicationDate.$date}")
-
       } else {
         res2.cause().printStackTrace()
       }
     })
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
@@ -688,31 +557,23 @@ Here's an example (in Java) of inserting a document with a binary field and read
 [source,groovy]
 ----
 byte[] binaryObject = new byte[40];
-
 JsonObject document = new JsonObject()
-        .put("name", "Alan Turing")
-        .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
-
+  .put("name", "Alan Turing")
+  .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
 mongoService.save("smartPeople", document, res -> {
-
   if (res.succeeded()) {
-
     String id = res.result();
-
     mongoService.findOne("smartPeople", new JsonObject().put("_id", id), null, res2 -> {
-      if(res2.succeeded()) {
-
+      if (res2.succeeded()) {
         byte[] reconstitutedBinaryObject = res2.result().getJsonObject("binaryStuff").getBinary("$binary");
         //This could now be de-serialized into an object in real life
       } else {
         res2.cause().printStackTrace();
       }
     });
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 
@@ -720,81 +581,66 @@ Here's an example of inserting a base 64 encoded string, typing it as binary a b
 
 [source,groovy]
 ----
-
 //This could be a the byte contents of a pdf file, etc converted to base 64
 def base64EncodedString = "a2FpbHVhIGlzIHRoZSAjMSBiZWFjaCBpbiB0aGUgd29ybGQ="
-
 def document = [
   name:"Alan Turing",
   binaryStuff:[
     $binary:base64EncodedString
   ]
 ]
-
 mongoService.save("smartPeople", document, { res ->
-
   if (res.succeeded()) {
-
     def id = res.result()
-
     mongoService.findOne("smartPeople", [
       _id:id
     ], null, { res2 ->
       if (res2.succeeded()) {
-
         def reconstitutedBase64EncodedString = res2.result().binaryStuff.$binary
         //This could now converted back to bytes from the base 64 string
       } else {
         res2.cause().printStackTrace()
       }
     })
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 Here's an example of inserting an object ID and reading it back
 
 [source,groovy]
 ----
-
 def individualId = new org.bson.types.ObjectId().toHexString()
-
 def document = [
   name:"Stephen Hawking",
   individualId:[
     $oid:individualId
   ]
 ]
-
 mongoService.save("smartPeople", document, { res ->
-
   if (res.succeeded()) {
-
     def id = res.result()
-
-    mongoService.findOne("smartPeople", [
+    def query = [
       _id:id
-    ], null, { res2 ->
+    ]
+    mongoService.findOne("smartPeople", query, null, { res2 ->
       if (res2.succeeded()) {
         def reconstitutedIndividualId = res2.result().individualId.$oid
       } else {
         res2.cause().printStackTrace()
       }
     })
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
 
-
 ----
+
+=== Getting distinct values
+
 Here's an example of getting distinct value
 
 [source,groovy]
@@ -802,19 +648,14 @@ Here's an example of getting distinct value
 def document = [
   title:"The Hobbit"
 ]
-
 mongoClient.save("books", document, { res ->
-
   if (res.succeeded()) {
-
     mongoClient.distinct("books", "title", java.lang.String.class.getName(), { res2 ->
       println("Title is : ${res2.result()[0]}")
     })
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
 
 ----
@@ -825,19 +666,14 @@ Here's an example of getting distinct value in batch mode
 def document = [
   title:"The Hobbit"
 ]
-
 mongoClient.save("books", document, { res ->
-
   if (res.succeeded()) {
-
     mongoClient.distinctBatch("books", "title", java.lang.String.class.getName()).handler({ book ->
       println("Title is : ${book.title}")
     })
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
 
 ----
@@ -858,15 +694,12 @@ def query = [
     ]
   ]
 ]
-
 mongoClient.save("books", document, { res ->
   if (res.succeeded()) {
-
     mongoClient.distinctWithQuery("books", "title", java.lang.String.class.getName(), query, { res2 ->
       println("Title is : ${res2.result()[0]}")
     })
   }
-
 })
 
 ----
@@ -887,16 +720,12 @@ def query = [
     ]
   ]
 ]
-
 mongoClient.save("books", document, { res ->
   if (res.succeeded()) {
-
     mongoClient.distinctBatchWithQuery("books", "title", java.lang.String.class.getName(), query).handler({ book ->
       println("Title is : ${book.title}")
     })
-
   }
-
 })
 
 ----
@@ -908,7 +737,7 @@ The client is configured with a json object.
 The following configuration is supported by the mongo client:
 
 
-`db_name`:: Name of the database in the mongoDB instance to use. Defaults to `default_db`
+`db_name`:: Name of the database in the MongoDB instance to use. Defaults to `default_db`
 `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true`, hex-strings will
 be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
 time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false` for other types of your choosing.
@@ -988,12 +817,12 @@ For more information on the format of the connection string please consult the d
 
 *Driver option descriptions*
 
-`host`:: The host the mongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
-`port`:: The port the mongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
-`hosts`:: An array representing the hosts and ports to support a mongoDB cluster (sharding / replication)
+`host`:: The host the MongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
+`port`:: The port the MongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
+`hosts`:: An array representing the hosts and ports to support a MongoDB cluster (sharding / replication)
 `host`:: A host in the cluster
 `port`:: The port a host in the cluster is listening on
-`replicaSet`:: The name of the replica set, if the mongoDB instance is a member of a replica set
+`replicaSet`:: The name of the replica set, if the MongoDB instance is a member of a replica set
 `serverSelectionTimeoutMS`:: The time in milliseconds that the mongo driver will wait to select a server for an operation before raising an error.
 `maxPoolSize`:: The maximum number of connections in the connection pool. The default value is `100`
 `minPoolSize`:: The minimum number of connections in the connection pool. The default value is `0`

--- a/vertx-mongo-client/src/main/asciidoc/java/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/java/index.adoc
@@ -322,13 +322,14 @@ This has the following fields:
 `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
 `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
 
-=== Find in batches
+=== Finding documents in batches
 
 When dealing with large data sets, it is not advised to use the
 `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#find-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[find]` and
 `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.FindOptions-io.vertx.core.Handler-[findWithOptions]` methods.
 In order to avoid inflating the whole response into memory, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findBatch-java.lang.String-io.vertx.core.json.JsonObject-[findBatch]`:
 
+[source,java]
 ----
 JsonObject query = new JsonObject()
   .put("author", "J. R. R. Tolkien");
@@ -339,6 +340,21 @@ mongoClient.findBatch("book", query)
 ----
 
 The matching documents are emitted one by one by the `link:../../apidocs/io/vertx/core/streams/ReadStream.html[ReadStream]` handler.
+
+`link:../../apidocs/io/vertx/ext/mongo/FindOptions.html[FindOptions]` has an extra parameter `batchSize` which you can use to set the number of documents to load at once:
+
+[source,java]
+----
+JsonObject query = new JsonObject()
+  .put("author", "J. R. R. Tolkien");
+FindOptions options = new FindOptions().setBatchSize(100);
+mongoClient.findBatchWithOptions("book", query, options)
+  .exceptionHandler(throwable -> throwable.printStackTrace())
+  .endHandler(v -> System.out.println("End of research"))
+  .handler(doc -> System.out.println("Found doc: " + doc.encodePrettily()));
+----
+
+By default, `batchSize` is set to 20.
 
 === Finding a single document
 
@@ -663,6 +679,7 @@ For more information on the format of the connection string please consult the d
 
 *Specific driver configuration options*
 
+[source,js]
 ----
 {
   // Single Cluster Settings

--- a/vertx-mongo-client/src/main/asciidoc/java/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/java/index.adoc
@@ -105,8 +105,8 @@ The client API is represented by `link:../../apidocs/io/vertx/ext/mongo/MongoCli
 
 To save a document you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#save-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[save]`.
 
-If the document has no `\_id` field, it is inserted, otherwise, it is _upserted_. Upserted means it is inserted
-if it doesn't already exist, otherwise it is updated.
+If the document has no `\_id` field, it is inserted, otherwise, it is __upserted__.
+Upserted means it is inserted if it doesn't already exist, otherwise it is updated.
 
 If the document is inserted and has no id, then the id field generated will be returned to the result handler.
 
@@ -114,19 +114,15 @@ Here's an example of saving a document and getting the id back
 
 [source,java]
 ----
-JsonObject document = new JsonObject().put("title", "The Hobbit");
-
+JsonObject document = new JsonObject()
+  .put("title", "The Hobbit");
 mongoClient.save("books", document, res -> {
-
   if (res.succeeded()) {
-
     String id = res.result();
     System.out.println("Saved book with id " + id);
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 
@@ -134,18 +130,15 @@ And here's an example of saving a document which already has an id.
 
 [source,java]
 ----
-JsonObject document = new JsonObject().put("title", "The Hobbit").put("_id", "123244");
-
+JsonObject document = new JsonObject()
+  .put("title", "The Hobbit")
+  .put("_id", "123244");
 mongoClient.save("books", document, res -> {
-
   if (res.succeeded()) {
-
     // ...
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 
@@ -157,49 +150,42 @@ If the document is inserted and has no id, then the id field generated will be r
 
 [source,java]
 ----
-JsonObject document = new JsonObject().put("title", "The Hobbit");
-
+JsonObject document = new JsonObject()
+  .put("title", "The Hobbit");
 mongoClient.insert("books", document, res -> {
-
   if (res.succeeded()) {
-
     String id = res.result();
     System.out.println("Inserted book with id " + id);
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 
-If a document is inserted with an id, and a document with that id already eists, the insert will fail:
+If a document is inserted with an id, and a document with that id already exists, the insert will fail:
 
 [source,java]
 ----
-JsonObject document = new JsonObject().put("title", "The Hobbit").put("_id", "123244");
-
+JsonObject document = new JsonObject()
+  .put("title", "The Hobbit")
+  .put("_id", "123244");
 mongoClient.insert("books", document, res -> {
-
   if (res.succeeded()) {
-
     //...
-
   } else {
-
     // Will fail if the book with that id already exists.
   }
-
 });
 ----
 
 === Updating documents
 
-To update a documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#update-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[update]`.
+To update a documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#updateCollection-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[updateCollection]`.
 
-This updates one or multiple documents in a collection. The json object that is passed in the `update`
-parameter must contain http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators] and determines
-how the object is updated.
+This updates one or multiple documents in a collection.
+The json object that is passed in the `updateCollection` parameter must contain
+http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators]
+and determines how the object is updated.
 
 The json object specified in the query parameter determines which documents in the collection will be updated.
 
@@ -207,26 +193,22 @@ Here's an example of updating a document in the books collection:
 
 [source,java]
 ----
-JsonObject query = new JsonObject().put("title", "The Hobbit");
-
+JsonObject query = new JsonObject()
+  .put("title", "The Hobbit");
 // Set the author field
-JsonObject update = new JsonObject().put("$set", new JsonObject().put("author", "J. R. R. Tolkien"));
-
-mongoClient.update("books", query, update, res -> {
-
+JsonObject update = new JsonObject().put("$set", new JsonObject()
+  .put("author", "J. R. R. Tolkien"));
+mongoClient.updateCollection("books", query, update, res -> {
   if (res.succeeded()) {
-
     System.out.println("Book updated !");
-
   } else {
-
     res.cause().printStackTrace();
   }
-
 });
 ----
 
-To specify if the update should upsert or update multiple documents, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#updateWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.UpdateOptions-io.vertx.core.Handler-[updateWithOptions]`
+To specify if the update should upsert or update multiple documents, use
+`link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#updateCollectionWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.UpdateOptions-io.vertx.core.Handler-[updateCollectionWithOptions]`
 and pass in an instance of `link:../../apidocs/io/vertx/ext/mongo/UpdateOptions.html[UpdateOptions]`.
 
 This has the following fields:
@@ -237,54 +219,43 @@ This has the following fields:
 
 [source,java]
 ----
-JsonObject query = new JsonObject().put("title", "The Hobbit");
-
+JsonObject query = new JsonObject()
+  .put("title", "The Hobbit");
 // Set the author field
-JsonObject update = new JsonObject().put("$set", new JsonObject().put("author", "J. R. R. Tolkien"));
-
+JsonObject update = new JsonObject().put("$set", new JsonObject()
+  .put("author", "J. R. R. Tolkien"));
 UpdateOptions options = new UpdateOptions().setMulti(true);
-
-mongoClient.updateWithOptions("books", query, update, options, res -> {
-
+mongoClient.updateCollectionWithOptions("books", query, update, options, res -> {
   if (res.succeeded()) {
-
     System.out.println("Book updated !");
-
   } else {
-
     res.cause().printStackTrace();
   }
-
 });
 ----
 
 === Replacing documents
 
-To replace documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#replace-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[replace]`.
+To replace documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#replaceDocuments-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[replaceDocuments]`.
 
-This is similar to the update operation, however it does not take any update operators like `update`.
+This is similar to the update operation, however it does not take any operator.
 Instead it replaces the entire document with the one provided.
 
 Here's an example of replacing a document in the books collection
 
 [source,java]
 ----
-JsonObject query = new JsonObject().put("title", "The Hobbit");
-
-JsonObject replace = new JsonObject().put("title", "The Lord of the Rings").put("author", "J. R. R. Tolkien");
-
-mongoClient.replace("books", query, replace, res -> {
-
+JsonObject query = new JsonObject()
+  .put("title", "The Hobbit");
+JsonObject replace = new JsonObject()
+  .put("title", "The Lord of the Rings")
+  .put("author", "J. R. R. Tolkien");
+mongoClient.replaceDocuments("books", query, replace, res -> {
   if (res.succeeded()) {
-
     System.out.println("Book replaced !");
-
   } else {
-
     res.cause().printStackTrace();
-
   }
-
 });
 ----
 
@@ -292,12 +263,13 @@ mongoClient.replace("books", query, replace, res -> {
 
 To execute multiple insert, update, replace, or delete operations at once, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#bulkWrite-java.lang.String-java.util.List-io.vertx.core.Handler-[bulkWrite]`.
 
-You can pass a list of `link:../../apidocs/io/vertx/ext/mongo/BulkOperation.html[BulkOperations]`, with each working similiar to the matching single operations.
+You can pass a list of `link:../../apidocs/io/vertx/ext/mongo/BulkOperation.html[BulkOperations]`, with each working similar to the matching single operation.
 You can pass as many operations, even of the same type, as you wish.
 
 To specify if the bulk operation should be executed in order, and with what write option, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#bulkWriteWithOptions-java.lang.String-java.util.List-io.vertx.ext.mongo.BulkWriteOptions-io.vertx.core.Handler-[bulkWriteWithOptions]`
 and pass an instance of `link:../../apidocs/io/vertx/ext/mongo/BulkWriteOptions.html[BulkWriteOptions]`.
-For more explanation what ordered means, see https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations
+For more explanation what ordered means, see
+https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations[Execution of Operations].
 
 === Finding documents
 
@@ -310,23 +282,14 @@ Here's a simple example with an empty query that will match all books:
 [source,java]
 ----
 JsonObject query = new JsonObject();
-
 mongoClient.find("books", query, res -> {
-
   if (res.succeeded()) {
-
     for (JsonObject json : res.result()) {
-
       System.out.println(json.encodePrettily());
-
     }
-
   } else {
-
     res.cause().printStackTrace();
-
   }
-
 });
 ----
 
@@ -334,24 +297,16 @@ Here's another example that will match all books by Tolkien:
 
 [source,java]
 ----
-JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
-
+JsonObject query = new JsonObject()
+  .put("author", "J. R. R. Tolkien");
 mongoClient.find("books", query, res -> {
-
   if (res.succeeded()) {
-
     for (JsonObject json : res.result()) {
-
       System.out.println(json.encodePrettily());
-
     }
-
   } else {
-
     res.cause().printStackTrace();
-
   }
-
 });
 ----
 
@@ -367,16 +322,23 @@ This has the following fields:
 `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
 `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
 
-----
-JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
+=== Find in batches
 
+When dealing with large data sets, it is not advised to use the
+`link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#find-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[find]` and
+`link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.FindOptions-io.vertx.core.Handler-[findWithOptions]` methods.
+In order to avoid inflating the whole response into memory, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findBatch-java.lang.String-io.vertx.core.json.JsonObject-[findBatch]`:
+
+----
+JsonObject query = new JsonObject()
+  .put("author", "J. R. R. Tolkien");
 mongoClient.findBatch("book", query)
   .exceptionHandler(throwable -> throwable.printStackTrace())
   .endHandler(v -> System.out.println("End of research"))
   .handler(doc -> System.out.println("Found doc: " + doc.encodePrettily()));
 ----
 
-The matching documents are returned unitary in the result handler.
+The matching documents are emitted one by one by the `link:../../apidocs/io/vertx/core/streams/ReadStream.html[ReadStream]` handler.
 
 === Finding a single document
 
@@ -394,18 +356,13 @@ Here's an example of removing all Tolkien books:
 
 [source,java]
 ----
-JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
-
-mongoClient.remove("books", query, res -> {
-
+JsonObject query = new JsonObject()
+  .put("author", "J. R. R. Tolkien");
+mongoClient.removeDocuments("books", query, res -> {
   if (res.succeeded()) {
-
     System.out.println("Never much liked Tolkien stuff!");
-
   } else {
-
     res.cause().printStackTrace();
-
   }
 });
 ----
@@ -424,18 +381,13 @@ Here's an example that counts the number of Tolkien books. The number is passed 
 
 [source,java]
 ----
-JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
-
+JsonObject query = new JsonObject()
+  .put("author", "J. R. R. Tolkien");
 mongoClient.count("books", query, res -> {
-
   if (res.succeeded()) {
-
     long num = res.result();
-
   } else {
-
     res.cause().printStackTrace();
-
   }
 });
 ----
@@ -449,15 +401,10 @@ To get a list of all collections you can use `link:../../apidocs/io/vertx/ext/mo
 [source,java]
 ----
 mongoClient.getCollections(res -> {
-
   if (res.succeeded()) {
-
     List<String> collections = res.result();
-
   } else {
-
     res.cause().printStackTrace();
-
   }
 });
 ----
@@ -467,15 +414,10 @@ To create a new collection you can use `link:../../apidocs/io/vertx/ext/mongo/Mo
 [source,java]
 ----
 mongoClient.createCollection("mynewcollectionr", res -> {
-
   if (res.succeeded()) {
-
     // Created ok!
-
   } else {
-
     res.cause().printStackTrace();
-
   }
 });
 ----
@@ -487,15 +429,10 @@ NOTE: Dropping a collection will delete all documents within it!
 [source,java]
 ----
 mongoClient.dropCollection("mynewcollectionr", res -> {
-
   if (res.succeeded()) {
-
     // Dropped ok!
-
   } else {
-
     res.cause().printStackTrace();
-
   }
 });
 ----
@@ -505,7 +442,7 @@ mongoClient.dropCollection("mynewcollectionr", res -> {
 
 You can run arbitrary MongoDB commands with `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#runCommand-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[runCommand]`.
 
-Commands can be used to run more advanced mongoDB features, such as using MapReduce.
+Commands can be used to run more advanced MongoDB features, such as using MapReduce.
 For more information see the mongo docs for supported http://docs.mongodb.org/manual/reference/command[Commands].
 
 Here's an example of running an aggregate command. Note that the command name must be specified as a parameter
@@ -518,7 +455,6 @@ of the entries in the JSON is the command name it must be specified as a paramet
 JsonObject command = new JsonObject()
   .put("aggregate", "collection_name")
   .put("pipeline", new JsonArray());
-
 mongoClient.runCommand("aggregate", command, res -> {
   if (res.succeeded()) {
     JsonArray resArr = res.result().getJsonArray("result");
@@ -531,37 +467,31 @@ mongoClient.runCommand("aggregate", command, res -> {
 
 === MongoDB Extended JSON support
 
-For now, only date, oid and binary types are supported (cf http://docs.mongodb.org/manual/reference/mongodb-extended-json )
+For now, only `date`, `oid` and `binary` types are supported
+(see http://docs.mongodb.org/manual/reference/mongodb-extended-json[MongoDB Extended JSON]).
 
-Here's an example of inserting a document with a date field
+Here's an example of inserting a document with a `date` field:
 
 [source,java]
 ----
-JsonObject document = new JsonObject().put("title", "The Hobbit")
+JsonObject document = new JsonObject()
+  .put("title", "The Hobbit")
   //ISO-8601 date
   .put("publicationDate", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00"));
-
 mongoService.save("publishedBooks", document, res -> {
-
   if (res.succeeded()) {
-
     String id = res.result();
-
     mongoService.findOne("publishedBooks", new JsonObject().put("_id", id), null, res2 -> {
       if (res2.succeeded()) {
-
         System.out.println("To retrieve ISO-8601 date : "
-                + res2.result().getJsonObject("publicationDate").getString("$date"));
-
+          + res2.result().getJsonObject("publicationDate").getString("$date"));
       } else {
         res2.cause().printStackTrace();
       }
     });
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 
@@ -570,31 +500,23 @@ Here's an example (in Java) of inserting a document with a binary field and read
 [source,java]
 ----
 byte[] binaryObject = new byte[40];
-
 JsonObject document = new JsonObject()
-        .put("name", "Alan Turing")
-        .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
-
+  .put("name", "Alan Turing")
+  .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
 mongoService.save("smartPeople", document, res -> {
-
   if (res.succeeded()) {
-
     String id = res.result();
-
     mongoService.findOne("smartPeople", new JsonObject().put("_id", id), null, res2 -> {
-      if(res2.succeeded()) {
-
+      if (res2.succeeded()) {
         byte[] reconstitutedBinaryObject = res2.result().getJsonObject("binaryStuff").getBinary("$binary");
         //This could now be de-serialized into an object in real life
       } else {
         res2.cause().printStackTrace();
       }
     });
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 
@@ -603,31 +525,23 @@ Here's an example of inserting a base 64 encoded string, typing it as binary a b
 [source,java]
 ----
 String base64EncodedString = "a2FpbHVhIGlzIHRoZSAjMSBiZWFjaCBpbiB0aGUgd29ybGQ=";
-
 JsonObject document = new JsonObject()
-        .put("name", "Alan Turing")
-        .put("binaryStuff", new JsonObject().put("$binary", base64EncodedString));
-
+  .put("name", "Alan Turing")
+  .put("binaryStuff", new JsonObject().put("$binary", base64EncodedString));
 mongoService.save("smartPeople", document, res -> {
-
   if (res.succeeded()) {
-
     String id = res.result();
-
     mongoService.findOne("smartPeople", new JsonObject().put("_id", id), null, res2 -> {
-      if(res2.succeeded()) {
-
+      if (res2.succeeded()) {
         String reconstitutedBase64EncodedString = res2.result().getJsonObject("binaryStuff").getString("$binary");
         //This could now converted back to bytes from the base 64 string
       } else {
         res2.cause().printStackTrace();
       }
     });
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 Here's an example of inserting an object ID and reading it back
@@ -635,108 +549,93 @@ Here's an example of inserting an object ID and reading it back
 [source,java]
 ----
 String individualId = new ObjectId().toHexString();
-
 JsonObject document = new JsonObject()
-        .put("name", "Stephen Hawking")
-        .put("individualId", new JsonObject().put("$oid", individualId));
-
+  .put("name", "Stephen Hawking")
+  .put("individualId", new JsonObject().put("$oid", individualId));
 mongoService.save("smartPeople", document, res -> {
-
   if (res.succeeded()) {
-
     String id = res.result();
-
-    mongoService.findOne("smartPeople", new JsonObject().put("_id", id), null, res2 -> {
-      if(res2.succeeded()) {
-        String reconstitutedIndividualId = res2.result().getJsonObject("individualId").getString("$oid");
+    JsonObject query = new JsonObject().put("_id", id);
+    mongoService.findOne("smartPeople", query, null, res2 -> {
+      if (res2.succeeded()) {
+        String reconstitutedIndividualId = res2.result()
+          .getJsonObject("individualId").getString("$oid");
       } else {
         res2.cause().printStackTrace();
       }
     });
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
+
+=== Getting distinct values
+
 Here's an example of getting distinct value
 
 [source,java]
 ----
-JsonObject document = new JsonObject().put("title", "The Hobbit");
-
+JsonObject document = new JsonObject()
+  .put("title", "The Hobbit");
 mongoClient.save("books", document, res -> {
-
   if (res.succeeded()) {
-
     mongoClient.distinct("books", "title", String.class.getName(), res2 -> {
       System.out.println("Title is : " + res2.result().getJsonArray(0));
     });
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 Here's an example of getting distinct value in batch mode
 
 [source,java]
 ----
-JsonObject document = new JsonObject().put("title", "The Hobbit");
-
+JsonObject document = new JsonObject()
+  .put("title", "The Hobbit");
 mongoClient.save("books", document, res -> {
-
   if (res.succeeded()) {
-
     mongoClient.distinctBatch("books", "title", String.class.getName())
       .handler(book -> System.out.println("Title is : " + book.getString("title")));
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 * Here's an example of getting distinct value with query
 
 [source,java]
 ----
-JsonObject document = new JsonObject().put("title", "The Hobbit")
-        .put("publicationDate", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00"));
+JsonObject document = new JsonObject()
+  .put("title", "The Hobbit")
+  .put("publicationDate", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00"));
 JsonObject query = new JsonObject()
-        .put("publicationDate",
-                new JsonObject().put("$gte", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00")));
-
+  .put("publicationDate",
+    new JsonObject().put("$gte", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00")));
 mongoClient.save("books", document, res -> {
   if (res.succeeded()) {
-
     mongoClient.distinctWithQuery("books", "title", String.class.getName(), query, res2 -> {
       System.out.println("Title is : " + res2.result().getJsonArray(0));
     });
   }
-
 });
 ----
 Here's an example of getting distinct value in batch mode with query
 
 [source,java]
 ----
-JsonObject document = new JsonObject().put("title", "The Hobbit")
-        .put("publicationDate", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00"));
+JsonObject document = new JsonObject()
+  .put("title", "The Hobbit")
+  .put("publicationDate", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00"));
 JsonObject query = new JsonObject()
-        .put("publicationDate",
-                new JsonObject().put("$gte", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00")));
-
+  .put("publicationDate", new JsonObject()
+    .put("$gte", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00")));
 mongoClient.save("books", document, res -> {
   if (res.succeeded()) {
-
     mongoClient.distinctBatchWithQuery("books", "title", String.class.getName(), query)
       .handler(book -> System.out.println("Title is : " + book.getString("title")));
-
   }
-
 });
 ----
 
@@ -747,7 +646,7 @@ The client is configured with a json object.
 The following configuration is supported by the mongo client:
 
 
-`db_name`:: Name of the database in the mongoDB instance to use. Defaults to `default_db`
+`db_name`:: Name of the database in the MongoDB instance to use. Defaults to `default_db`
 `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true`, hex-strings will
 be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
 time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false` for other types of your choosing.
@@ -827,12 +726,12 @@ For more information on the format of the connection string please consult the d
 
 *Driver option descriptions*
 
-`host`:: The host the mongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
-`port`:: The port the mongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
-`hosts`:: An array representing the hosts and ports to support a mongoDB cluster (sharding / replication)
+`host`:: The host the MongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
+`port`:: The port the MongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
+`hosts`:: An array representing the hosts and ports to support a MongoDB cluster (sharding / replication)
 `host`:: A host in the cluster
 `port`:: The port a host in the cluster is listening on
-`replicaSet`:: The name of the replica set, if the mongoDB instance is a member of a replica set
+`replicaSet`:: The name of the replica set, if the MongoDB instance is a member of a replica set
 `serverSelectionTimeoutMS`:: The time in milliseconds that the mongo driver will wait to select a server for an operation before raising an error.
 `maxPoolSize`:: The maximum number of connections in the connection pool. The default value is `100`
 `minPoolSize`:: The minimum number of connections in the connection pool. The default value is `0`

--- a/vertx-mongo-client/src/main/asciidoc/java/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/java/index.adoc
@@ -370,26 +370,10 @@ This has the following fields:
 ----
 JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
 
-mongoClient.findBatch("book", query, res -> {
-
-  if (res.succeeded()) {
-
-    if (res.result() == null) {
-
-      System.out.println("End of research");
-
-    } else {
-
-      System.out.println("Found doc: " + res.result().encodePrettily());
-
-    }
-
-  } else {
-
-    res.cause().printStackTrace();
-
-  }
-});
+mongoClient.findBatch("book", query)
+  .exceptionHandler(throwable -> throwable.printStackTrace())
+  .endHandler(v -> System.out.println("End of research"))
+  .handler(doc -> System.out.println("Found doc: " + doc.encodePrettily()));
 ----
 
 The matching documents are returned unitary in the result handler.
@@ -706,9 +690,8 @@ mongoClient.save("books", document, res -> {
 
   if (res.succeeded()) {
 
-    mongoClient.distinctBatch("books", "title", String.class.getName(), res2 -> {
-      System.out.println("Title is : " + res2.result().getString("title"));
-    });
+    mongoClient.distinctBatch("books", "title", String.class.getName())
+      .handler(book -> System.out.println("Title is : " + book.getString("title")));
 
   } else {
     res.cause().printStackTrace();
@@ -749,9 +732,9 @@ JsonObject query = new JsonObject()
 mongoClient.save("books", document, res -> {
   if (res.succeeded()) {
 
-    mongoClient.distinctBatchWithQuery("books", "title", String.class.getName(), query, res2 -> {
-      System.out.println("Title is : " + res2.result().getString("title"));
-    });
+    mongoClient.distinctBatchWithQuery("books", "title", String.class.getName(), query)
+      .handler(book -> System.out.println("Title is : " + book.getString("title")));
+
   }
 
 });

--- a/vertx-mongo-client/src/main/asciidoc/js/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/js/index.adoc
@@ -457,27 +457,13 @@ var query = {
   "author" : "J. R. R. Tolkien"
 };
 
-mongoClient.findBatch("book", query, function (res, res_err) {
-
-  if (res_err == null) {
-
-    if ((res === null || res === undefined)) {
-
-      console.log("End of research");
-
-    } else {
-
-      console.log("Found doc: " + JSON.stringify(res));
-
-    }
-
-  } else {
-
-    res_err.printStackTrace();
-
-  }
+mongoClient.findBatch("book", query).exceptionHandler(function (throwable) {
+  throwable.printStackTrace();
+}).endHandler(function (v) {
+  console.log("End of research");
+}).handler(function (doc) {
+  console.log("Found doc: " + JSON.stringify(doc));
 });
-
 
 ----
 
@@ -848,8 +834,8 @@ mongoClient.save("books", document, function (res, res_err) {
 
   if (res_err == null) {
 
-    mongoClient.distinctBatch("books", "title", Java.type("java.lang.String").class.getName(), function (res2, res2_err) {
-      console.log("Title is : " + res2.title);
+    mongoClient.distinctBatch("books", "title", Java.type("java.lang.String").class.getName()).handler(function (book) {
+      console.log("Title is : " + book.title);
     });
 
   } else {
@@ -909,9 +895,10 @@ var query = {
 mongoClient.save("books", document, function (res, res_err) {
   if (res_err == null) {
 
-    mongoClient.distinctBatchWithQuery("books", "title", Java.type("java.lang.String").class.getName(), query, function (res2, res2_err) {
-      console.log("Title is : " + res2.title);
+    mongoClient.distinctBatchWithQuery("books", "title", Java.type("java.lang.String").class.getName(), query).handler(function (book) {
+      console.log("Title is : " + book.title);
     });
+
   }
 
 });

--- a/vertx-mongo-client/src/main/asciidoc/js/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/js/index.adoc
@@ -54,9 +54,7 @@ The simplest way to do this is as follows:
 [source,js]
 ----
 var MongoClient = require("vertx-mongo-js/mongo_client");
-
 var client = MongoClient.createShared(vertx, config);
-
 
 ----
 
@@ -72,9 +70,7 @@ You can create a client specifying a pool source name as follows
 [source,js]
 ----
 var MongoClient = require("vertx-mongo-js/mongo_client");
-
 var client = MongoClient.createShared(vertx, config, "MyPoolName");
-
 
 ----
 
@@ -99,9 +95,7 @@ In that case you can use `link:../../jsdoc/module-vertx-mongo-js_mongo_client-Mo
 [source,js]
 ----
 var MongoClient = require("vertx-mongo-js/mongo_client");
-
 var client = MongoClient.createNonShared(vertx, config);
-
 
 ----
 
@@ -117,8 +111,8 @@ The client API is represented by `link:../../jsdoc/module-vertx-mongo-js_mongo_c
 
 To save a document you use `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#save[save]`.
 
-If the document has no `\_id` field, it is inserted, otherwise, it is _upserted_. Upserted means it is inserted
-if it doesn't already exist, otherwise it is updated.
+If the document has no `\_id` field, it is inserted, otherwise, it is __upserted__.
+Upserted means it is inserted if it doesn't already exist, otherwise it is updated.
 
 If the document is inserted and has no id, then the id field generated will be returned to the result handler.
 
@@ -126,26 +120,18 @@ Here's an example of saving a document and getting the id back
 
 [source,js]
 ----
-
 // Document has no id
-
 var document = {
   "title" : "The Hobbit"
 };
-
 mongoClient.save("books", document, function (res, res_err) {
-
   if (res_err == null) {
-
     var id = res;
     console.log("Saved book with id " + id);
-
   } else {
     res_err.printStackTrace();
   }
-
 });
-
 
 ----
 
@@ -153,26 +139,18 @@ And here's an example of saving a document which already has an id.
 
 [source,js]
 ----
-
 // Document has an id already
-
 var document = {
   "title" : "The Hobbit",
   "_id" : "123244"
 };
-
 mongoClient.save("books", document, function (res, res_err) {
-
   if (res_err == null) {
-
     // ...
-
   } else {
     res_err.printStackTrace();
   }
-
 });
-
 
 ----
 
@@ -184,64 +162,48 @@ If the document is inserted and has no id, then the id field generated will be r
 
 [source,js]
 ----
-
 // Document has an id already
-
 var document = {
   "title" : "The Hobbit"
 };
-
 mongoClient.insert("books", document, function (res, res_err) {
-
   if (res_err == null) {
-
     var id = res;
     console.log("Inserted book with id " + id);
-
   } else {
     res_err.printStackTrace();
   }
-
 });
-
 
 ----
 
-If a document is inserted with an id, and a document with that id already eists, the insert will fail:
+If a document is inserted with an id, and a document with that id already exists, the insert will fail:
 
 [source,js]
 ----
-
 // Document has an id already
-
 var document = {
   "title" : "The Hobbit",
   "_id" : "123244"
 };
-
 mongoClient.insert("books", document, function (res, res_err) {
-
   if (res_err == null) {
-
     //...
-
   } else {
-
     // Will fail if the book with that id already exists.
   }
-
 });
-
 
 ----
 
 === Updating documents
 
-To update a documents you use `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#update[update]`.
+To update a documents you use `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#updateCollection[updateCollection]`.
 
-This updates one or multiple documents in a collection. The json object that is passed in the `update`
-parameter must contain http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators] and determines
-how the object is updated.
+This updates one or multiple documents in a collection.
+The json object that is passed in the `updateCollection` parameter must contain
+http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators]
+and determines how the object is updated.
 
 The json object specified in the query parameter determines which documents in the collection will be updated.
 
@@ -249,36 +211,28 @@ Here's an example of updating a document in the books collection:
 
 [source,js]
 ----
-
 // Match any documents with title=The Hobbit
 var query = {
   "title" : "The Hobbit"
 };
-
 // Set the author field
 var update = {
   "$set" : {
     "author" : "J. R. R. Tolkien"
   }
 };
-
-mongoClient.update("books", query, update, function (res, res_err) {
-
+mongoClient.updateCollection("books", query, update, function (res, res_err) {
   if (res_err == null) {
-
     console.log("Book updated !");
-
   } else {
-
     res_err.printStackTrace();
   }
-
 });
-
 
 ----
 
-To specify if the update should upsert or update multiple documents, use `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#updateWithOptions[updateWithOptions]`
+To specify if the update should upsert or update multiple documents, use
+`link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#updateCollectionWithOptions[updateCollectionWithOptions]`
 and pass in an instance of `link:../dataobjects.html#UpdateOptions[UpdateOptions]`.
 
 This has the following fields:
@@ -289,74 +243,54 @@ This has the following fields:
 
 [source,js]
 ----
-
 // Match any documents with title=The Hobbit
 var query = {
   "title" : "The Hobbit"
 };
-
 // Set the author field
 var update = {
   "$set" : {
     "author" : "J. R. R. Tolkien"
   }
 };
-
 var options = {
   "multi" : true
 };
-
-mongoClient.updateWithOptions("books", query, update, options, function (res, res_err) {
-
+mongoClient.updateCollectionWithOptions("books", query, update, options, function (res, res_err) {
   if (res_err == null) {
-
     console.log("Book updated !");
-
   } else {
-
     res_err.printStackTrace();
   }
-
 });
-
 
 ----
 
 === Replacing documents
 
-To replace documents you use `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#replace[replace]`.
+To replace documents you use `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#replaceDocuments[replaceDocuments]`.
 
-This is similar to the update operation, however it does not take any update operators like `update`.
+This is similar to the update operation, however it does not take any operator.
 Instead it replaces the entire document with the one provided.
 
 Here's an example of replacing a document in the books collection
 
 [source,js]
 ----
-
 var query = {
   "title" : "The Hobbit"
 };
-
 var replace = {
   "title" : "The Lord of the Rings",
   "author" : "J. R. R. Tolkien"
 };
-
-mongoClient.replace("books", query, replace, function (res, res_err) {
-
+mongoClient.replaceDocuments("books", query, replace, function (res, res_err) {
   if (res_err == null) {
-
     console.log("Book replaced !");
-
   } else {
-
     res_err.printStackTrace();
-
   }
-
 });
-
 
 ----
 
@@ -364,12 +298,13 @@ mongoClient.replace("books", query, replace, function (res, res_err) {
 
 To execute multiple insert, update, replace, or delete operations at once, use `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#bulkWrite[bulkWrite]`.
 
-You can pass a list of `link:../dataobjects.html#BulkOperation[BulkOperations]`, with each working similiar to the matching single operations.
+You can pass a list of `link:../dataobjects.html#BulkOperation[BulkOperations]`, with each working similar to the matching single operation.
 You can pass as many operations, even of the same type, as you wish.
 
 To specify if the bulk operation should be executed in order, and with what write option, use `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#bulkWriteWithOptions[bulkWriteWithOptions]`
 and pass an instance of `link:../dataobjects.html#BulkWriteOptions[BulkWriteOptions]`.
-For more explanation what ordered means, see https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations
+For more explanation what ordered means, see
+https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations[Execution of Operations].
 
 === Finding documents
 
@@ -381,29 +316,18 @@ Here's a simple example with an empty query that will match all books:
 
 [source,js]
 ----
-
 // empty query = match any
 var query = {
 };
-
 mongoClient.find("books", query, function (res, res_err) {
-
   if (res_err == null) {
-
     Array.prototype.forEach.call(res, function(json) {
-
       console.log(JSON.stringify(json));
-
     });
-
   } else {
-
     res_err.printStackTrace();
-
   }
-
 });
-
 
 ----
 
@@ -411,30 +335,19 @@ Here's another example that will match all books by Tolkien:
 
 [source,js]
 ----
-
 // will match all Tolkien books
 var query = {
   "author" : "J. R. R. Tolkien"
 };
-
 mongoClient.find("books", query, function (res, res_err) {
-
   if (res_err == null) {
-
     Array.prototype.forEach.call(res, function(json) {
-
       console.log(JSON.stringify(json));
-
     });
-
   } else {
-
     res_err.printStackTrace();
-
   }
-
 });
-
 
 ----
 
@@ -450,13 +363,18 @@ This has the following fields:
 `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
 `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
 
-----
+=== Find in batches
 
+When dealing with large data sets, it is not advised to use the
+`link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#find[find]` and
+`link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#findWithOptions[findWithOptions]` methods.
+In order to avoid inflating the whole response into memory, use `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#findBatch[findBatch]`:
+
+----
 // will match all Tolkien books
 var query = {
   "author" : "J. R. R. Tolkien"
 };
-
 mongoClient.findBatch("book", query).exceptionHandler(function (throwable) {
   throwable.printStackTrace();
 }).endHandler(function (v) {
@@ -467,7 +385,7 @@ mongoClient.findBatch("book", query).exceptionHandler(function (throwable) {
 
 ----
 
-The matching documents are returned unitary in the result handler.
+The matching documents are emitted one by one by the `link:../../jsdoc/module-vertx-js_read_stream-ReadStream.html[ReadStream]` handler.
 
 === Finding a single document
 
@@ -485,24 +403,16 @@ Here's an example of removing all Tolkien books:
 
 [source,js]
 ----
-
 var query = {
   "author" : "J. R. R. Tolkien"
 };
-
-mongoClient.remove("books", query, function (res, res_err) {
-
+mongoClient.removeDocuments("books", query, function (res, res_err) {
   if (res_err == null) {
-
     console.log("Never much liked Tolkien stuff!");
-
   } else {
-
     res_err.printStackTrace();
-
   }
 });
-
 
 ----
 
@@ -520,24 +430,16 @@ Here's an example that counts the number of Tolkien books. The number is passed 
 
 [source,js]
 ----
-
 var query = {
   "author" : "J. R. R. Tolkien"
 };
-
 mongoClient.count("books", query, function (res, res_err) {
-
   if (res_err == null) {
-
     var num = res;
-
   } else {
-
     res_err.printStackTrace();
-
   }
 });
-
 
 ----
 
@@ -549,20 +451,13 @@ To get a list of all collections you can use `link:../../jsdoc/module-vertx-mong
 
 [source,js]
 ----
-
 mongoClient.getCollections(function (res, res_err) {
-
   if (res_err == null) {
-
     var collections = res;
-
   } else {
-
     res_err.printStackTrace();
-
   }
 });
-
 
 ----
 
@@ -570,20 +465,13 @@ To create a new collection you can use `link:../../jsdoc/module-vertx-mongo-js_m
 
 [source,js]
 ----
-
 mongoClient.createCollection("mynewcollectionr", function (res, res_err) {
-
   if (res_err == null) {
-
     // Created ok!
-
   } else {
-
     res_err.printStackTrace();
-
   }
 });
-
 
 ----
 
@@ -593,20 +481,13 @@ NOTE: Dropping a collection will delete all documents within it!
 
 [source,js]
 ----
-
 mongoClient.dropCollection("mynewcollectionr", function (res, res_err) {
-
   if (res_err == null) {
-
     // Dropped ok!
-
   } else {
-
     res_err.printStackTrace();
-
   }
 });
-
 
 ----
 
@@ -615,7 +496,7 @@ mongoClient.dropCollection("mynewcollectionr", function (res, res_err) {
 
 You can run arbitrary MongoDB commands with `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#runCommand[runCommand]`.
 
-Commands can be used to run more advanced mongoDB features, such as using MapReduce.
+Commands can be used to run more advanced MongoDB features, such as using MapReduce.
 For more information see the mongo docs for supported http://docs.mongodb.org/manual/reference/command[Commands].
 
 Here's an example of running an aggregate command. Note that the command name must be specified as a parameter
@@ -625,13 +506,11 @@ of the entries in the JSON is the command name it must be specified as a paramet
 
 [source,js]
 ----
-
 var command = {
   "aggregate" : "collection_name",
   "pipeline" : [
   ]
 };
-
 mongoClient.runCommand("aggregate", command, function (res, res_err) {
   if (res_err == null) {
     var resArr = res.result;
@@ -641,49 +520,39 @@ mongoClient.runCommand("aggregate", command, function (res, res_err) {
   }
 });
 
-
 ----
 
 === MongoDB Extended JSON support
 
-For now, only date, oid and binary types are supported (cf http://docs.mongodb.org/manual/reference/mongodb-extended-json )
+For now, only `date`, `oid` and `binary` types are supported
+(see http://docs.mongodb.org/manual/reference/mongodb-extended-json[MongoDB Extended JSON]).
 
-Here's an example of inserting a document with a date field
+Here's an example of inserting a document with a `date` field:
 
 [source,js]
 ----
-
 var document = {
   "title" : "The Hobbit",
   "publicationDate" : {
     "$date" : "1937-09-21T00:00:00+00:00"
   }
 };
-
 mongoService.save("publishedBooks", document, function (res, res_err) {
-
   if (res_err == null) {
-
     var id = res;
-
     mongoService.findOne("publishedBooks", {
       "_id" : id
     }, null, function (res2, res2_err) {
       if (res2_err == null) {
-
         console.log("To retrieve ISO-8601 date : " + res2.publicationDate.$date);
-
       } else {
         res2_err.printStackTrace();
       }
     });
-
   } else {
     res_err.printStackTrace();
   }
-
 });
-
 
 ----
 
@@ -692,31 +561,23 @@ Here's an example (in Java) of inserting a document with a binary field and read
 [source,js]
 ----
 byte[] binaryObject = new byte[40];
-
 JsonObject document = new JsonObject()
-        .put("name", "Alan Turing")
-        .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
-
+  .put("name", "Alan Turing")
+  .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
 mongoService.save("smartPeople", document, res -> {
-
   if (res.succeeded()) {
-
     String id = res.result();
-
     mongoService.findOne("smartPeople", new JsonObject().put("_id", id), null, res2 -> {
-      if(res2.succeeded()) {
-
+      if (res2.succeeded()) {
         byte[] reconstitutedBinaryObject = res2.result().getJsonObject("binaryStuff").getBinary("$binary");
         //This could now be de-serialized into an object in real life
       } else {
         res2.cause().printStackTrace();
       }
     });
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 
@@ -724,81 +585,66 @@ Here's an example of inserting a base 64 encoded string, typing it as binary a b
 
 [source,js]
 ----
-
 //This could be a the byte contents of a pdf file, etc converted to base 64
 var base64EncodedString = "a2FpbHVhIGlzIHRoZSAjMSBiZWFjaCBpbiB0aGUgd29ybGQ=";
-
 var document = {
   "name" : "Alan Turing",
   "binaryStuff" : {
     "$binary" : base64EncodedString
   }
 };
-
 mongoService.save("smartPeople", document, function (res, res_err) {
-
   if (res_err == null) {
-
     var id = res;
-
     mongoService.findOne("smartPeople", {
       "_id" : id
     }, null, function (res2, res2_err) {
       if (res2_err == null) {
-
         var reconstitutedBase64EncodedString = res2.binaryStuff.$binary;
         //This could now converted back to bytes from the base 64 string
       } else {
         res2_err.printStackTrace();
       }
     });
-
   } else {
     res_err.printStackTrace();
   }
-
 });
-
 
 ----
 Here's an example of inserting an object ID and reading it back
 
 [source,js]
 ----
-
 var individualId = new (Java.type("org.bson.types.ObjectId"))().toHexString();
-
 var document = {
   "name" : "Stephen Hawking",
   "individualId" : {
     "$oid" : individualId
   }
 };
-
 mongoService.save("smartPeople", document, function (res, res_err) {
-
   if (res_err == null) {
-
     var id = res;
-
-    mongoService.findOne("smartPeople", {
+    var query = {
       "_id" : id
-    }, null, function (res2, res2_err) {
+    };
+    mongoService.findOne("smartPeople", query, null, function (res2, res2_err) {
       if (res2_err == null) {
         var reconstitutedIndividualId = res2.individualId.$oid;
       } else {
         res2_err.printStackTrace();
       }
     });
-
   } else {
     res_err.printStackTrace();
   }
-
 });
 
-
 ----
+
+=== Getting distinct values
+
 Here's an example of getting distinct value
 
 [source,js]
@@ -806,19 +652,14 @@ Here's an example of getting distinct value
 var document = {
   "title" : "The Hobbit"
 };
-
 mongoClient.save("books", document, function (res, res_err) {
-
   if (res_err == null) {
-
     mongoClient.distinct("books", "title", Java.type("java.lang.String").class.getName(), function (res2, res2_err) {
       console.log("Title is : " + res2[0]);
     });
-
   } else {
     res_err.printStackTrace();
   }
-
 });
 
 ----
@@ -829,19 +670,14 @@ Here's an example of getting distinct value in batch mode
 var document = {
   "title" : "The Hobbit"
 };
-
 mongoClient.save("books", document, function (res, res_err) {
-
   if (res_err == null) {
-
     mongoClient.distinctBatch("books", "title", Java.type("java.lang.String").class.getName()).handler(function (book) {
       console.log("Title is : " + book.title);
     });
-
   } else {
     res_err.printStackTrace();
   }
-
 });
 
 ----
@@ -862,15 +698,12 @@ var query = {
     }
   }
 };
-
 mongoClient.save("books", document, function (res, res_err) {
   if (res_err == null) {
-
     mongoClient.distinctWithQuery("books", "title", Java.type("java.lang.String").class.getName(), query, function (res2, res2_err) {
       console.log("Title is : " + res2[0]);
     });
   }
-
 });
 
 ----
@@ -891,16 +724,12 @@ var query = {
     }
   }
 };
-
 mongoClient.save("books", document, function (res, res_err) {
   if (res_err == null) {
-
     mongoClient.distinctBatchWithQuery("books", "title", Java.type("java.lang.String").class.getName(), query).handler(function (book) {
       console.log("Title is : " + book.title);
     });
-
   }
-
 });
 
 ----
@@ -912,7 +741,7 @@ The client is configured with a json object.
 The following configuration is supported by the mongo client:
 
 
-`db_name`:: Name of the database in the mongoDB instance to use. Defaults to `default_db`
+`db_name`:: Name of the database in the MongoDB instance to use. Defaults to `default_db`
 `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true`, hex-strings will
 be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
 time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false` for other types of your choosing.
@@ -992,12 +821,12 @@ For more information on the format of the connection string please consult the d
 
 *Driver option descriptions*
 
-`host`:: The host the mongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
-`port`:: The port the mongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
-`hosts`:: An array representing the hosts and ports to support a mongoDB cluster (sharding / replication)
+`host`:: The host the MongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
+`port`:: The port the MongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
+`hosts`:: An array representing the hosts and ports to support a MongoDB cluster (sharding / replication)
 `host`:: A host in the cluster
 `port`:: The port a host in the cluster is listening on
-`replicaSet`:: The name of the replica set, if the mongoDB instance is a member of a replica set
+`replicaSet`:: The name of the replica set, if the MongoDB instance is a member of a replica set
 `serverSelectionTimeoutMS`:: The time in milliseconds that the mongo driver will wait to select a server for an operation before raising an error.
 `maxPoolSize`:: The maximum number of connections in the connection pool. The default value is `100`
 `minPoolSize`:: The minimum number of connections in the connection pool. The default value is `0`

--- a/vertx-mongo-client/src/main/asciidoc/js/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/js/index.adoc
@@ -363,13 +363,14 @@ This has the following fields:
 `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
 `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
 
-=== Find in batches
+=== Finding documents in batches
 
 When dealing with large data sets, it is not advised to use the
 `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#find[find]` and
 `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#findWithOptions[findWithOptions]` methods.
 In order to avoid inflating the whole response into memory, use `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html#findBatch[findBatch]`:
 
+[source,js]
 ----
 // will match all Tolkien books
 var query = {
@@ -386,6 +387,29 @@ mongoClient.findBatch("book", query).exceptionHandler(function (throwable) {
 ----
 
 The matching documents are emitted one by one by the `link:../../jsdoc/module-vertx-js_read_stream-ReadStream.html[ReadStream]` handler.
+
+`link:../dataobjects.html#FindOptions[FindOptions]` has an extra parameter `batchSize` which you can use to set the number of documents to load at once:
+
+[source,js]
+----
+// will match all Tolkien books
+var query = {
+  "author" : "J. R. R. Tolkien"
+};
+var options = {
+  "batchSize" : 100
+};
+mongoClient.findBatchWithOptions("book", query, options).exceptionHandler(function (throwable) {
+  throwable.printStackTrace();
+}).endHandler(function (v) {
+  console.log("End of research");
+}).handler(function (doc) {
+  console.log("Found doc: " + JSON.stringify(doc));
+});
+
+----
+
+By default, `batchSize` is set to 20.
 
 === Finding a single document
 
@@ -758,6 +782,7 @@ For more information on the format of the connection string please consult the d
 
 *Specific driver configuration options*
 
+[source,js]
 ----
 {
   // Single Cluster Settings

--- a/vertx-mongo-client/src/main/asciidoc/kotlin/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/kotlin/index.adoc
@@ -456,27 +456,13 @@ var query = json {
   obj("author" to "J. R. R. Tolkien")
 }
 
-mongoClient.findBatch("book", query, { res ->
-
-  if (res.succeeded()) {
-
-    if (res.result() == null) {
-
-      println("End of research")
-
-    } else {
-
-      println("Found doc: ${res.result().toString()}")
-
-    }
-
-  } else {
-
-    res.cause().printStackTrace()
-
-  }
+mongoClient.findBatch("book", query).exceptionHandler({ throwable ->
+  throwable.printStackTrace()
+}).endHandler({ v ->
+  println("End of research")
+}).handler({ doc ->
+  println("Found doc: ${doc.toString()}")
 })
-
 
 ----
 
@@ -848,8 +834,8 @@ mongoClient.save("books", document, { res ->
 
   if (res.succeeded()) {
 
-    mongoClient.distinctBatch("books", "title", String.`class`.getName(), { res2 ->
-      println("Title is : ${res2.result().getString("title")}")
+    mongoClient.distinctBatch("books", "title", String.`class`.getName()).handler({ book ->
+      println("Title is : ${book.getString("title")}")
     })
 
   } else {
@@ -901,9 +887,10 @@ var query = json {
 mongoClient.save("books", document, { res ->
   if (res.succeeded()) {
 
-    mongoClient.distinctBatchWithQuery("books", "title", String.`class`.getName(), query, { res2 ->
-      println("Title is : ${res2.result().getString("title")}")
+    mongoClient.distinctBatchWithQuery("books", "title", String.`class`.getName(), query).handler({ book ->
+      println("Title is : ${book.getString("title")}")
     })
+
   }
 
 })

--- a/vertx-mongo-client/src/main/asciidoc/kotlin/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/kotlin/index.adoc
@@ -362,13 +362,14 @@ This has the following fields:
 `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
 `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
 
-=== Find in batches
+=== Finding documents in batches
 
 When dealing with large data sets, it is not advised to use the
 `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#find-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[find]` and
 `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.FindOptions-io.vertx.core.Handler-[findWithOptions]` methods.
 In order to avoid inflating the whole response into memory, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findBatch-java.lang.String-io.vertx.core.json.JsonObject-[findBatch]`:
 
+[source,kotlin]
 ----
 // will match all Tolkien books
 var query = json {
@@ -385,6 +386,28 @@ mongoClient.findBatch("book", query).exceptionHandler({ throwable ->
 ----
 
 The matching documents are emitted one by one by the `link:../../apidocs/io/vertx/core/streams/ReadStream.html[ReadStream]` handler.
+
+`link:../../apidocs/io/vertx/ext/mongo/FindOptions.html[FindOptions]` has an extra parameter `batchSize` which you can use to set the number of documents to load at once:
+
+[source,kotlin]
+----
+// will match all Tolkien books
+var query = json {
+  obj("author" to "J. R. R. Tolkien")
+}
+var options = FindOptions(
+  batchSize = 100)
+mongoClient.findBatchWithOptions("book", query, options).exceptionHandler({ throwable ->
+  throwable.printStackTrace()
+}).endHandler({ v ->
+  println("End of research")
+}).handler({ doc ->
+  println("Found doc: ${doc.toString()}")
+})
+
+----
+
+By default, `batchSize` is set to 20.
 
 === Finding a single document
 
@@ -750,6 +773,7 @@ For more information on the format of the connection string please consult the d
 
 *Specific driver configuration options*
 
+[source,js]
 ----
 {
   // Single Cluster Settings

--- a/vertx-mongo-client/src/main/asciidoc/kotlin/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/kotlin/index.adoc
@@ -53,9 +53,7 @@ The simplest way to do this is as follows:
 
 [source,kotlin]
 ----
-
 var client = MongoClient.createShared(vertx, config)
-
 
 ----
 
@@ -70,9 +68,7 @@ You can create a client specifying a pool source name as follows
 
 [source,kotlin]
 ----
-
 var client = MongoClient.createShared(vertx, config, "MyPoolName")
-
 
 ----
 
@@ -96,9 +92,7 @@ In that case you can use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html
 
 [source,kotlin]
 ----
-
 var client = MongoClient.createNonShared(vertx, config)
-
 
 ----
 
@@ -114,8 +108,8 @@ The client API is represented by `link:../../apidocs/io/vertx/ext/mongo/MongoCli
 
 To save a document you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#save-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[save]`.
 
-If the document has no `\_id` field, it is inserted, otherwise, it is _upserted_. Upserted means it is inserted
-if it doesn't already exist, otherwise it is updated.
+If the document has no `\_id` field, it is inserted, otherwise, it is __upserted__.
+Upserted means it is inserted if it doesn't already exist, otherwise it is updated.
 
 If the document is inserted and has no id, then the id field generated will be returned to the result handler.
 
@@ -123,26 +117,18 @@ Here's an example of saving a document and getting the id back
 
 [source,kotlin]
 ----
-
 // Document has no id
-
 var document = json {
   obj("title" to "The Hobbit")
 }
-
 mongoClient.save("books", document, { res ->
-
   if (res.succeeded()) {
-
     var id = res.result()
     println("Saved book with id ${id}")
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
@@ -150,28 +136,20 @@ And here's an example of saving a document which already has an id.
 
 [source,kotlin]
 ----
-
 // Document has an id already
-
 var document = json {
   obj(
     "title" to "The Hobbit",
     "_id" to "123244"
   )
 }
-
 mongoClient.save("books", document, { res ->
-
   if (res.succeeded()) {
-
     // ...
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
@@ -183,66 +161,50 @@ If the document is inserted and has no id, then the id field generated will be r
 
 [source,kotlin]
 ----
-
 // Document has an id already
-
 var document = json {
   obj("title" to "The Hobbit")
 }
-
 mongoClient.insert("books", document, { res ->
-
   if (res.succeeded()) {
-
     var id = res.result()
     println("Inserted book with id ${id}")
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
-If a document is inserted with an id, and a document with that id already eists, the insert will fail:
+If a document is inserted with an id, and a document with that id already exists, the insert will fail:
 
 [source,kotlin]
 ----
-
 // Document has an id already
-
 var document = json {
   obj(
     "title" to "The Hobbit",
     "_id" to "123244"
   )
 }
-
 mongoClient.insert("books", document, { res ->
-
   if (res.succeeded()) {
-
     //...
-
   } else {
-
     // Will fail if the book with that id already exists.
   }
-
 })
-
 
 ----
 
 === Updating documents
 
-To update a documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#update-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[update]`.
+To update a documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#updateCollection-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[updateCollection]`.
 
-This updates one or multiple documents in a collection. The json object that is passed in the `update`
-parameter must contain http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators] and determines
-how the object is updated.
+This updates one or multiple documents in a collection.
+The json object that is passed in the `updateCollection` parameter must contain
+http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators]
+and determines how the object is updated.
 
 The json object specified in the query parameter determines which documents in the collection will be updated.
 
@@ -250,34 +212,26 @@ Here's an example of updating a document in the books collection:
 
 [source,kotlin]
 ----
-
 // Match any documents with title=The Hobbit
 var query = json {
   obj("title" to "The Hobbit")
 }
-
 // Set the author field
 var update = json {
   obj("\$$set" to obj("author" to "J. R. R. Tolkien"))
 }
-
-mongoClient.update("books", query, update, { res ->
-
+mongoClient.updateCollection("books", query, update, { res ->
   if (res.succeeded()) {
-
     println("Book updated !")
-
   } else {
-
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
-To specify if the update should upsert or update multiple documents, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#updateWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.UpdateOptions-io.vertx.core.Handler-[updateWithOptions]`
+To specify if the update should upsert or update multiple documents, use
+`link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#updateCollectionWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.UpdateOptions-io.vertx.core.Handler-[updateCollectionWithOptions]`
 and pass in an instance of `link:../../apidocs/io/vertx/ext/mongo/UpdateOptions.html[UpdateOptions]`.
 
 This has the following fields:
@@ -288,73 +242,53 @@ This has the following fields:
 
 [source,kotlin]
 ----
-
 // Match any documents with title=The Hobbit
 var query = json {
   obj("title" to "The Hobbit")
 }
-
 // Set the author field
 var update = json {
   obj("\$$set" to obj("author" to "J. R. R. Tolkien"))
 }
-
 var options = UpdateOptions(
   multi = true)
-
-mongoClient.updateWithOptions("books", query, update, options, { res ->
-
+mongoClient.updateCollectionWithOptions("books", query, update, options, { res ->
   if (res.succeeded()) {
-
     println("Book updated !")
-
   } else {
-
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
 === Replacing documents
 
-To replace documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#replace-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[replace]`.
+To replace documents you use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#replaceDocuments-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[replaceDocuments]`.
 
-This is similar to the update operation, however it does not take any update operators like `update`.
+This is similar to the update operation, however it does not take any operator.
 Instead it replaces the entire document with the one provided.
 
 Here's an example of replacing a document in the books collection
 
 [source,kotlin]
 ----
-
 var query = json {
   obj("title" to "The Hobbit")
 }
-
 var replace = json {
   obj(
     "title" to "The Lord of the Rings",
     "author" to "J. R. R. Tolkien"
   )
 }
-
-mongoClient.replace("books", query, replace, { res ->
-
+mongoClient.replaceDocuments("books", query, replace, { res ->
   if (res.succeeded()) {
-
     println("Book replaced !")
-
   } else {
-
     res.cause().printStackTrace()
-
   }
-
 })
-
 
 ----
 
@@ -362,12 +296,13 @@ mongoClient.replace("books", query, replace, { res ->
 
 To execute multiple insert, update, replace, or delete operations at once, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#bulkWrite-java.lang.String-java.util.List-io.vertx.core.Handler-[bulkWrite]`.
 
-You can pass a list of `link:../../apidocs/io/vertx/ext/mongo/BulkOperation.html[BulkOperations]`, with each working similiar to the matching single operations.
+You can pass a list of `link:../../apidocs/io/vertx/ext/mongo/BulkOperation.html[BulkOperations]`, with each working similar to the matching single operation.
 You can pass as many operations, even of the same type, as you wish.
 
 To specify if the bulk operation should be executed in order, and with what write option, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#bulkWriteWithOptions-java.lang.String-java.util.List-io.vertx.ext.mongo.BulkWriteOptions-io.vertx.core.Handler-[bulkWriteWithOptions]`
 and pass an instance of `link:../../apidocs/io/vertx/ext/mongo/BulkWriteOptions.html[BulkWriteOptions]`.
-For more explanation what ordered means, see https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations
+For more explanation what ordered means, see
+https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations[Execution of Operations].
 
 === Finding documents
 
@@ -379,30 +314,19 @@ Here's a simple example with an empty query that will match all books:
 
 [source,kotlin]
 ----
-
 // empty query = match any
 var query = json {
   obj()
 }
-
 mongoClient.find("books", query, { res ->
-
   if (res.succeeded()) {
-
     for (json in res.result()) {
-
       println(json.toString())
-
     }
-
   } else {
-
     res.cause().printStackTrace()
-
   }
-
 })
-
 
 ----
 
@@ -410,30 +334,19 @@ Here's another example that will match all books by Tolkien:
 
 [source,kotlin]
 ----
-
 // will match all Tolkien books
 var query = json {
   obj("author" to "J. R. R. Tolkien")
 }
-
 mongoClient.find("books", query, { res ->
-
   if (res.succeeded()) {
-
     for (json in res.result()) {
-
       println(json.toString())
-
     }
-
   } else {
-
     res.cause().printStackTrace()
-
   }
-
 })
-
 
 ----
 
@@ -449,13 +362,18 @@ This has the following fields:
 `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
 `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
 
-----
+=== Find in batches
 
+When dealing with large data sets, it is not advised to use the
+`link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#find-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[find]` and
+`link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findWithOptions-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.ext.mongo.FindOptions-io.vertx.core.Handler-[findWithOptions]` methods.
+In order to avoid inflating the whole response into memory, use `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#findBatch-java.lang.String-io.vertx.core.json.JsonObject-[findBatch]`:
+
+----
 // will match all Tolkien books
 var query = json {
   obj("author" to "J. R. R. Tolkien")
 }
-
 mongoClient.findBatch("book", query).exceptionHandler({ throwable ->
   throwable.printStackTrace()
 }).endHandler({ v ->
@@ -466,7 +384,7 @@ mongoClient.findBatch("book", query).exceptionHandler({ throwable ->
 
 ----
 
-The matching documents are returned unitary in the result handler.
+The matching documents are emitted one by one by the `link:../../apidocs/io/vertx/core/streams/ReadStream.html[ReadStream]` handler.
 
 === Finding a single document
 
@@ -484,24 +402,16 @@ Here's an example of removing all Tolkien books:
 
 [source,kotlin]
 ----
-
 var query = json {
   obj("author" to "J. R. R. Tolkien")
 }
-
-mongoClient.remove("books", query, { res ->
-
+mongoClient.removeDocuments("books", query, { res ->
   if (res.succeeded()) {
-
     println("Never much liked Tolkien stuff!")
-
   } else {
-
     res.cause().printStackTrace()
-
   }
 })
-
 
 ----
 
@@ -519,24 +429,16 @@ Here's an example that counts the number of Tolkien books. The number is passed 
 
 [source,kotlin]
 ----
-
 var query = json {
   obj("author" to "J. R. R. Tolkien")
 }
-
 mongoClient.count("books", query, { res ->
-
   if (res.succeeded()) {
-
     var num = res.result()
-
   } else {
-
     res.cause().printStackTrace()
-
   }
 })
-
 
 ----
 
@@ -548,20 +450,13 @@ To get a list of all collections you can use `link:../../apidocs/io/vertx/ext/mo
 
 [source,kotlin]
 ----
-
 mongoClient.getCollections({ res ->
-
   if (res.succeeded()) {
-
     var collections = res.result()
-
   } else {
-
     res.cause().printStackTrace()
-
   }
 })
-
 
 ----
 
@@ -569,20 +464,13 @@ To create a new collection you can use `link:../../apidocs/io/vertx/ext/mongo/Mo
 
 [source,kotlin]
 ----
-
 mongoClient.createCollection("mynewcollectionr", { res ->
-
   if (res.succeeded()) {
-
     // Created ok!
-
   } else {
-
     res.cause().printStackTrace()
-
   }
 })
-
 
 ----
 
@@ -592,20 +480,13 @@ NOTE: Dropping a collection will delete all documents within it!
 
 [source,kotlin]
 ----
-
 mongoClient.dropCollection("mynewcollectionr", { res ->
-
   if (res.succeeded()) {
-
     // Dropped ok!
-
   } else {
-
     res.cause().printStackTrace()
-
   }
 })
-
 
 ----
 
@@ -614,7 +495,7 @@ mongoClient.dropCollection("mynewcollectionr", { res ->
 
 You can run arbitrary MongoDB commands with `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html#runCommand-java.lang.String-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[runCommand]`.
 
-Commands can be used to run more advanced mongoDB features, such as using MapReduce.
+Commands can be used to run more advanced MongoDB features, such as using MapReduce.
 For more information see the mongo docs for supported http://docs.mongodb.org/manual/reference/command[Commands].
 
 Here's an example of running an aggregate command. Note that the command name must be specified as a parameter
@@ -624,14 +505,12 @@ of the entries in the JSON is the command name it must be specified as a paramet
 
 [source,kotlin]
 ----
-
 var command = json {
   obj(
     "aggregate" to "collection_name",
     "pipeline" to array()
   )
 }
-
 mongoClient.runCommand("aggregate", command, { res ->
   if (res.succeeded()) {
     var resArr = res.result().getJsonArray("result")
@@ -641,49 +520,39 @@ mongoClient.runCommand("aggregate", command, { res ->
   }
 })
 
-
 ----
 
 === MongoDB Extended JSON support
 
-For now, only date, oid and binary types are supported (cf http://docs.mongodb.org/manual/reference/mongodb-extended-json )
+For now, only `date`, `oid` and `binary` types are supported
+(see http://docs.mongodb.org/manual/reference/mongodb-extended-json[MongoDB Extended JSON]).
 
-Here's an example of inserting a document with a date field
+Here's an example of inserting a document with a `date` field:
 
 [source,kotlin]
 ----
-
 var document = json {
   obj(
     "title" to "The Hobbit",
     "publicationDate" to obj("\$$date" to "1937-09-21T00:00:00+00:00")
   )
 }
-
 mongoService.save("publishedBooks", document, { res ->
-
   if (res.succeeded()) {
-
     var id = res.result()
-
     mongoService.findOne("publishedBooks", json {
       obj("_id" to id)
     }, null, { res2 ->
       if (res2.succeeded()) {
-
         println("To retrieve ISO-8601 date : ${res2.result().getJsonObject("publicationDate").getString("\$$date")}")
-
       } else {
         res2.cause().printStackTrace()
       }
     })
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 
@@ -692,31 +561,23 @@ Here's an example (in Java) of inserting a document with a binary field and read
 [source,kotlin]
 ----
 byte[] binaryObject = new byte[40];
-
 JsonObject document = new JsonObject()
-        .put("name", "Alan Turing")
-        .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
-
+  .put("name", "Alan Turing")
+  .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
 mongoService.save("smartPeople", document, res -> {
-
   if (res.succeeded()) {
-
     String id = res.result();
-
     mongoService.findOne("smartPeople", new JsonObject().put("_id", id), null, res2 -> {
-      if(res2.succeeded()) {
-
+      if (res2.succeeded()) {
         byte[] reconstitutedBinaryObject = res2.result().getJsonObject("binaryStuff").getBinary("$binary");
         //This could now be de-serialized into an object in real life
       } else {
         res2.cause().printStackTrace();
       }
     });
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 
@@ -724,81 +585,66 @@ Here's an example of inserting a base 64 encoded string, typing it as binary a b
 
 [source,kotlin]
 ----
-
 //This could be a the byte contents of a pdf file, etc converted to base 64
 var base64EncodedString = "a2FpbHVhIGlzIHRoZSAjMSBiZWFjaCBpbiB0aGUgd29ybGQ="
-
 var document = json {
   obj(
     "name" to "Alan Turing",
     "binaryStuff" to obj("\$$binary" to base64EncodedString)
   )
 }
-
 mongoService.save("smartPeople", document, { res ->
-
   if (res.succeeded()) {
-
     var id = res.result()
-
     mongoService.findOne("smartPeople", json {
       obj("_id" to id)
     }, null, { res2 ->
       if (res2.succeeded()) {
-
         var reconstitutedBase64EncodedString = res2.result().getJsonObject("binaryStuff").getString("\$$binary")
         //This could now converted back to bytes from the base 64 string
       } else {
         res2.cause().printStackTrace()
       }
     })
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
-
 
 ----
 Here's an example of inserting an object ID and reading it back
 
 [source,kotlin]
 ----
-
 var individualId = org.bson.types.ObjectId().toHexString()
-
 var document = json {
   obj(
     "name" to "Stephen Hawking",
     "individualId" to obj("\$$oid" to individualId)
   )
 }
-
 mongoService.save("smartPeople", document, { res ->
-
   if (res.succeeded()) {
-
     var id = res.result()
-
-    mongoService.findOne("smartPeople", json {
+    var query = json {
       obj("_id" to id)
-    }, null, { res2 ->
+    }
+    mongoService.findOne("smartPeople", query, null, { res2 ->
       if (res2.succeeded()) {
         var reconstitutedIndividualId = res2.result().getJsonObject("individualId").getString("\$$oid")
       } else {
         res2.cause().printStackTrace()
       }
     })
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
 
-
 ----
+
+=== Getting distinct values
+
 Here's an example of getting distinct value
 
 [source,kotlin]
@@ -806,19 +652,14 @@ Here's an example of getting distinct value
 var document = json {
   obj("title" to "The Hobbit")
 }
-
 mongoClient.save("books", document, { res ->
-
   if (res.succeeded()) {
-
     mongoClient.distinct("books", "title", String.`class`.getName(), { res2 ->
       println("Title is : ${res2.result().getJsonArray(0)}")
     })
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
 
 ----
@@ -829,19 +670,14 @@ Here's an example of getting distinct value in batch mode
 var document = json {
   obj("title" to "The Hobbit")
 }
-
 mongoClient.save("books", document, { res ->
-
   if (res.succeeded()) {
-
     mongoClient.distinctBatch("books", "title", String.`class`.getName()).handler({ book ->
       println("Title is : ${book.getString("title")}")
     })
-
   } else {
     res.cause().printStackTrace()
   }
-
 })
 
 ----
@@ -858,15 +694,12 @@ var document = json {
 var query = json {
   obj("publicationDate" to obj("\$$gte" to obj("\$$date" to "1937-09-21T00:00:00+00:00")))
 }
-
 mongoClient.save("books", document, { res ->
   if (res.succeeded()) {
-
     mongoClient.distinctWithQuery("books", "title", String.`class`.getName(), query, { res2 ->
       println("Title is : ${res2.result().getJsonArray(0)}")
     })
   }
-
 })
 
 ----
@@ -883,16 +716,12 @@ var document = json {
 var query = json {
   obj("publicationDate" to obj("\$$gte" to obj("\$$date" to "1937-09-21T00:00:00+00:00")))
 }
-
 mongoClient.save("books", document, { res ->
   if (res.succeeded()) {
-
     mongoClient.distinctBatchWithQuery("books", "title", String.`class`.getName(), query).handler({ book ->
       println("Title is : ${book.getString("title")}")
     })
-
   }
-
 })
 
 ----
@@ -904,7 +733,7 @@ The client is configured with a json object.
 The following configuration is supported by the mongo client:
 
 
-`db_name`:: Name of the database in the mongoDB instance to use. Defaults to `default_db`
+`db_name`:: Name of the database in the MongoDB instance to use. Defaults to `default_db`
 `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true`, hex-strings will
 be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
 time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false` for other types of your choosing.
@@ -984,12 +813,12 @@ For more information on the format of the connection string please consult the d
 
 *Driver option descriptions*
 
-`host`:: The host the mongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
-`port`:: The port the mongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
-`hosts`:: An array representing the hosts and ports to support a mongoDB cluster (sharding / replication)
+`host`:: The host the MongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
+`port`:: The port the MongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
+`hosts`:: An array representing the hosts and ports to support a MongoDB cluster (sharding / replication)
 `host`:: A host in the cluster
 `port`:: The port a host in the cluster is listening on
-`replicaSet`:: The name of the replica set, if the mongoDB instance is a member of a replica set
+`replicaSet`:: The name of the replica set, if the MongoDB instance is a member of a replica set
 `serverSelectionTimeoutMS`:: The time in milliseconds that the mongo driver will wait to select a server for an operation before raising an error.
 `maxPoolSize`:: The maximum number of connections in the connection pool. The default value is `100`
 `minPoolSize`:: The minimum number of connections in the connection pool. The default value is `0`

--- a/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
@@ -460,27 +460,13 @@ query = {
   'author' => "J. R. R. Tolkien"
 }
 
-mongoClient.find_batch("book", query) { |res_err,res|
-
-  if (res_err == nil)
-
-    if (res == nil)
-
-      puts "End of research"
-
-    else
-
-      puts "Found doc: #{JSON.generate(res)}"
-
-    end
-
-  else
-
-    res_err.print_stack_trace()
-
-  end
+mongoClient.find_batch("book", query).exception_handler() { |throwable|
+  throwable.print_stack_trace()
+}.end_handler() { |v|
+  puts "End of research"
+}.handler() { |doc|
+  puts "Found doc: #{JSON.generate(doc)}"
 }
-
 
 ----
 
@@ -851,8 +837,8 @@ mongoClient.save("books", document) { |res_err,res|
 
   if (res_err == nil)
 
-    mongoClient.distinct_batch("books", "title", Java::JavaLang::String::class.get_name()) { |res2_err,res2|
-      puts "Title is : #{res2['title']}"
+    mongoClient.distinct_batch("books", "title", Java::JavaLang::String::class.get_name()).handler() { |book|
+      puts "Title is : #{book['title']}"
     }
 
   else
@@ -912,9 +898,10 @@ query = {
 mongoClient.save("books", document) { |res_err,res|
   if (res_err == nil)
 
-    mongoClient.distinct_batch_with_query("books", "title", Java::JavaLang::String::class.get_name(), query) { |res2_err,res2|
-      puts "Title is : #{res2['title']}"
+    mongoClient.distinct_batch_with_query("books", "title", Java::JavaLang::String::class.get_name(), query).handler() { |book|
+      puts "Title is : #{book['title']}"
     }
+
   end
 
 }

--- a/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
@@ -54,9 +54,7 @@ The simplest way to do this is as follows:
 [source,ruby]
 ----
 require 'vertx-mongo/mongo_client'
-
 client = VertxMongo::MongoClient.create_shared(vertx, config)
-
 
 ----
 
@@ -72,9 +70,7 @@ You can create a client specifying a pool source name as follows
 [source,ruby]
 ----
 require 'vertx-mongo/mongo_client'
-
 client = VertxMongo::MongoClient.create_shared(vertx, config, "MyPoolName")
-
 
 ----
 
@@ -99,9 +95,7 @@ In that case you can use `link:../../yardoc/VertxMongo/MongoClient.html#create_n
 [source,ruby]
 ----
 require 'vertx-mongo/mongo_client'
-
 client = VertxMongo::MongoClient.create_non_shared(vertx, config)
-
 
 ----
 
@@ -117,8 +111,8 @@ The client API is represented by `link:../../yardoc/VertxMongo/MongoClient.html[
 
 To save a document you use `link:../../yardoc/VertxMongo/MongoClient.html#save-instance_method[save]`.
 
-If the document has no `\_id` field, it is inserted, otherwise, it is _upserted_. Upserted means it is inserted
-if it doesn't already exist, otherwise it is updated.
+If the document has no `\_id` field, it is inserted, otherwise, it is __upserted__.
+Upserted means it is inserted if it doesn't already exist, otherwise it is updated.
 
 If the document is inserted and has no id, then the id field generated will be returned to the result handler.
 
@@ -126,26 +120,18 @@ Here's an example of saving a document and getting the id back
 
 [source,ruby]
 ----
-
 # Document has no id
-
 document = {
   'title' => "The Hobbit"
 }
-
 mongoClient.save("books", document) { |res_err,res|
-
   if (res_err == nil)
-
     id = res
     puts "Saved book with id #{id}"
-
   else
     res_err.print_stack_trace()
   end
-
 }
-
 
 ----
 
@@ -153,26 +139,18 @@ And here's an example of saving a document which already has an id.
 
 [source,ruby]
 ----
-
 # Document has an id already
-
 document = {
   'title' => "The Hobbit",
   '_id' => "123244"
 }
-
 mongoClient.save("books", document) { |res_err,res|
-
   if (res_err == nil)
-
     # ...
-
   else
     res_err.print_stack_trace()
   end
-
 }
-
 
 ----
 
@@ -184,64 +162,48 @@ If the document is inserted and has no id, then the id field generated will be r
 
 [source,ruby]
 ----
-
 # Document has an id already
-
 document = {
   'title' => "The Hobbit"
 }
-
 mongoClient.insert("books", document) { |res_err,res|
-
   if (res_err == nil)
-
     id = res
     puts "Inserted book with id #{id}"
-
   else
     res_err.print_stack_trace()
   end
-
 }
-
 
 ----
 
-If a document is inserted with an id, and a document with that id already eists, the insert will fail:
+If a document is inserted with an id, and a document with that id already exists, the insert will fail:
 
 [source,ruby]
 ----
-
 # Document has an id already
-
 document = {
   'title' => "The Hobbit",
   '_id' => "123244"
 }
-
 mongoClient.insert("books", document) { |res_err,res|
-
   if (res_err == nil)
-
     #...
-
   else
-
     # Will fail if the book with that id already exists.
   end
-
 }
-
 
 ----
 
 === Updating documents
 
-To update a documents you use `link:../../yardoc/VertxMongo/MongoClient.html#update-instance_method[update]`.
+To update a documents you use `link:../../yardoc/VertxMongo/MongoClient.html#update_collection-instance_method[updateCollection]`.
 
-This updates one or multiple documents in a collection. The json object that is passed in the `update`
-parameter must contain http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators] and determines
-how the object is updated.
+This updates one or multiple documents in a collection.
+The json object that is passed in the `updateCollection` parameter must contain
+http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators]
+and determines how the object is updated.
 
 The json object specified in the query parameter determines which documents in the collection will be updated.
 
@@ -249,36 +211,28 @@ Here's an example of updating a document in the books collection:
 
 [source,ruby]
 ----
-
 # Match any documents with title=The Hobbit
 query = {
   'title' => "The Hobbit"
 }
-
 # Set the author field
 update = {
   '$set' => {
     'author' => "J. R. R. Tolkien"
   }
 }
-
-mongoClient.update("books", query, update) { |res_err,res|
-
+mongoClient.update_collection("books", query, update) { |res_err,res|
   if (res_err == nil)
-
     puts "Book updated !"
-
   else
-
     res_err.print_stack_trace()
   end
-
 }
-
 
 ----
 
-To specify if the update should upsert or update multiple documents, use `link:../../yardoc/VertxMongo/MongoClient.html#update_with_options-instance_method[updateWithOptions]`
+To specify if the update should upsert or update multiple documents, use
+`link:../../yardoc/VertxMongo/MongoClient.html#update_collection_with_options-instance_method[updateCollectionWithOptions]`
 and pass in an instance of `link:../dataobjects.html#UpdateOptions[UpdateOptions]`.
 
 This has the following fields:
@@ -289,74 +243,54 @@ This has the following fields:
 
 [source,ruby]
 ----
-
 # Match any documents with title=The Hobbit
 query = {
   'title' => "The Hobbit"
 }
-
 # Set the author field
 update = {
   '$set' => {
     'author' => "J. R. R. Tolkien"
   }
 }
-
 options = {
   'multi' => true
 }
-
-mongoClient.update_with_options("books", query, update, options) { |res_err,res|
-
+mongoClient.update_collection_with_options("books", query, update, options) { |res_err,res|
   if (res_err == nil)
-
     puts "Book updated !"
-
   else
-
     res_err.print_stack_trace()
   end
-
 }
-
 
 ----
 
 === Replacing documents
 
-To replace documents you use `link:../../yardoc/VertxMongo/MongoClient.html#replace-instance_method[replace]`.
+To replace documents you use `link:../../yardoc/VertxMongo/MongoClient.html#replace_documents-instance_method[replaceDocuments]`.
 
-This is similar to the update operation, however it does not take any update operators like `update`.
+This is similar to the update operation, however it does not take any operator.
 Instead it replaces the entire document with the one provided.
 
 Here's an example of replacing a document in the books collection
 
 [source,ruby]
 ----
-
 query = {
   'title' => "The Hobbit"
 }
-
 replace = {
   'title' => "The Lord of the Rings",
   'author' => "J. R. R. Tolkien"
 }
-
-mongoClient.replace("books", query, replace) { |res_err,res|
-
+mongoClient.replace_documents("books", query, replace) { |res_err,res|
   if (res_err == nil)
-
     puts "Book replaced !"
-
   else
-
     res_err.print_stack_trace()
-
   end
-
 }
-
 
 ----
 
@@ -364,12 +298,13 @@ mongoClient.replace("books", query, replace) { |res_err,res|
 
 To execute multiple insert, update, replace, or delete operations at once, use `link:../../yardoc/VertxMongo/MongoClient.html#bulk_write-instance_method[bulkWrite]`.
 
-You can pass a list of `link:../dataobjects.html#BulkOperation[BulkOperations]`, with each working similiar to the matching single operations.
+You can pass a list of `link:../dataobjects.html#BulkOperation[BulkOperations]`, with each working similar to the matching single operation.
 You can pass as many operations, even of the same type, as you wish.
 
 To specify if the bulk operation should be executed in order, and with what write option, use `link:../../yardoc/VertxMongo/MongoClient.html#bulk_write_with_options-instance_method[bulkWriteWithOptions]`
 and pass an instance of `link:../dataobjects.html#BulkWriteOptions[BulkWriteOptions]`.
-For more explanation what ordered means, see https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations
+For more explanation what ordered means, see
+https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations[Execution of Operations].
 
 === Finding documents
 
@@ -382,29 +317,18 @@ Here's a simple example with an empty query that will match all books:
 [source,ruby]
 ----
 require 'json'
-
 # empty query = match any
 query = {
 }
-
 mongoClient.find("books", query) { |res_err,res|
-
   if (res_err == nil)
-
     res.each do |json|
-
       puts JSON.generate(json)
-
     end
-
   else
-
     res_err.print_stack_trace()
-
   end
-
 }
-
 
 ----
 
@@ -413,30 +337,19 @@ Here's another example that will match all books by Tolkien:
 [source,ruby]
 ----
 require 'json'
-
 # will match all Tolkien books
 query = {
   'author' => "J. R. R. Tolkien"
 }
-
 mongoClient.find("books", query) { |res_err,res|
-
   if (res_err == nil)
-
     res.each do |json|
-
       puts JSON.generate(json)
-
     end
-
   else
-
     res_err.print_stack_trace()
-
   end
-
 }
-
 
 ----
 
@@ -452,14 +365,19 @@ This has the following fields:
 `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
 `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
 
+=== Find in batches
+
+When dealing with large data sets, it is not advised to use the
+`link:../../yardoc/VertxMongo/MongoClient.html#find-instance_method[find]` and
+`link:../../yardoc/VertxMongo/MongoClient.html#find_with_options-instance_method[findWithOptions]` methods.
+In order to avoid inflating the whole response into memory, use `link:../../yardoc/VertxMongo/MongoClient.html#find_batch-instance_method[findBatch]`:
+
 ----
 require 'json'
-
 # will match all Tolkien books
 query = {
   'author' => "J. R. R. Tolkien"
 }
-
 mongoClient.find_batch("book", query).exception_handler() { |throwable|
   throwable.print_stack_trace()
 }.end_handler() { |v|
@@ -470,7 +388,7 @@ mongoClient.find_batch("book", query).exception_handler() { |throwable|
 
 ----
 
-The matching documents are returned unitary in the result handler.
+The matching documents are emitted one by one by the `link:../../yardoc/Vertx/ReadStream.html[ReadStream]` handler.
 
 === Finding a single document
 
@@ -488,24 +406,16 @@ Here's an example of removing all Tolkien books:
 
 [source,ruby]
 ----
-
 query = {
   'author' => "J. R. R. Tolkien"
 }
-
-mongoClient.remove("books", query) { |res_err,res|
-
+mongoClient.remove_documents("books", query) { |res_err,res|
   if (res_err == nil)
-
     puts "Never much liked Tolkien stuff!"
-
   else
-
     res_err.print_stack_trace()
-
   end
 }
-
 
 ----
 
@@ -523,24 +433,16 @@ Here's an example that counts the number of Tolkien books. The number is passed 
 
 [source,ruby]
 ----
-
 query = {
   'author' => "J. R. R. Tolkien"
 }
-
 mongoClient.count("books", query) { |res_err,res|
-
   if (res_err == nil)
-
     num = res
-
   else
-
     res_err.print_stack_trace()
-
   end
 }
-
 
 ----
 
@@ -552,20 +454,13 @@ To get a list of all collections you can use `link:../../yardoc/VertxMongo/Mongo
 
 [source,ruby]
 ----
-
 mongoClient.get_collections() { |res_err,res|
-
   if (res_err == nil)
-
     collections = res
-
   else
-
     res_err.print_stack_trace()
-
   end
 }
-
 
 ----
 
@@ -573,20 +468,13 @@ To create a new collection you can use `link:../../yardoc/VertxMongo/MongoClient
 
 [source,ruby]
 ----
-
 mongoClient.create_collection("mynewcollectionr") { |res_err,res|
-
   if (res_err == nil)
-
     # Created ok!
-
   else
-
     res_err.print_stack_trace()
-
   end
 }
-
 
 ----
 
@@ -596,20 +484,13 @@ NOTE: Dropping a collection will delete all documents within it!
 
 [source,ruby]
 ----
-
 mongoClient.drop_collection("mynewcollectionr") { |res_err,res|
-
   if (res_err == nil)
-
     # Dropped ok!
-
   else
-
     res_err.print_stack_trace()
-
   end
 }
-
 
 ----
 
@@ -618,7 +499,7 @@ mongoClient.drop_collection("mynewcollectionr") { |res_err,res|
 
 You can run arbitrary MongoDB commands with `link:../../yardoc/VertxMongo/MongoClient.html#run_command-instance_method[runCommand]`.
 
-Commands can be used to run more advanced mongoDB features, such as using MapReduce.
+Commands can be used to run more advanced MongoDB features, such as using MapReduce.
 For more information see the mongo docs for supported http://docs.mongodb.org/manual/reference/command[Commands].
 
 Here's an example of running an aggregate command. Note that the command name must be specified as a parameter
@@ -628,13 +509,11 @@ of the entries in the JSON is the command name it must be specified as a paramet
 
 [source,ruby]
 ----
-
 command = {
   'aggregate' => "collection_name",
   'pipeline' => [
   ]
 }
-
 mongoClient.run_command("aggregate", command) { |res_err,res|
   if (res_err == nil)
     resArr = res['result']
@@ -644,49 +523,39 @@ mongoClient.run_command("aggregate", command) { |res_err,res|
   end
 }
 
-
 ----
 
 === MongoDB Extended JSON support
 
-For now, only date, oid and binary types are supported (cf http://docs.mongodb.org/manual/reference/mongodb-extended-json )
+For now, only `date`, `oid` and `binary` types are supported
+(see http://docs.mongodb.org/manual/reference/mongodb-extended-json[MongoDB Extended JSON]).
 
-Here's an example of inserting a document with a date field
+Here's an example of inserting a document with a `date` field:
 
 [source,ruby]
 ----
-
 document = {
   'title' => "The Hobbit",
   'publicationDate' => {
     '$date' => "1937-09-21T00:00:00+00:00"
   }
 }
-
 mongoService.save("publishedBooks", document) { |res_err,res|
-
   if (res_err == nil)
-
     id = res
-
     mongoService.find_one("publishedBooks", {
       '_id' => id
     }, nil) { |res2_err,res2|
       if (res2_err == nil)
-
         puts "To retrieve ISO-8601 date : #{res2['publicationDate']['$date']}"
-
       else
         res2_err.print_stack_trace()
       end
     }
-
   else
     res_err.print_stack_trace()
   end
-
 }
-
 
 ----
 
@@ -695,31 +564,23 @@ Here's an example (in Java) of inserting a document with a binary field and read
 [source,ruby]
 ----
 byte[] binaryObject = new byte[40];
-
 JsonObject document = new JsonObject()
-        .put("name", "Alan Turing")
-        .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
-
+  .put("name", "Alan Turing")
+  .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
 mongoService.save("smartPeople", document, res -> {
-
   if (res.succeeded()) {
-
     String id = res.result();
-
     mongoService.findOne("smartPeople", new JsonObject().put("_id", id), null, res2 -> {
-      if(res2.succeeded()) {
-
+      if (res2.succeeded()) {
         byte[] reconstitutedBinaryObject = res2.result().getJsonObject("binaryStuff").getBinary("$binary");
         //This could now be de-serialized into an object in real life
       } else {
         res2.cause().printStackTrace();
       }
     });
-
   } else {
     res.cause().printStackTrace();
   }
-
 });
 ----
 
@@ -727,81 +588,66 @@ Here's an example of inserting a base 64 encoded string, typing it as binary a b
 
 [source,ruby]
 ----
-
 #This could be a the byte contents of a pdf file, etc converted to base 64
 base64EncodedString = "a2FpbHVhIGlzIHRoZSAjMSBiZWFjaCBpbiB0aGUgd29ybGQ="
-
 document = {
   'name' => "Alan Turing",
   'binaryStuff' => {
     '$binary' => base64EncodedString
   }
 }
-
 mongoService.save("smartPeople", document) { |res_err,res|
-
   if (res_err == nil)
-
     id = res
-
     mongoService.find_one("smartPeople", {
       '_id' => id
     }, nil) { |res2_err,res2|
       if (res2_err == nil)
-
         reconstitutedBase64EncodedString = res2['binaryStuff']['$binary']
         #This could now converted back to bytes from the base 64 string
       else
         res2_err.print_stack_trace()
       end
     }
-
   else
     res_err.print_stack_trace()
   end
-
 }
-
 
 ----
 Here's an example of inserting an object ID and reading it back
 
 [source,ruby]
 ----
-
 individualId = Java::OrgBsonTypes::ObjectId.new().to_hex_string()
-
 document = {
   'name' => "Stephen Hawking",
   'individualId' => {
     '$oid' => individualId
   }
 }
-
 mongoService.save("smartPeople", document) { |res_err,res|
-
   if (res_err == nil)
-
     id = res
-
-    mongoService.find_one("smartPeople", {
+    query = {
       '_id' => id
-    }, nil) { |res2_err,res2|
+    }
+    mongoService.find_one("smartPeople", query, nil) { |res2_err,res2|
       if (res2_err == nil)
         reconstitutedIndividualId = res2['individualId']['$oid']
       else
         res2_err.print_stack_trace()
       end
     }
-
   else
     res_err.print_stack_trace()
   end
-
 }
 
-
 ----
+
+=== Getting distinct values
+
 Here's an example of getting distinct value
 
 [source,ruby]
@@ -809,19 +655,14 @@ Here's an example of getting distinct value
 document = {
   'title' => "The Hobbit"
 }
-
 mongoClient.save("books", document) { |res_err,res|
-
   if (res_err == nil)
-
     mongoClient.distinct("books", "title", Java::JavaLang::String::class.get_name()) { |res2_err,res2|
       puts "Title is : #{res2[0]}"
     }
-
   else
     res_err.print_stack_trace()
   end
-
 }
 
 ----
@@ -832,19 +673,14 @@ Here's an example of getting distinct value in batch mode
 document = {
   'title' => "The Hobbit"
 }
-
 mongoClient.save("books", document) { |res_err,res|
-
   if (res_err == nil)
-
     mongoClient.distinct_batch("books", "title", Java::JavaLang::String::class.get_name()).handler() { |book|
       puts "Title is : #{book['title']}"
     }
-
   else
     res_err.print_stack_trace()
   end
-
 }
 
 ----
@@ -865,15 +701,12 @@ query = {
     }
   }
 }
-
 mongoClient.save("books", document) { |res_err,res|
   if (res_err == nil)
-
     mongoClient.distinct_with_query("books", "title", Java::JavaLang::String::class.get_name(), query) { |res2_err,res2|
       puts "Title is : #{res2[0]}"
     }
   end
-
 }
 
 ----
@@ -894,16 +727,12 @@ query = {
     }
   }
 }
-
 mongoClient.save("books", document) { |res_err,res|
   if (res_err == nil)
-
     mongoClient.distinct_batch_with_query("books", "title", Java::JavaLang::String::class.get_name(), query).handler() { |book|
       puts "Title is : #{book['title']}"
     }
-
   end
-
 }
 
 ----
@@ -915,7 +744,7 @@ The client is configured with a json object.
 The following configuration is supported by the mongo client:
 
 
-`db_name`:: Name of the database in the mongoDB instance to use. Defaults to `default_db`
+`db_name`:: Name of the database in the MongoDB instance to use. Defaults to `default_db`
 `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true`, hex-strings will
 be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
 time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false` for other types of your choosing.
@@ -995,12 +824,12 @@ For more information on the format of the connection string please consult the d
 
 *Driver option descriptions*
 
-`host`:: The host the mongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
-`port`:: The port the mongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
-`hosts`:: An array representing the hosts and ports to support a mongoDB cluster (sharding / replication)
+`host`:: The host the MongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
+`port`:: The port the MongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
+`hosts`:: An array representing the hosts and ports to support a MongoDB cluster (sharding / replication)
 `host`:: A host in the cluster
 `port`:: The port a host in the cluster is listening on
-`replicaSet`:: The name of the replica set, if the mongoDB instance is a member of a replica set
+`replicaSet`:: The name of the replica set, if the MongoDB instance is a member of a replica set
 `serverSelectionTimeoutMS`:: The time in milliseconds that the mongo driver will wait to select a server for an operation before raising an error.
 `maxPoolSize`:: The maximum number of connections in the connection pool. The default value is `100`
 `minPoolSize`:: The minimum number of connections in the connection pool. The default value is `0`

--- a/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
@@ -365,13 +365,14 @@ This has the following fields:
 `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
 `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
 
-=== Find in batches
+=== Finding documents in batches
 
 When dealing with large data sets, it is not advised to use the
 `link:../../yardoc/VertxMongo/MongoClient.html#find-instance_method[find]` and
 `link:../../yardoc/VertxMongo/MongoClient.html#find_with_options-instance_method[findWithOptions]` methods.
 In order to avoid inflating the whole response into memory, use `link:../../yardoc/VertxMongo/MongoClient.html#find_batch-instance_method[findBatch]`:
 
+[source,ruby]
 ----
 require 'json'
 # will match all Tolkien books
@@ -389,6 +390,30 @@ mongoClient.find_batch("book", query).exception_handler() { |throwable|
 ----
 
 The matching documents are emitted one by one by the `link:../../yardoc/Vertx/ReadStream.html[ReadStream]` handler.
+
+`link:../dataobjects.html#FindOptions[FindOptions]` has an extra parameter `batchSize` which you can use to set the number of documents to load at once:
+
+[source,ruby]
+----
+require 'json'
+# will match all Tolkien books
+query = {
+  'author' => "J. R. R. Tolkien"
+}
+options = {
+  'batchSize' => 100
+}
+mongoClient.find_batch_with_options("book", query, options).exception_handler() { |throwable|
+  throwable.print_stack_trace()
+}.end_handler() { |v|
+  puts "End of research"
+}.handler() { |doc|
+  puts "Found doc: #{JSON.generate(doc)}"
+}
+
+----
+
+By default, `batchSize` is set to 20.
 
 === Finding a single document
 
@@ -761,6 +786,7 @@ For more information on the format of the connection string please consult the d
 
 *Specific driver configuration options*
 
+[source,js]
 ----
 {
   // Single Cluster Settings

--- a/vertx-mongo-client/src/main/generated/io/vertx/ext/mongo/FindOptionsConverter.java
+++ b/vertx-mongo-client/src/main/generated/io/vertx/ext/mongo/FindOptionsConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Converter for {@link io.vertx.ext.mongo.FindOptions}.
+ *
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.FindOptions} original class using Vert.x codegen.
+ */
+public class FindOptionsConverter {
+
+  public static void fromJson(JsonObject json, FindOptions obj) {
+    if (json.getValue("batchSize") instanceof Number) {
+      obj.setBatchSize(((Number) json.getValue("batchSize")).intValue());
+    }
+    if (json.getValue("fields") instanceof JsonObject) {
+      obj.setFields(((JsonObject) json.getValue("fields")).copy());
+    }
+    if (json.getValue("limit") instanceof Number) {
+      obj.setLimit(((Number) json.getValue("limit")).intValue());
+    }
+    if (json.getValue("skip") instanceof Number) {
+      obj.setSkip(((Number) json.getValue("skip")).intValue());
+    }
+    if (json.getValue("sort") instanceof JsonObject) {
+      obj.setSort(((JsonObject) json.getValue("sort")).copy());
+    }
+  }
+
+  public static void toJson(FindOptions obj, JsonObject json) {
+    json.put("batchSize", obj.getBatchSize());
+    if (obj.getFields() != null) {
+      json.put("fields", obj.getFields());
+    }
+    json.put("limit", obj.getLimit());
+    json.put("skip", obj.getSkip());
+    if (obj.getSort() != null) {
+      json.put("sort", obj.getSort());
+    }
+  }
+}

--- a/vertx-mongo-client/src/main/java/examples/Examples.java
+++ b/vertx-mongo-client/src/main/java/examples/Examples.java
@@ -259,27 +259,10 @@ public class Examples {
     // will match all Tolkien books
     JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
 
-    mongoClient.findBatch("book", query, res -> {
-
-      if (res.succeeded()) {
-
-        if (res.result() == null) {
-
-          System.out.println("End of research");
-
-        } else {
-
-          System.out.println("Found doc: " + res.result().encodePrettily());
-
-        }
-
-      } else {
-
-        res.cause().printStackTrace();
-
-      }
-    });
-
+    mongoClient.findBatch("book", query)
+      .exceptionHandler(throwable -> throwable.printStackTrace())
+      .endHandler(v -> System.out.println("End of research"))
+      .handler(doc -> System.out.println("Found doc: " + doc.encodePrettily()));
   }
 
 
@@ -537,9 +520,8 @@ public class Examples {
 
       if (res.succeeded()) {
 
-        mongoClient.distinctBatch("books", "title", String.class.getName(), res2 -> {
-          System.out.println("Title is : " + res2.result().getString("title"));
-        });
+        mongoClient.distinctBatch("books", "title", String.class.getName())
+          .handler(book -> System.out.println("Title is : " + book.getString("title")));
 
       } else {
         res.cause().printStackTrace();
@@ -576,9 +558,9 @@ public class Examples {
     mongoClient.save("books", document, res -> {
       if (res.succeeded()) {
 
-        mongoClient.distinctBatchWithQuery("books", "title", String.class.getName(), query, res2 -> {
-          System.out.println("Title is : " + res2.result().getString("title"));
-        });
+        mongoClient.distinctBatchWithQuery("books", "title", String.class.getName(), query)
+          .handler(book -> System.out.println("Title is : " + book.getString("title")));
+
       }
 
     });

--- a/vertx-mongo-client/src/main/java/examples/Examples.java
+++ b/vertx-mongo-client/src/main/java/examples/Examples.java
@@ -13,7 +13,6 @@
  *
  *  You may elect to redistribute this code under either of these licenses.
  */
-
 package examples;
 
 import io.vertx.core.Vertx;
@@ -31,336 +30,219 @@ import java.util.List;
  */
 public class Examples {
 
-
   public void exampleCreateDefault(Vertx vertx, JsonObject config) {
-
     MongoClient client = MongoClient.createShared(vertx, config);
-
   }
 
   public void exampleCreatePoolName(Vertx vertx, JsonObject config) {
-
     MongoClient client = MongoClient.createShared(vertx, config, "MyPoolName");
-
   }
 
   public void exampleCreateNonShared(Vertx vertx, JsonObject config) {
-
     MongoClient client = MongoClient.createNonShared(vertx, config);
-
   }
 
-
   public void example1(MongoClient mongoClient) {
-
     // Document has no id
-
-    JsonObject document = new JsonObject().put("title", "The Hobbit");
-
+    JsonObject document = new JsonObject()
+      .put("title", "The Hobbit");
     mongoClient.save("books", document, res -> {
-
       if (res.succeeded()) {
-
         String id = res.result();
         System.out.println("Saved book with id " + id);
-
       } else {
         res.cause().printStackTrace();
       }
-
     });
-
   }
 
   public void example2(MongoClient mongoClient) {
-
     // Document has an id already
-
-    JsonObject document = new JsonObject().put("title", "The Hobbit").put("_id", "123244");
-
+    JsonObject document = new JsonObject()
+      .put("title", "The Hobbit")
+      .put("_id", "123244");
     mongoClient.save("books", document, res -> {
-
       if (res.succeeded()) {
-
         // ...
-
       } else {
         res.cause().printStackTrace();
       }
-
     });
-
   }
 
   public void example3(MongoClient mongoClient) {
-
     // Document has an id already
-
-    JsonObject document = new JsonObject().put("title", "The Hobbit");
-
+    JsonObject document = new JsonObject()
+      .put("title", "The Hobbit");
     mongoClient.insert("books", document, res -> {
-
       if (res.succeeded()) {
-
         String id = res.result();
         System.out.println("Inserted book with id " + id);
-
       } else {
         res.cause().printStackTrace();
       }
-
     });
-
   }
 
   public void example4(MongoClient mongoClient) {
-
     // Document has an id already
-
-    JsonObject document = new JsonObject().put("title", "The Hobbit").put("_id", "123244");
-
+    JsonObject document = new JsonObject()
+      .put("title", "The Hobbit")
+      .put("_id", "123244");
     mongoClient.insert("books", document, res -> {
-
       if (res.succeeded()) {
-
         //...
-
       } else {
-
         // Will fail if the book with that id already exists.
       }
-
     });
-
   }
 
   public void example5(MongoClient mongoClient) {
-
     // Match any documents with title=The Hobbit
-    JsonObject query = new JsonObject().put("title", "The Hobbit");
-
+    JsonObject query = new JsonObject()
+      .put("title", "The Hobbit");
     // Set the author field
-    JsonObject update = new JsonObject().put("$set", new JsonObject().put("author", "J. R. R. Tolkien"));
-
-    mongoClient.update("books", query, update, res -> {
-
+    JsonObject update = new JsonObject().put("$set", new JsonObject()
+      .put("author", "J. R. R. Tolkien"));
+    mongoClient.updateCollection("books", query, update, res -> {
       if (res.succeeded()) {
-
         System.out.println("Book updated !");
-
       } else {
-
         res.cause().printStackTrace();
       }
-
     });
-
   }
 
   public void example6(MongoClient mongoClient) {
-
     // Match any documents with title=The Hobbit
-    JsonObject query = new JsonObject().put("title", "The Hobbit");
-
+    JsonObject query = new JsonObject()
+      .put("title", "The Hobbit");
     // Set the author field
-    JsonObject update = new JsonObject().put("$set", new JsonObject().put("author", "J. R. R. Tolkien"));
-
+    JsonObject update = new JsonObject().put("$set", new JsonObject()
+      .put("author", "J. R. R. Tolkien"));
     UpdateOptions options = new UpdateOptions().setMulti(true);
-
-    mongoClient.updateWithOptions("books", query, update, options, res -> {
-
+    mongoClient.updateCollectionWithOptions("books", query, update, options, res -> {
       if (res.succeeded()) {
-
         System.out.println("Book updated !");
-
       } else {
-
         res.cause().printStackTrace();
       }
-
     });
-
   }
 
   public void example7(MongoClient mongoClient) {
-
-    JsonObject query = new JsonObject().put("title", "The Hobbit");
-
-    JsonObject replace = new JsonObject().put("title", "The Lord of the Rings").put("author", "J. R. R. Tolkien");
-
-    mongoClient.replace("books", query, replace, res -> {
-
+    JsonObject query = new JsonObject()
+      .put("title", "The Hobbit");
+    JsonObject replace = new JsonObject()
+      .put("title", "The Lord of the Rings")
+      .put("author", "J. R. R. Tolkien");
+    mongoClient.replaceDocuments("books", query, replace, res -> {
       if (res.succeeded()) {
-
         System.out.println("Book replaced !");
-
       } else {
-
         res.cause().printStackTrace();
-
       }
-
     });
-
   }
 
   public void example8(MongoClient mongoClient) {
-
     // empty query = match any
     JsonObject query = new JsonObject();
-
     mongoClient.find("books", query, res -> {
-
       if (res.succeeded()) {
-
         for (JsonObject json : res.result()) {
-
           System.out.println(json.encodePrettily());
-
         }
-
       } else {
-
         res.cause().printStackTrace();
-
       }
-
     });
-
   }
 
   public void example9(MongoClient mongoClient) {
-
     // will match all Tolkien books
-    JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
-
+    JsonObject query = new JsonObject()
+      .put("author", "J. R. R. Tolkien");
     mongoClient.find("books", query, res -> {
-
       if (res.succeeded()) {
-
         for (JsonObject json : res.result()) {
-
           System.out.println(json.encodePrettily());
-
         }
-
       } else {
-
         res.cause().printStackTrace();
-
       }
-
     });
-
   }
 
-  public void example9_1(MongoClient mongoClient) {
-
+  public void findBatch(MongoClient mongoClient) {
     // will match all Tolkien books
-    JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
-
+    JsonObject query = new JsonObject()
+      .put("author", "J. R. R. Tolkien");
     mongoClient.findBatch("book", query)
       .exceptionHandler(throwable -> throwable.printStackTrace())
       .endHandler(v -> System.out.println("End of research"))
       .handler(doc -> System.out.println("Found doc: " + doc.encodePrettily()));
   }
 
-
   public void example10(MongoClient mongoClient) {
-
-    JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
-
-    mongoClient.remove("books", query, res -> {
-
+    JsonObject query = new JsonObject()
+      .put("author", "J. R. R. Tolkien");
+    mongoClient.removeDocuments("books", query, res -> {
       if (res.succeeded()) {
-
         System.out.println("Never much liked Tolkien stuff!");
-
       } else {
-
         res.cause().printStackTrace();
-
       }
     });
-
   }
 
   public void example11(MongoClient mongoClient) {
-
-    JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
-
+    JsonObject query = new JsonObject()
+      .put("author", "J. R. R. Tolkien");
     mongoClient.count("books", query, res -> {
-
       if (res.succeeded()) {
-
         long num = res.result();
-
       } else {
-
         res.cause().printStackTrace();
-
       }
     });
-
   }
 
   public void example11_1(MongoClient mongoClient) {
-
     mongoClient.getCollections(res -> {
-
       if (res.succeeded()) {
-
         List<String> collections = res.result();
-
       } else {
-
         res.cause().printStackTrace();
-
       }
     });
-
   }
 
   public void example11_2(MongoClient mongoClient) {
-
     mongoClient.createCollection("mynewcollectionr", res -> {
-
       if (res.succeeded()) {
-
         // Created ok!
-
       } else {
-
         res.cause().printStackTrace();
-
       }
     });
-
   }
 
   public void example11_3(MongoClient mongoClient) {
-
     mongoClient.dropCollection("mynewcollectionr", res -> {
-
       if (res.succeeded()) {
-
         // Dropped ok!
-
       } else {
-
         res.cause().printStackTrace();
-
       }
     });
-
   }
 
   public void example12(MongoClient mongoClient) {
-
     JsonObject command = new JsonObject()
       .put("aggregate", "collection_name")
       .put("pipeline", new JsonArray());
-
     mongoClient.runCommand("aggregate", command, res -> {
       if (res.succeeded()) {
         JsonArray resArr = res.result().getJsonArray("result");
@@ -369,200 +251,155 @@ public class Examples {
         res.cause().printStackTrace();
       }
     });
-
   }
 
   public void example13_0(MongoClient mongoService) {
-
-    JsonObject document = new JsonObject().put("title", "The Hobbit")
+    JsonObject document = new JsonObject()
+      .put("title", "The Hobbit")
       //ISO-8601 date
       .put("publicationDate", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00"));
-
     mongoService.save("publishedBooks", document, res -> {
-
       if (res.succeeded()) {
-
         String id = res.result();
-
         mongoService.findOne("publishedBooks", new JsonObject().put("_id", id), null, res2 -> {
           if (res2.succeeded()) {
-
             System.out.println("To retrieve ISO-8601 date : "
-                    + res2.result().getJsonObject("publicationDate").getString("$date"));
-
+              + res2.result().getJsonObject("publicationDate").getString("$date"));
           } else {
             res2.cause().printStackTrace();
           }
         });
-
       } else {
         res.cause().printStackTrace();
       }
-
     });
-
   }
-  @Source(translate=false)
-  public void example14_01_dl(MongoClient mongoService) throws Exception {
 
+  @Source(translate = false)
+  public void example14_01_dl(MongoClient mongoService) {
     //This could be a serialized object or the contents of a pdf file, etc,  in real life
     byte[] binaryObject = new byte[40];
-
     JsonObject document = new JsonObject()
-            .put("name", "Alan Turing")
-            .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
-
+      .put("name", "Alan Turing")
+      .put("binaryStuff", new JsonObject().put("$binary", binaryObject));
     mongoService.save("smartPeople", document, res -> {
-
       if (res.succeeded()) {
-
         String id = res.result();
-
         mongoService.findOne("smartPeople", new JsonObject().put("_id", id), null, res2 -> {
-          if(res2.succeeded()) {
-
+          if (res2.succeeded()) {
             byte[] reconstitutedBinaryObject = res2.result().getJsonObject("binaryStuff").getBinary("$binary");
             //This could now be de-serialized into an object in real life
           } else {
             res2.cause().printStackTrace();
           }
         });
-
       } else {
         res.cause().printStackTrace();
       }
-
     });
-
   }
-  public void example14_02_dl(MongoClient mongoService) throws Exception {
 
+  public void example14_02_dl(MongoClient mongoService) {
     //This could be a the byte contents of a pdf file, etc converted to base 64
     String base64EncodedString = "a2FpbHVhIGlzIHRoZSAjMSBiZWFjaCBpbiB0aGUgd29ybGQ=";
-
     JsonObject document = new JsonObject()
-            .put("name", "Alan Turing")
-            .put("binaryStuff", new JsonObject().put("$binary", base64EncodedString));
-
+      .put("name", "Alan Turing")
+      .put("binaryStuff", new JsonObject().put("$binary", base64EncodedString));
     mongoService.save("smartPeople", document, res -> {
-
       if (res.succeeded()) {
-
         String id = res.result();
-
         mongoService.findOne("smartPeople", new JsonObject().put("_id", id), null, res2 -> {
-          if(res2.succeeded()) {
-
+          if (res2.succeeded()) {
             String reconstitutedBase64EncodedString = res2.result().getJsonObject("binaryStuff").getString("$binary");
             //This could now converted back to bytes from the base 64 string
           } else {
             res2.cause().printStackTrace();
           }
         });
-
       } else {
         res.cause().printStackTrace();
       }
-
     });
-
   }
-  public void example15_dl(MongoClient mongoService) throws Exception {
 
+  public void example15_dl(MongoClient mongoService) {
     String individualId = new ObjectId().toHexString();
-
     JsonObject document = new JsonObject()
-            .put("name", "Stephen Hawking")
-            .put("individualId", new JsonObject().put("$oid", individualId));
-
+      .put("name", "Stephen Hawking")
+      .put("individualId", new JsonObject().put("$oid", individualId));
     mongoService.save("smartPeople", document, res -> {
-
       if (res.succeeded()) {
-
         String id = res.result();
-
-        mongoService.findOne("smartPeople", new JsonObject().put("_id", id), null, res2 -> {
-          if(res2.succeeded()) {
-            String reconstitutedIndividualId = res2.result().getJsonObject("individualId").getString("$oid");
+        JsonObject query = new JsonObject().put("_id", id);
+        mongoService.findOne("smartPeople", query, null, res2 -> {
+          if (res2.succeeded()) {
+            String reconstitutedIndividualId = res2.result()
+              .getJsonObject("individualId").getString("$oid");
           } else {
             res2.cause().printStackTrace();
           }
         });
-
       } else {
         res.cause().printStackTrace();
       }
-
     });
-
   }
-  public void example16(MongoClient mongoClient) throws Exception{
-    JsonObject document = new JsonObject().put("title", "The Hobbit");
 
+  public void example16(MongoClient mongoClient) {
+    JsonObject document = new JsonObject()
+      .put("title", "The Hobbit");
     mongoClient.save("books", document, res -> {
-
       if (res.succeeded()) {
-
         mongoClient.distinct("books", "title", String.class.getName(), res2 -> {
           System.out.println("Title is : " + res2.result().getJsonArray(0));
         });
-
       } else {
         res.cause().printStackTrace();
       }
-
     });
   }
-  public void example16_d1(MongoClient mongoClient) throws Exception{
-    JsonObject document = new JsonObject().put("title", "The Hobbit");
 
+  public void example16_d1(MongoClient mongoClient) {
+    JsonObject document = new JsonObject()
+      .put("title", "The Hobbit");
     mongoClient.save("books", document, res -> {
-
       if (res.succeeded()) {
-
         mongoClient.distinctBatch("books", "title", String.class.getName())
           .handler(book -> System.out.println("Title is : " + book.getString("title")));
-
       } else {
         res.cause().printStackTrace();
       }
-
     });
   }
 
-  public void example17(MongoClient mongoClient) throws Exception{
-    JsonObject document = new JsonObject().put("title", "The Hobbit")
-            .put("publicationDate", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00"));
+  public void example17(MongoClient mongoClient) {
+    JsonObject document = new JsonObject()
+      .put("title", "The Hobbit")
+      .put("publicationDate", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00"));
     JsonObject query = new JsonObject()
-            .put("publicationDate",
-                    new JsonObject().put("$gte", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00")));
-
+      .put("publicationDate",
+        new JsonObject().put("$gte", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00")));
     mongoClient.save("books", document, res -> {
       if (res.succeeded()) {
-
         mongoClient.distinctWithQuery("books", "title", String.class.getName(), query, res2 -> {
           System.out.println("Title is : " + res2.result().getJsonArray(0));
         });
       }
-
     });
   }
 
-  public void example17_d1(MongoClient mongoClient) throws Exception{
-    JsonObject document = new JsonObject().put("title", "The Hobbit")
-            .put("publicationDate", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00"));
+  public void example17_d1(MongoClient mongoClient) {
+    JsonObject document = new JsonObject()
+      .put("title", "The Hobbit")
+      .put("publicationDate", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00"));
     JsonObject query = new JsonObject()
-            .put("publicationDate",
-                    new JsonObject().put("$gte", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00")));
-
+      .put("publicationDate", new JsonObject()
+        .put("$gte", new JsonObject().put("$date", "1937-09-21T00:00:00+00:00")));
     mongoClient.save("books", document, res -> {
       if (res.succeeded()) {
-
         mongoClient.distinctBatchWithQuery("books", "title", String.class.getName(), query)
           .handler(book -> System.out.println("Title is : " + book.getString("title")));
-
       }
-
     });
   }
 }

--- a/vertx-mongo-client/src/main/java/examples/Examples.java
+++ b/vertx-mongo-client/src/main/java/examples/Examples.java
@@ -19,6 +19,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.docgen.Source;
+import io.vertx.ext.mongo.FindOptions;
 import io.vertx.ext.mongo.MongoClient;
 import io.vertx.ext.mongo.UpdateOptions;
 import org.bson.types.ObjectId;
@@ -180,6 +181,17 @@ public class Examples {
     JsonObject query = new JsonObject()
       .put("author", "J. R. R. Tolkien");
     mongoClient.findBatch("book", query)
+      .exceptionHandler(throwable -> throwable.printStackTrace())
+      .endHandler(v -> System.out.println("End of research"))
+      .handler(doc -> System.out.println("Found doc: " + doc.encodePrettily()));
+  }
+
+  public void findBatchWithOptions(MongoClient mongoClient) {
+    // will match all Tolkien books
+    JsonObject query = new JsonObject()
+      .put("author", "J. R. R. Tolkien");
+    FindOptions options = new FindOptions().setBatchSize(100);
+    mongoClient.findBatchWithOptions("book", query, options)
       .exceptionHandler(throwable -> throwable.printStackTrace())
       .endHandler(v -> System.out.println("End of research"))
       .handler(doc -> System.out.println("Found doc: " + doc.encodePrettily()));

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -1,8 +1,5 @@
 package io.vertx.ext.mongo;
 
-import java.util.List;
-import java.util.UUID;
-
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
@@ -10,7 +7,11 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.streams.ReadStream;
 import io.vertx.ext.mongo.impl.MongoClientImpl;
+
+import java.util.List;
+import java.util.UUID;
 
 /**
  * A Vert.x service used to interact with MongoDB server instances.
@@ -262,10 +263,8 @@ public interface MongoClient {
    *
    * @param collection  the collection
    * @param query  query used to match documents
-   * @param resultHandler  will be provided with each found document
    */
-  @Fluent
-  MongoClient findBatch(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+  ReadStream<JsonObject> findBatch(String collection, JsonObject query);
 
   /**
    * Find matching documents in the specified collection, specifying options
@@ -285,10 +284,8 @@ public interface MongoClient {
    * @param collection  the collection
    * @param query  query used to match documents
    * @param options options to configure the find
-   * @param resultHandler  will be provided with each found document
    */
-  @Fluent
-  MongoClient findBatchWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<JsonObject>> resultHandler);
+  ReadStream<JsonObject> findBatchWithOptions(String collection, JsonObject query, FindOptions options);
 
   /**
    * Find a single matching document in the specified collection
@@ -588,10 +585,8 @@ public interface MongoClient {
    *
    * @param collection  the collection
    * @param fieldName  the field name
-   * @param resultHandler  will be provided with each found value
    */
-  @Fluent
-  MongoClient distinctBatch(String collection, String fieldName, String resultClassname, Handler<AsyncResult<JsonObject>> resultHandler);
+  ReadStream<JsonObject> distinctBatch(String collection, String fieldName, String resultClassname);
 
   /**
    * Gets the distinct values of the specified field name filtered by specified query.
@@ -601,10 +596,8 @@ public interface MongoClient {
    * @param collection  the collection
    * @param fieldName  the field name
    * @param query the query
-   * @param resultHandler  will be provided with each found value
    */
-  @Fluent
-  MongoClient distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+  ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query);
 
   /**
    * Close the client and release its resources

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -604,6 +604,19 @@ public interface MongoClient {
   ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query);
 
   /**
+   * Gets the distinct values of the specified field name filtered by specified query.
+   * This method use batchCursor for returning each found value.
+   * Each value is a json fragment with fieldName key (eg: {"num": 1}).
+   *
+   * @param collection the collection
+   * @param fieldName  the field name
+   * @param query      the query
+   * @param batchSize  the number of documents to load in a batch
+   * @return a {@link ReadStream} emitting json fragments
+   */
+  ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, int batchSize);
+
+  /**
    * Close the client and release its resources
    */
   void close();

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -263,6 +263,7 @@ public interface MongoClient {
    *
    * @param collection  the collection
    * @param query  query used to match documents
+   * @return a {@link ReadStream} emitting found documents
    */
   ReadStream<JsonObject> findBatch(String collection, JsonObject query);
 
@@ -284,6 +285,7 @@ public interface MongoClient {
    * @param collection  the collection
    * @param query  query used to match documents
    * @param options options to configure the find
+   * @return a {@link ReadStream} emitting found documents
    */
   ReadStream<JsonObject> findBatchWithOptions(String collection, JsonObject query, FindOptions options);
 
@@ -585,6 +587,7 @@ public interface MongoClient {
    *
    * @param collection  the collection
    * @param fieldName  the field name
+   * @return a {@link ReadStream} emitting json fragments
    */
   ReadStream<JsonObject> distinctBatch(String collection, String fieldName, String resultClassname);
 
@@ -596,6 +599,7 @@ public interface MongoClient {
    * @param collection  the collection
    * @param fieldName  the field name
    * @param query the query
+   * @return a {@link ReadStream} emitting json fragments
    */
   ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query);
 

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -691,7 +691,8 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     Bson bquery = wrap(encodedQuery);
 
     MongoCollection<JsonObject> mongoCollection = getCollection(collection);
-    return mongoCollection.distinct(fieldName, bquery, Class.forName(resultClassname));
+    Class<?> resultClass = this.getClass().getClassLoader().loadClass(resultClassname);
+    return mongoCollection.distinct(fieldName, bquery, resultClass);
   }
 
 

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -271,7 +271,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     requireNonNull(collection, "collection cannot be null");
     requireNonNull(query, "query cannot be null");
     FindIterable<JsonObject> view = doFind(collection, query, options);
-    return new MongoIterableStream(vertx.getOrCreateContext(), view);
+    return new MongoIterableStream(vertx.getOrCreateContext(), view, options.getBatchSize());
   }
 
   @Override
@@ -653,10 +653,15 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
 
   @Override
   public ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query) {
+    return distinctBatchWithQuery(collection, fieldName, resultClassname, query, FindOptions.DEFAULT_BATCH_SIZE);
+  }
+
+  @Override
+  public ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, int batchSize) {
     try {
       MongoIterable<JsonObject> distinctValues = findDistinctValuesWithQuery(collection, fieldName, resultClassname, query)
         .map(value -> new JsonObject().put(fieldName, value));
-      return new MongoIterableStream(vertx.getOrCreateContext(), distinctValues);
+      return new MongoIterableStream(vertx.getOrCreateContext(), distinctValues, batchSize);
     } catch (ClassNotFoundException e) {
       return new FailedStream(e);
     }

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoIterableStream.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoIterableStream.java
@@ -1,0 +1,186 @@
+package io.vertx.ext.mongo.impl;
+
+import com.mongodb.async.AsyncBatchCursor;
+import com.mongodb.async.SingleResultCallback;
+import com.mongodb.async.client.MongoIterable;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.streams.ReadStream;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author Thomas Segismont
+ */
+class MongoIterableStream implements ReadStream<JsonObject> {
+
+  private static final int BATCH_SIZE = 10;
+
+  private final Context context;
+  private final MongoIterable<JsonObject> mongoIterable;
+
+  private AsyncBatchCursor<JsonObject> batchCursor;
+  private Deque<JsonObject> queue;
+  private Handler<JsonObject> dataHandler;
+  private Handler<Throwable> exceptionHandler;
+  private Handler<Void> endHandler;
+  private boolean paused;
+  private boolean readInProgress;
+  private boolean closed;
+
+  MongoIterableStream(Context context, MongoIterable<JsonObject> mongoIterable) {
+    this.context = context;
+    this.mongoIterable = mongoIterable;
+  }
+
+  @Override
+  public synchronized MongoIterableStream exceptionHandler(Handler<Throwable> handler) {
+    checkClosed();
+    this.exceptionHandler = handler;
+    return this;
+  }
+
+  private void checkClosed() {
+    if (closed) {
+      throw new IllegalArgumentException("Stream is closed");
+    }
+  }
+
+  @Override
+  public synchronized MongoIterableStream handler(Handler<JsonObject> handler) {
+    checkClosed();
+    if (handler == null) {
+      close();
+    } else {
+      dataHandler = handler;
+      SingleResultCallback<AsyncBatchCursor<JsonObject>> callback = (result, t) -> {
+        context.runOnContext(v -> {
+          synchronized (this) {
+            if (t != null) {
+              close();
+              handleException(t);
+            } else {
+              batchCursor = result;
+              if (canRead()) {
+                doRead();
+              }
+            }
+          }
+        });
+      };
+      try {
+        mongoIterable.batchCursor(callback);
+      } catch (Exception e) {
+        close();
+        handleException(e);
+      }
+    }
+    return this;
+  }
+
+  private boolean canRead() {
+    return !paused && !closed;
+  }
+
+  @Override
+  public synchronized MongoIterableStream pause() {
+    checkClosed();
+    paused = true;
+    return this;
+  }
+
+  @Override
+  public synchronized MongoIterableStream resume() {
+    checkClosed();
+    if (paused) {
+      paused = false;
+      if (dataHandler != null) {
+        doRead();
+      }
+    }
+    return this;
+  }
+
+  private synchronized void doRead() {
+    if (readInProgress) {
+      return;
+    }
+    readInProgress = true;
+    if (queue == null) {
+      queue = new ArrayDeque<>(BATCH_SIZE);
+    }
+    if (!queue.isEmpty()) {
+      context.runOnContext(v -> emitQueued());
+      return;
+    }
+    batchCursor.setBatchSize(BATCH_SIZE);
+    context.<List<JsonObject>>executeBlocking(fut -> {
+      batchCursor.next((result, t) -> {
+        if (t != null) {
+          fut.fail(t);
+        } else {
+          fut.complete(result == null ? Collections.emptyList() : result);
+        }
+      });
+    }, false, ar -> {
+      synchronized (this) {
+        if (ar.succeeded()) {
+          queue.addAll(ar.result());
+          if (queue.isEmpty()) {
+            close();
+            if (endHandler != null) {
+              endHandler.handle(null);
+            }
+          } else {
+            emitQueued();
+          }
+        } else {
+          close();
+          handleException(ar.cause());
+        }
+      }
+    });
+  }
+
+  private void handleException(Throwable cause) {
+    if (exceptionHandler != null) {
+      exceptionHandler.handle(cause);
+    }
+  }
+
+  private synchronized void emitQueued() {
+    while (!queue.isEmpty() && canRead()) {
+      dataHandler.handle(queue.remove());
+    }
+    readInProgress = false;
+    if (canRead()) {
+      doRead();
+    }
+  }
+
+  @Override
+  public synchronized MongoIterableStream endHandler(Handler<Void> handler) {
+    endHandler = handler;
+    return this;
+  }
+
+  private void close() {
+    closed = true;
+    AtomicReference<AsyncBatchCursor> cursorRef = new AtomicReference<>();
+    context.executeBlocking(fut -> {
+      synchronized (this) {
+        cursorRef.set(batchCursor);
+      }
+      AsyncBatchCursor cursor = cursorRef.get();
+      if (cursor != null) {
+        cursor.close();
+      }
+      fut.complete();
+    }, false, null);
+  }
+}

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoIterableStream.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoIterableStream.java
@@ -24,6 +24,7 @@ class MongoIterableStream implements ReadStream<JsonObject> {
   private final Context context;
   private final MongoIterable<JsonObject> mongoIterable;
 
+  // All the following fields are guarded by this instance
   private AsyncBatchCursor<JsonObject> batchCursor;
   private Deque<JsonObject> queue;
   private Handler<JsonObject> dataHandler;
@@ -45,6 +46,7 @@ class MongoIterableStream implements ReadStream<JsonObject> {
     return this;
   }
 
+  // Always called from a synchronized method or block
   private void checkClosed() {
     if (closed) {
       throw new IllegalArgumentException("Stream is closed");
@@ -84,6 +86,7 @@ class MongoIterableStream implements ReadStream<JsonObject> {
     return this;
   }
 
+  // Always called from a synchronized method or block
   private boolean canRead() {
     return !paused && !closed;
   }
@@ -107,6 +110,7 @@ class MongoIterableStream implements ReadStream<JsonObject> {
     return this;
   }
 
+  // Always called from a synchronized method or block
   private synchronized void doRead() {
     if (readInProgress) {
       return;
@@ -147,12 +151,14 @@ class MongoIterableStream implements ReadStream<JsonObject> {
     });
   }
 
+  // Always called from a synchronized method or block
   private void handleException(Throwable cause) {
     if (exceptionHandler != null) {
       exceptionHandler.handle(cause);
     }
   }
 
+  // Always called from a synchronized method or block
   private synchronized void emitQueued() {
     while (!queue.isEmpty() && canRead()) {
       dataHandler.handle(queue.remove());
@@ -169,6 +175,7 @@ class MongoIterableStream implements ReadStream<JsonObject> {
     return this;
   }
 
+  // Always called from a synchronized method or block
   private void close() {
     closed = true;
     AtomicReference<AsyncBatchCursor> cursorRef = new AtomicReference<>();

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoIterableStream.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoIterableStream.java
@@ -66,6 +66,7 @@ class MongoIterableStream implements ReadStream<JsonObject> {
               handleException(t);
             } else {
               batchCursor = result;
+              batchCursor.setBatchSize(BATCH_SIZE);
               if (canRead()) {
                 doRead();
               }
@@ -118,7 +119,6 @@ class MongoIterableStream implements ReadStream<JsonObject> {
       context.runOnContext(v -> emitQueued());
       return;
     }
-    batchCursor.setBatchSize(BATCH_SIZE);
     context.<List<JsonObject>>executeBlocking(fut -> {
       batchCursor.next((result, t) -> {
         if (t != null) {

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
@@ -248,18 +248,28 @@
  * `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
  * `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
  *
- * === Find in batches
+ * === Finding documents in batches
  *
  * When dealing with large data sets, it is not advised to use the
  * {@link io.vertx.ext.mongo.MongoClient#find} and
  * {@link io.vertx.ext.mongo.MongoClient#findWithOptions} methods.
  * In order to avoid inflating the whole response into memory, use {@link io.vertx.ext.mongo.MongoClient#findBatch}:
  *
+ * [source,$lang]
  * ----
  * {@link examples.Examples#findBatch}
  * ----
  *
  * The matching documents are emitted one by one by the {@link io.vertx.core.streams.ReadStream} handler.
+ *
+ * {@link io.vertx.ext.mongo.FindOptions} has an extra parameter `batchSize` which you can use to set the number of documents to load at once:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.Examples#findBatchWithOptions}
+ * ----
+ *
+ * By default, `batchSize` is set to 20.
  *
  * === Finding a single document
  *
@@ -425,6 +435,7 @@
  *
  * *Specific driver configuration options*
  *
+ * [source,js]
  * ----
  * {
  *   // Single Cluster Settings

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/package-info.java
@@ -120,8 +120,8 @@
  *
  * To save a document you use {@link io.vertx.ext.mongo.MongoClient#save}.
  *
- * If the document has no `\_id` field, it is inserted, otherwise, it is _upserted_. Upserted means it is inserted
- * if it doesn't already exist, otherwise it is updated.
+ * If the document has no `\_id` field, it is inserted, otherwise, it is __upserted__.
+ * Upserted means it is inserted if it doesn't already exist, otherwise it is updated.
  *
  * If the document is inserted and has no id, then the id field generated will be returned to the result handler.
  *
@@ -150,7 +150,7 @@
  * {@link examples.Examples#example3}
  * ----
  *
- * If a document is inserted with an id, and a document with that id already eists, the insert will fail:
+ * If a document is inserted with an id, and a document with that id already exists, the insert will fail:
  *
  * [source,$lang]
  * ----
@@ -159,11 +159,12 @@
  *
  * === Updating documents
  *
- * To update a documents you use {@link io.vertx.ext.mongo.MongoClient#update}.
+ * To update a documents you use {@link io.vertx.ext.mongo.MongoClient#updateCollection}.
  *
- * This updates one or multiple documents in a collection. The json object that is passed in the `update`
- * parameter must contain http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators] and determines
- * how the object is updated.
+ * This updates one or multiple documents in a collection.
+ * The json object that is passed in the `updateCollection` parameter must contain
+ * http://docs.mongodb.org/manual/reference/operator/update-field/[Update Operators]
+ * and determines how the object is updated.
  *
  * The json object specified in the query parameter determines which documents in the collection will be updated.
  *
@@ -174,7 +175,8 @@
  * {@link examples.Examples#example5}
  * ----
  *
- * To specify if the update should upsert or update multiple documents, use {@link io.vertx.ext.mongo.MongoClient#updateWithOptions}
+ * To specify if the update should upsert or update multiple documents, use
+ * {@link io.vertx.ext.mongo.MongoClient#updateCollectionWithOptions}
  * and pass in an instance of {@link io.vertx.ext.mongo.UpdateOptions}.
  *
  * This has the following fields:
@@ -190,9 +192,9 @@
  *
  * === Replacing documents
  *
- * To replace documents you use {@link io.vertx.ext.mongo.MongoClient#replace}.
+ * To replace documents you use {@link io.vertx.ext.mongo.MongoClient#replaceDocuments}.
  *
- * This is similar to the update operation, however it does not take any update operators like `update`.
+ * This is similar to the update operation, however it does not take any operator.
  * Instead it replaces the entire document with the one provided.
  *
  * Here's an example of replacing a document in the books collection
@@ -206,12 +208,13 @@
  *
  * To execute multiple insert, update, replace, or delete operations at once, use {@link io.vertx.ext.mongo.MongoClient#bulkWrite}.
  *
- * You can pass a list of {@link io.vertx.ext.mongo.BulkOperation BulkOperations}, with each working similiar to the matching single operations.
+ * You can pass a list of {@link io.vertx.ext.mongo.BulkOperation BulkOperations}, with each working similar to the matching single operation.
  * You can pass as many operations, even of the same type, as you wish.
  *
  * To specify if the bulk operation should be executed in order, and with what write option, use {@link io.vertx.ext.mongo.MongoClient#bulkWriteWithOptions}
  * and pass an instance of {@link io.vertx.ext.mongo.BulkWriteOptions}.
- * For more explanation what ordered means, see https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations
+ * For more explanation what ordered means, see
+ * https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#execution-of-operations[Execution of Operations].
  *
  * === Finding documents
  *
@@ -245,11 +248,18 @@
  * `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
  * `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
  *
+ * === Find in batches
+ *
+ * When dealing with large data sets, it is not advised to use the
+ * {@link io.vertx.ext.mongo.MongoClient#find} and
+ * {@link io.vertx.ext.mongo.MongoClient#findWithOptions} methods.
+ * In order to avoid inflating the whole response into memory, use {@link io.vertx.ext.mongo.MongoClient#findBatch}:
+ *
  * ----
- * {@link examples.Examples#example9_1}
+ * {@link examples.Examples#findBatch}
  * ----
  *
- * The matching documents are returned unitary in the result handler.
+ * The matching documents are emitted one by one by the {@link io.vertx.core.streams.ReadStream} handler.
  *
  * === Finding a single document
  *
@@ -319,7 +329,7 @@
  *
  * You can run arbitrary MongoDB commands with {@link io.vertx.ext.mongo.MongoClient#runCommand}.
  *
- * Commands can be used to run more advanced mongoDB features, such as using MapReduce.
+ * Commands can be used to run more advanced MongoDB features, such as using MapReduce.
  * For more information see the mongo docs for supported http://docs.mongodb.org/manual/reference/command[Commands].
  *
  * Here's an example of running an aggregate command. Note that the command name must be specified as a parameter
@@ -334,9 +344,10 @@
  *
  * === MongoDB Extended JSON support
  *
- * For now, only date, oid and binary types are supported (cf http://docs.mongodb.org/manual/reference/mongodb-extended-json )
+ * For now, only `date`, `oid` and `binary` types are supported
+ * (see http://docs.mongodb.org/manual/reference/mongodb-extended-json[MongoDB Extended JSON]).
  *
- * Here's an example of inserting a document with a date field
+ * Here's an example of inserting a document with a `date` field:
  *
  * [source,$lang]
  * ----
@@ -362,6 +373,9 @@
  * ----
  * {@link examples.Examples#example15_dl}
  * ----
+ *
+ * === Getting distinct values
+ *
  * Here's an example of getting distinct value
  *
  * [source,$lang]
@@ -394,7 +408,7 @@
  * The following configuration is supported by the mongo client:
  *
  *
- * `db_name`:: Name of the database in the mongoDB instance to use. Defaults to `default_db`
+ * `db_name`:: Name of the database in the MongoDB instance to use. Defaults to `default_db`
  * `useObjectId`:: Toggle this option to support persisting and retrieving ObjectId's as strings. If `true`, hex-strings will
  * be saved as native Mongodb ObjectId types in the document collection. This will allow the sorting of documents based on creation
  * time. You can also derive the creation time from the hex-string using ObjectId::getDate(). Set to `false` for other types of your choosing.
@@ -474,12 +488,12 @@
  *
  * *Driver option descriptions*
  *
- * `host`:: The host the mongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
- * `port`:: The port the mongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
- * `hosts`:: An array representing the hosts and ports to support a mongoDB cluster (sharding / replication)
+ * `host`:: The host the MongoDB instance is running. Defaults to `127.0.0.1`. This is ignored if `hosts` is specified
+ * `port`:: The port the MongoDB instance is listening on. Defaults to `27017`. This is ignored if `hosts` is specified
+ * `hosts`:: An array representing the hosts and ports to support a MongoDB cluster (sharding / replication)
  * `host`:: A host in the cluster
  * `port`:: The port a host in the cluster is listening on
- * `replicaSet`:: The name of the replica set, if the mongoDB instance is a member of a replica set
+ * `replicaSet`:: The name of the replica set, if the MongoDB instance is a member of a replica set
  * `serverSelectionTimeoutMS`:: The time in milliseconds that the mongo driver will wait to select a server for an operation before raising an error.
  * `maxPoolSize`:: The maximum number of connections in the connection pool. The default value is `100`
  * `minPoolSize`:: The minimum number of connections in the connection pool. The default value is `0`

--- a/vertx-mongo-client/src/main/kotlin/io/vertx/kotlin/ext/mongo/FindOptions.kt
+++ b/vertx-mongo-client/src/main/kotlin/io/vertx/kotlin/ext/mongo/FindOptions.kt
@@ -7,6 +7,7 @@ import io.vertx.ext.mongo.FindOptions
  *
  * Options used to configure find operations.
  *
+ * @param batchSize  Set the batch size for methods loading found data in batches.
  * @param fields  Set the fields
  * @param limit  Set the limit
  * @param skip  Set the skip
@@ -16,11 +17,15 @@ import io.vertx.ext.mongo.FindOptions
  * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.FindOptions original] using Vert.x codegen.
  */
 fun FindOptions(
+  batchSize: Int? = null,
   fields: io.vertx.core.json.JsonObject? = null,
   limit: Int? = null,
   skip: Int? = null,
   sort: io.vertx.core.json.JsonObject? = null): FindOptions = io.vertx.ext.mongo.FindOptions().apply {
 
+  if (batchSize != null) {
+    this.setBatchSize(batchSize)
+  }
   if (fields != null) {
     this.setFields(fields)
   }

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/FindOptionsTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/FindOptionsTest.java
@@ -34,10 +34,12 @@ public class FindOptionsTest {
   @Test
   public void testDefaultOptions() {
     FindOptions options = new FindOptions();
-    assertNull(options.getFields());
-    assertNull(options.getSort());
-    assertEquals(-1, options.getLimit());
-    assertEquals(0, options.getSkip());
+    assertNotNull(options.getFields());
+    assertTrue(options.getFields().isEmpty());
+    assertNotNull(options.getSort());
+    assertTrue(options.getSort().isEmpty());
+    assertEquals(FindOptions.DEFAULT_LIMIT, options.getLimit());
+    assertEquals(FindOptions.DEFAULT_SKIP, options.getSkip());
   }
 
   @Test

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
@@ -38,13 +38,10 @@ public class MongoClientTest extends MongoClientTestBase {
     List<String> foos = new ArrayList<>();
     mongoClient.createCollection(collection, onSuccess(res -> {
       insertDocs(mongoClient, collection, numDocs, onSuccess(res2 -> {
-          mongoClient.findBatchWithOptions(collection, new JsonObject(), new FindOptions().setSort(new JsonObject().put("foo", 1)), onSuccess(result -> {
-            if (result == null) {
-              latch.countDown();
-            } else {
-              foos.add(result.getString("foo"));
-            }
-          }));
+        mongoClient.findBatchWithOptions(collection, new JsonObject(), new FindOptions().setSort(new JsonObject().put("foo", 1)))
+          .exceptionHandler(this::fail)
+          .endHandler(v -> latch.countDown())
+          .handler(result -> foos.add(result.getString("foo")));
       }));
     }));
     awaitLatch(latch);

--- a/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/MongoService.java
+++ b/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/MongoService.java
@@ -1,8 +1,7 @@
 package io.vertx.ext.mongo;
 
-import java.util.List;
-
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.ProxyIgnore;
 import io.vertx.codegen.annotations.VertxGen;
@@ -11,7 +10,10 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.streams.ReadStream;
 import io.vertx.serviceproxy.ProxyHelper;
+
+import java.util.List;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -99,16 +101,20 @@ public interface MongoService extends MongoClient {
   MongoService find(String collection, JsonObject query, Handler<AsyncResult<List<JsonObject>>> resultHandler);
 
   @Override
-  @Fluent
-  MongoService findBatch(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+  @GenIgnore
+  default ReadStream<JsonObject> findBatch(String collection, JsonObject query) {
+    throw new UnsupportedOperationException();
+  }
 
   @Override
   @Fluent
   MongoService findWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<List<JsonObject>>> resultHandler);
 
   @Override
-  @Fluent
-  MongoService findBatchWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<JsonObject>> resultHandler);
+  @GenIgnore
+  default ReadStream<JsonObject> findBatchWithOptions(String collection, JsonObject query, FindOptions options) {
+    throw new UnsupportedOperationException();
+  }
 
   @Override
   @Fluent
@@ -215,16 +221,20 @@ public interface MongoService extends MongoClient {
   MongoService distinct(String collection, String fieldName, String resultClassname, Handler<AsyncResult<JsonArray>> resultHandler);
 
   @Override
-  @Fluent
-  MongoService distinctBatch(String collection, String fieldName, String resultClassname, Handler<AsyncResult<JsonObject>> resultHandler);
+  @GenIgnore
+  default ReadStream<JsonObject> distinctBatch(String collection, String fieldName, String resultClassname) {
+    throw new UnsupportedOperationException();
+  }
 
   @Override
   @Fluent
   MongoService distinctWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonArray>> resultHandler);
 
   @Override
-  @Fluent
-  MongoService distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+  @GenIgnore
+  default ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query) {
+    throw new UnsupportedOperationException();
+  }
 
   @Override
   @ProxyIgnore

--- a/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/MongoService.java
+++ b/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/MongoService.java
@@ -237,6 +237,12 @@ public interface MongoService extends MongoClient {
   }
 
   @Override
+  @GenIgnore
+  default ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, int batchSize) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   @ProxyIgnore
   void close();
 }

--- a/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/impl/MongoServiceImpl.java
+++ b/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/impl/MongoServiceImpl.java
@@ -1,7 +1,5 @@
 package io.vertx.ext.mongo.impl;
 
-import java.util.List;
-
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -18,6 +16,8 @@ import io.vertx.ext.mongo.MongoClientUpdateResult;
 import io.vertx.ext.mongo.MongoService;
 import io.vertx.ext.mongo.UpdateOptions;
 import io.vertx.ext.mongo.WriteOption;
+
+import java.util.List;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -152,23 +152,10 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  public MongoService findBatch(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler) {
-    client.findBatch(collection, query, resultHandler);
-    return this;
-  }
-
-  @Override
   @Fluent
   public MongoService findWithOptions(String collection, JsonObject query, FindOptions options,
       Handler<AsyncResult<List<JsonObject>>> resultHandler) {
     client.findWithOptions(collection, query, options, resultHandler);
-    return this;
-  }
-
-  @Override
-  public MongoService findBatchWithOptions(String collection, JsonObject query, FindOptions options,
-      Handler<AsyncResult<JsonObject>> resultHandler) {
-    client.findBatchWithOptions(collection, query, options, resultHandler);
     return this;
   }
 
@@ -367,20 +354,6 @@ public class MongoServiceImpl implements MongoService {
   @Override
   public MongoService distinctWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonArray>> resultHandler) {
     client.distinctWithQuery(collection, fieldName, resultClassname, query, resultHandler);
-    return this;
-  }
-
-  @Override
-  @Fluent
-  public MongoService distinctBatch(String collection, String fieldName, String resultClassname,
-      Handler<AsyncResult<JsonObject>> resultHandler) {
-    client.distinctBatch(collection, fieldName, resultClassname, resultHandler);
-    return this;
-  }
-
-  @Override
-  public MongoService distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler) {
-    client.distinctBatchWithQuery(collection, fieldName, resultClassname, query, resultHandler);
     return this;
   }
 

--- a/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/impl/MongoServiceImpl.java
+++ b/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/impl/MongoServiceImpl.java
@@ -1,6 +1,5 @@
 package io.vertx.ext.mongo.impl;
 
-import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
@@ -31,14 +30,12 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService save(String collection, JsonObject document, Handler<AsyncResult<String>> resultHandler) {
     client.save(collection, document, resultHandler);
     return this;
   }
 
   @Override
-  @Fluent
   public MongoService saveWithOptions(String collection, JsonObject document, WriteOption writeOption,
       Handler<AsyncResult<String>> resultHandler) {
     client.saveWithOptions(collection, document, writeOption, resultHandler);
@@ -46,14 +43,12 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService insert(String collection, JsonObject document, Handler<AsyncResult<String>> resultHandler) {
     client.insert(collection, document, resultHandler);
     return this;
   }
 
   @Override
-  @Fluent
   public MongoService insertWithOptions(String collection, JsonObject document, WriteOption writeOption,
       Handler<AsyncResult<String>> resultHandler) {
     client.insertWithOptions(collection, document, writeOption, resultHandler);
@@ -62,7 +57,6 @@ public class MongoServiceImpl implements MongoService {
 
   @Deprecated
   @Override
-  @Fluent
   public MongoService update(String collection, JsonObject query, JsonObject update,
       Handler<AsyncResult<Void>> resultHandler) {
     client.update(collection, query, update, resultHandler);
@@ -70,7 +64,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService updateCollection(String collection, JsonObject query, JsonObject update,
       Handler<AsyncResult<MongoClientUpdateResult>> resultHandler) {
     client.updateCollection(collection, query, update, resultHandler);
@@ -79,7 +72,6 @@ public class MongoServiceImpl implements MongoService {
 
   @Deprecated
   @Override
-  @Fluent
   public MongoService updateWithOptions(String collection, JsonObject query, JsonObject update, UpdateOptions options,
       Handler<AsyncResult<Void>> resultHandler) {
     client.updateWithOptions(collection, query, update, options, resultHandler);
@@ -87,7 +79,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService updateCollectionWithOptions(String collection, JsonObject query, JsonObject update,
       UpdateOptions options, Handler<AsyncResult<MongoClientUpdateResult>> resultHandler) {
     client.updateCollectionWithOptions(collection, query, update, options, resultHandler);
@@ -96,7 +87,6 @@ public class MongoServiceImpl implements MongoService {
 
   @Deprecated
   @Override
-  @Fluent
   public MongoService replace(String collection, JsonObject query, JsonObject replace,
       Handler<AsyncResult<Void>> resultHandler) {
     client.replace(collection, query, replace, resultHandler);
@@ -104,7 +94,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService replaceDocuments(String collection, JsonObject query, JsonObject replace,
       Handler<AsyncResult<MongoClientUpdateResult>> resultHandler) {
     client.replaceDocuments(collection, query, replace, resultHandler);
@@ -113,7 +102,6 @@ public class MongoServiceImpl implements MongoService {
 
   @Deprecated
   @Override
-  @Fluent
   public MongoService replaceWithOptions(String collection, JsonObject query, JsonObject replace, UpdateOptions options,
       Handler<AsyncResult<Void>> resultHandler) {
     client.replaceWithOptions(collection, query, replace, options, resultHandler);
@@ -121,7 +109,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService replaceDocumentsWithOptions(String collection, JsonObject query, JsonObject replace,
       UpdateOptions options, Handler<AsyncResult<MongoClientUpdateResult>> resultHandler) {
     client.replaceDocumentsWithOptions(collection, query, replace, options, resultHandler);
@@ -129,7 +116,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService bulkWrite(String collection, List<BulkOperation> operations,
       Handler<AsyncResult<MongoClientBulkWriteResult>> resultHandler) {
     client.bulkWrite(collection, operations, resultHandler);
@@ -137,7 +123,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService bulkWriteWithOptions(String collection, List<BulkOperation> operations,
       BulkWriteOptions bulkWriteOptions, Handler<AsyncResult<MongoClientBulkWriteResult>> resultHandler) {
     client.bulkWriteWithOptions(collection, operations, bulkWriteOptions, resultHandler);
@@ -145,14 +130,12 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService find(String collection, JsonObject query, Handler<AsyncResult<List<JsonObject>>> resultHandler) {
     client.find(collection, query, resultHandler);
     return this;
   }
 
   @Override
-  @Fluent
   public MongoService findWithOptions(String collection, JsonObject query, FindOptions options,
       Handler<AsyncResult<List<JsonObject>>> resultHandler) {
     client.findWithOptions(collection, query, options, resultHandler);
@@ -160,7 +143,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService findOne(String collection, JsonObject query, JsonObject fields,
       Handler<AsyncResult<JsonObject>> resultHandler) {
     client.findOne(collection, query, fields, resultHandler);
@@ -168,7 +150,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService findOneAndUpdate(String collection, JsonObject query, JsonObject update,
       Handler<AsyncResult<JsonObject>> resultHandler) {
     client.findOneAndUpdate(collection, query, update, resultHandler);
@@ -176,7 +157,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService findOneAndUpdateWithOptions(String collection, JsonObject query, JsonObject update,
       FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler) {
     client.findOneAndUpdateWithOptions(collection, query, update, findOptions, updateOptions, resultHandler);
@@ -184,7 +164,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService findOneAndReplace(String collection, JsonObject query, JsonObject replace,
       Handler<AsyncResult<JsonObject>> resultHandler) {
     client.findOneAndReplace(collection, query, replace, resultHandler);
@@ -192,7 +171,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService findOneAndReplaceWithOptions(String collection, JsonObject query, JsonObject update,
       FindOptions findOptions, UpdateOptions updateOptions, Handler<AsyncResult<JsonObject>> resultHandler) {
     client.findOneAndReplaceWithOptions(collection, query, update, findOptions, updateOptions, resultHandler);
@@ -200,7 +178,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService findOneAndDelete(String collection, JsonObject query,
       Handler<AsyncResult<JsonObject>> resultHandler) {
     client.findOneAndDelete(collection, query, resultHandler);
@@ -208,7 +185,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService findOneAndDeleteWithOptions(String collection, JsonObject query, FindOptions findOptions,
       Handler<AsyncResult<JsonObject>> resultHandler) {
     client.findOneAndDeleteWithOptions(collection, query, findOptions, resultHandler);
@@ -216,7 +192,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService count(String collection, JsonObject query, Handler<AsyncResult<Long>> resultHandler) {
     client.count(collection, query, resultHandler);
     return this;
@@ -224,7 +199,6 @@ public class MongoServiceImpl implements MongoService {
 
   @Deprecated
   @Override
-  @Fluent
   public MongoService remove(String collection, JsonObject query, Handler<AsyncResult<Void>> resultHandler) {
     client.remove(collection, query, resultHandler);
     return this;
@@ -239,7 +213,6 @@ public class MongoServiceImpl implements MongoService {
 
   @Deprecated
   @Override
-  @Fluent
   public MongoService removeWithOptions(String collection, JsonObject query, WriteOption writeOption,
       Handler<AsyncResult<Void>> resultHandler) {
     client.removeWithOptions(collection, query, writeOption, resultHandler);
@@ -247,7 +220,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService removeDocumentsWithOptions(String collection, JsonObject query, WriteOption writeOption,
       Handler<AsyncResult<MongoClientDeleteResult>> resultHandler) {
     client.removeDocumentsWithOptions(collection, query, writeOption, resultHandler);
@@ -256,14 +228,12 @@ public class MongoServiceImpl implements MongoService {
 
   @Deprecated
   @Override
-  @Fluent
   public MongoService removeOne(String collection, JsonObject query, Handler<AsyncResult<Void>> resultHandler) {
     client.removeOne(collection, query, resultHandler);
     return this;
   }
 
   @Override
-  @Fluent
   public MongoService removeDocument(String collection, JsonObject query,
       Handler<AsyncResult<MongoClientDeleteResult>> resultHandler) {
     client.removeDocument(collection, query, resultHandler);
@@ -272,7 +242,6 @@ public class MongoServiceImpl implements MongoService {
 
   @Deprecated
   @Override
-  @Fluent
   public MongoService removeOneWithOptions(String collection, JsonObject query, WriteOption writeOption,
       Handler<AsyncResult<Void>> resultHandler) {
     client.removeOneWithOptions(collection, query, writeOption, resultHandler);
@@ -280,7 +249,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService removeDocumentWithOptions(String collection, JsonObject query, WriteOption writeOption,
       Handler<AsyncResult<MongoClientDeleteResult>> resultHandler) {
     client.removeDocumentWithOptions(collection, query, writeOption, resultHandler);
@@ -288,35 +256,30 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService createCollection(String collectionName, Handler<AsyncResult<Void>> resultHandler) {
     client.createCollection(collectionName, resultHandler);
     return this;
   }
 
   @Override
-  @Fluent
   public MongoService getCollections(Handler<AsyncResult<List<String>>> resultHandler) {
     client.getCollections(resultHandler);
     return this;
   }
 
   @Override
-  @Fluent
   public MongoService dropCollection(String collection, Handler<AsyncResult<Void>> resultHandler) {
     client.dropCollection(collection, resultHandler);
     return this;
   }
 
   @Override
-  @Fluent
   public MongoService createIndex(String collection, JsonObject key, Handler<AsyncResult<Void>> resultHandler) {
     client.createIndex(collection, key, resultHandler);
     return this;
   }
 
   @Override
-  @Fluent
   public MongoService createIndexWithOptions(String collection, JsonObject key, IndexOptions options,
       Handler<AsyncResult<Void>> resultHandler) {
     client.createIndexWithOptions(collection, key, options, resultHandler);
@@ -336,7 +299,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService runCommand(String commandName, JsonObject command,
       Handler<AsyncResult<JsonObject>> resultHandler) {
     client.runCommand(commandName, command, resultHandler);
@@ -344,7 +306,6 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  @Fluent
   public MongoService distinct(String collection, String fieldName, String resultClassname,
       Handler<AsyncResult<JsonArray>> resultHandler) {
     client.distinct(collection, fieldName, resultClassname, resultHandler);


### PR DESCRIPTION
Fixes #110 

The `xxxBatch` methods implementation use async result handlers incorrectly: such handlers should be called just once.

Instead, they should return a `ReadStream`, which brings:
- backpressure support
- RxJava support (via `ReadStream.toFlowable`)

Note that `MongoService` cannot implement them since `ReadStream` are not supported in service proxies.