### PR TITLE
Improve ssl support

### DIFF
--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParser.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParser.java
@@ -52,6 +52,9 @@ public class MongoClientOptionsParser {
     SocketSettings socketSettings = new SocketSettingsParser(connectionString, config).settings();
     options.socketSettings(socketSettings);
 
+    // Transport type
+    new StreamTypeParser(connectionString, config).streamFactory().ifPresent(options::streamFactoryFactory);
+
     // SSLSettings
     SslSettings sslSettings = new SSLSettingsParser(connectionString, config).settings();
     options.sslSettings(sslSettings);

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/SSLSettingsParser.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/SSLSettingsParser.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
-public class SSLSettingsParser {
+class SSLSettingsParser {
   private final ConnectionString connectionString;
   private final JsonObject config;
 

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/SSLSettingsParser.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/SSLSettingsParser.java
@@ -4,28 +4,36 @@ import com.mongodb.ConnectionString;
 import com.mongodb.connection.SslSettings;
 import io.vertx.core.json.JsonObject;
 
+import java.util.Optional;
+
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
 public class SSLSettingsParser {
-  private final SslSettings settings;
+  private final ConnectionString connectionString;
+  private final JsonObject config;
 
-  public SSLSettingsParser(ConnectionString connectionString, JsonObject config) {
-    SslSettings.Builder settings = SslSettings.builder();
-    Boolean ssl;
-    if (connectionString != null) {
-      ssl = connectionString.getSslEnabled();
-    } else {
-      ssl = config.getBoolean("ssl");
-    }
-
-    if (ssl != null) {
-      settings.enabled(ssl);
-    }
-    this.settings = settings.build();
+  SSLSettingsParser(ConnectionString connectionString, JsonObject config) {
+    this.connectionString = connectionString;
+    this.config = config;
   }
 
   public SslSettings settings() {
-    return settings;
+    return fromConnectionString().orElseGet(this::fromConfiguration);
+  }
+
+  private Optional<SslSettings> fromConnectionString() {
+    return Optional.ofNullable(connectionString).map(cs ->
+      SslSettings.builder()
+        .applyConnectionString(cs)
+        .build()
+    );
+  }
+
+  private SslSettings fromConfiguration() {
+    return SslSettings.builder()
+      .enabled(config.getBoolean("ssl", false))
+      .invalidHostNameAllowed(config.getBoolean("sslInvalidHostNameAllowed", false))
+      .build();
   }
 }

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/StreamTypeParser.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/config/StreamTypeParser.java
@@ -1,0 +1,66 @@
+package io.vertx.ext.mongo.impl.config;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.connection.AsynchronousSocketChannelStreamFactoryFactory;
+import com.mongodb.connection.StreamFactoryFactory;
+import com.mongodb.connection.netty.NettyStreamFactoryFactory;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Optional;
+
+class StreamTypeParser {
+  private final ConnectionString connectionString;
+  private final JsonObject config;
+
+  StreamTypeParser(ConnectionString connectionString, JsonObject config) {
+    this.connectionString = connectionString;
+    this.config = config;
+  }
+
+  Optional<StreamFactoryFactory> streamFactory() {
+    return fromConnectionString().map(this::lift).orElseGet(this::fromConfiguration);
+  }
+
+  private Optional<StreamFactoryFactory> fromConnectionString() {
+    return Optional.ofNullable(connectionString)
+      .flatMap(cs -> Optional.ofNullable(cs.getStreamType()))
+      .map(StreamType::parse)
+      .map(StreamType::streamFactory);
+  }
+
+  private Optional<StreamFactoryFactory> lift(StreamFactoryFactory factory) {
+    return Optional.ofNullable(factory);
+  }
+
+  private Optional<StreamFactoryFactory> fromConfiguration() {
+    return Optional.ofNullable(config.getString("streamType"))
+      .map(StreamType::parse)
+      .map(StreamType::streamFactory);
+  }
+
+  private enum StreamType {
+    NIO2 {
+      @Override
+      StreamFactoryFactory streamFactory() {
+        return AsynchronousSocketChannelStreamFactoryFactory.builder().build();
+      }
+    },
+
+    NETTY {
+      @Override
+      StreamFactoryFactory streamFactory() {
+        return NettyStreamFactoryFactory.builder().build();
+      }
+    };
+
+    abstract StreamFactoryFactory streamFactory();
+
+    static StreamType parse(String streamType) {
+      try {
+        return valueOf(streamType.toUpperCase());
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Not supported StreamType. Supported values are [nio2|netty]");
+      }
+    }
+  }
+}

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/config/ParsingSSLOptionsTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/config/ParsingSSLOptionsTest.java
@@ -1,0 +1,85 @@
+package io.vertx.ext.mongo.impl.config;
+
+import com.mongodb.async.client.MongoClientSettings;
+import com.mongodb.connection.SslSettings;
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ParsingSSLOptionsTest {
+
+  @Test
+  public void ssl_should_be_disabled_by_default() {
+    // given
+    final JsonObject configWithoutSSLInfo = new JsonObject().put(
+      "connection_string", "mongodb://localhost:27017/mydb?replicaSet=myRs"
+    );
+
+    // when
+    final MongoClientSettings parsedSettings = new MongoClientOptionsParser(configWithoutSSLInfo).settings();
+
+    // then
+    assertFalse(parsedSettings.getSslSettings().isEnabled());
+    assertFalse(parsedSettings.getSslSettings().isInvalidHostNameAllowed());
+  }
+
+  @Test
+  public void one_should_be_able_to_enable_ssl_support_via_connection_string() {
+    // given
+    final JsonObject withSSLEnabled = new JsonObject().put(
+      "connection_string", "mongodb://localhost:27017/mydb?replicaSet=myRs&ssl=true"
+    );
+
+    // when
+    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLEnabled).settings().getSslSettings();
+
+    // then
+    assertTrue(sslSettings.isEnabled());
+  }
+
+  @Test
+  public void one_should_be_able_to_enable_ssl_support_via_config_property() {
+    // given
+    final JsonObject withSSLEnabled = new JsonObject().put("ssl", true);
+
+    // when
+    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLEnabled).settings().getSslSettings();
+
+    // then
+    assertTrue(sslSettings.isEnabled());
+  }
+
+  @Test
+  public void one_should_be_able_to_allow_invalid_host_names_via_connection_string() {
+    // given
+    final JsonObject withSSLAndInvalidHostnameEnabled = new JsonObject().put(
+      "connection_string", "mongodb://localhost:27017/mydb?replicaSet=myRs&ssl=true&sslInvalidHostNameAllowed=true"
+    );
+
+    // when
+    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLAndInvalidHostnameEnabled)
+      .settings()
+      .getSslSettings();
+
+    // then
+    assertTrue(sslSettings.isInvalidHostNameAllowed());
+  }
+
+  @Test
+  public void one_should_be_able_to_allow_invalid_host_names_via_config_property() {
+    // given
+    final JsonObject withSSLAndInvalidHostnameEnabled = new JsonObject()
+      .put("ssl", true)
+      .put("sslInvalidHostNameAllowed", true);
+
+    // when
+    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLAndInvalidHostnameEnabled)
+      .settings()
+      .getSslSettings();
+
+    // then
+    assertTrue(sslSettings.isInvalidHostNameAllowed());
+  }
+}

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/config/ParsingStreamTypeTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/impl/config/ParsingStreamTypeTest.java
@@ -1,0 +1,91 @@
+package io.vertx.ext.mongo.impl.config;
+
+import com.mongodb.async.client.MongoClientSettings;
+import com.mongodb.connection.AsynchronousSocketChannelStreamFactoryFactory;
+import com.mongodb.connection.StreamFactoryFactory;
+import com.mongodb.connection.netty.NettyStreamFactoryFactory;
+import io.vertx.core.json.JsonObject;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class ParsingStreamTypeTest {
+
+  @Test
+  public void should_not_include_any_stream_type_by_default_for_backwards_compatibility() {
+    // given
+    final JsonObject noStreamTypeProvided = new JsonObject().put(
+      "connection_string", "mongodb://localhost:27017/mydb?replicaSet=myRs"
+    );
+
+    // when
+    final MongoClientSettings parsedSettings = new MongoClientOptionsParser(noStreamTypeProvided).settings();
+
+    // then
+    assertNull(parsedSettings.getStreamFactoryFactory());
+  }
+
+  @Parameters(method = "validSteamTypes")
+  @Test
+  public void should_parse_stream_type_from_connection_string(String streamTypeString, Class<StreamFactoryFactory> streamType) {
+    // given
+    final JsonObject cfgWithStreamTypeProvided = new JsonObject().put(
+      "connection_string",
+      format("mongodb://localhost:27017/mydb?replicaSet=myRs&streamType=%s", streamTypeString)
+    );
+
+    // when
+    final MongoClientSettings parsedSettings = new MongoClientOptionsParser(cfgWithStreamTypeProvided).settings();
+
+    // then
+    assertThat(parsedSettings.getStreamFactoryFactory(), instanceOf(streamType));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void only_valid_stream_type_values_allowed_in_connection_string() {
+    // given
+    final JsonObject withInvalidStreamType = new JsonObject().put(
+      "connection_string",
+      "mongodb://localhost:27017/mydb?replicaSet=myRs&streamType=unrecognized"
+    );
+
+    // expect thrown
+    new MongoClientOptionsParser(withInvalidStreamType).settings();
+  }
+
+  @Parameters(method = "validSteamTypes")
+  @Test
+  public void should_parse_stream_type_from_config_property(String streamTypeString, Class<StreamFactoryFactory> streamType) {
+    // given
+    final JsonObject cfgWithStreamTypeProvided = new JsonObject().put("streamType", streamTypeString);
+
+    // when
+    final MongoClientSettings parsedSettings = new MongoClientOptionsParser(cfgWithStreamTypeProvided).settings();
+
+    // then
+    assertThat(parsedSettings.getStreamFactoryFactory(), instanceOf(streamType));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void only_valid_stream_type_values_allowed_as_config_property() {
+    // given
+    final JsonObject withInvalidStreamType = new JsonObject().put("streamType", "unrecognized");
+
+    // expect thrown
+    new MongoClientOptionsParser(withInvalidStreamType).settings();
+  }
+
+  private Object[] validSteamTypes() {
+    return new Object[]{
+      new Object[]{"nio2", AsynchronousSocketChannelStreamFactoryFactory.class},
+      new Object[]{"netty", NettyStreamFactoryFactory.class},
+    };
+  }
+}


### PR DESCRIPTION
During the process of securing the traffic between existing mongodb cluster and the client, it is useful to use `sslInvalidHostNameAllowed ` for a while, during the transition period.

However, it seems like the driver completely ignores that connection string property.
It also ignores `streamType` and according to https://github.com/vert-x3/vertx-mongo-client/issues/1, the only way to use netty is to set `System.setProperty("org.mongodb.async.type", "netty");` which is now deprecated.

This PR adds support for both of these properties.

Oh and btw: i feel it would be much easier to either drop the 'JsonObject' configuration altogether or at least allow to rely only on connectionString and pass it to underlying mongo driver factory as it is