### PR TITLE
aggregate support for mongo 3.6

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -14,7 +14,8 @@
 ^|Name | Type ^| Description
 |[[allowDiskUse]]`allowDiskUse`|`Boolean`|
 +++
-Set the flag if writing to temporary files is enabled.
+Set the flag for enabling/disabling writing  to the _tmp subdirectory in the dbPath directory.
+.  Defaults to false if not set.
 +++
 |[[batchSize]]`batchSize`|`Number (int)`|
 +++

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -18,7 +18,7 @@ Set the flag if writing to temporary files is enabled.
 +++
 |[[batchSize]]`batchSize`|`Number (int)`|
 +++
-Set the batch size for methods loading found data in batches.
+Set the batch size for methods loading in data.
 +++
 |[[maxAwaitTime]]`maxAwaitTime`|`Number (long)`|
 +++

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -1,5 +1,35 @@
 = Cheatsheets
 
+[[AggregateOptions]]
+== AggregateOptions
+
+++++
+ Options used to configure aggregate operations.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[allowDiskUse]]`allowDiskUse`|`Boolean`|
++++
+Set the flag if writing to temporary files is enabled.
++++
+|[[batchSize]]`batchSize`|`Number (int)`|
++++
+Set the batch size for methods loading found data in batches.
++++
+|[[maxAwaitTime]]`maxAwaitTime`|`Number (long)`|
++++
+The maximum amount of time for the server to wait on new documents to satisfy a $changeStream aggregation.
++++
+|[[maxTime]]`maxTime`|`Number (long)`|
++++
+Set the time limit in milliseconds for processing operations on a cursor.
++++
+|===
+
 [[BulkOperation]]
 == BulkOperation
 

--- a/src/main/generated/io/vertx/ext/mongo/AggregateOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/AggregateOptionsConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2014 Red Hat, Inc. and others
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Converter for {@link io.vertx.ext.mongo.AggregateOptions}.
+ * <p>
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.AggregateOptions} original class using Vert.x codegen.
+ */
+public class AggregateOptionsConverter {
+
+  public static void fromJson(JsonObject json, AggregateOptions obj) {
+    if (json.getValue("allowDiskUse") instanceof Boolean) {
+      obj.setAllowDiskUse((Boolean) json.getValue("allowDiskUse"));
+    }
+    if (json.getValue("batchSize") instanceof Number) {
+      obj.setBatchSize(((Number) json.getValue("batchSize")).intValue());
+    }
+    if (json.getValue("maxAwaitTime") instanceof Number) {
+      obj.setMaxAwaitTime(((Number) json.getValue("maxAwaitTime")).longValue());
+    }
+    if (json.getValue("maxTime") instanceof Number) {
+      obj.setMaxTime(((Number) json.getValue("maxTime")).longValue());
+    }
+  }
+
+  public static void toJson(AggregateOptions obj, JsonObject json) {
+    if (obj.getAllowDiskUse() != null) {
+      json.put("allowDiskUse", obj.getAllowDiskUse());
+    }
+    json.put("batchSize", obj.getBatchSize());
+    json.put("maxAwaitTime", obj.getMaxAwaitTime());
+    json.put("maxTime", obj.getMaxTime());
+  }
+}

--- a/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
@@ -21,7 +21,7 @@ public class AggregateOptions {
    */
   public static final long DEFAULT_MAX_TIME       = 0L;
   /**
-   * The default value of maxAwaiTime = 0.
+   * The default value of maxAwaiTime = 1000.
    */
   public static final long DEFAULT_MAX_AWAIT_TIME = 1000L;
 
@@ -95,21 +95,15 @@ public class AggregateOptions {
   }
 
   /**
-   * @return the batch size for methods loading found data in batches
-   */
-  public int getBatchSize() {
-    return batchSize;
-  }
-
-  /**
    * Get the flag if writing to temporary files is enabled.
    * When set to true, aggregation operations can write data to the _tmp subdirectory in the dbPath directory.
    *
    * @return true if writing to temporary files is enabled.
    */
-  public Boolean getAllowDiskUse(){
+  public Boolean getAllowDiskUse() {
     return allowDiskUse;
   }
+
   /**
    * Set the flag if writing to temporary files is enabled.
    *
@@ -119,6 +113,13 @@ public class AggregateOptions {
   public AggregateOptions setAllowDiskUse(final Boolean allowDiskUse) {
     this.allowDiskUse = allowDiskUse;
     return this;
+  }
+
+  /**
+   * @return the batch size for methods loading found data in batches
+   */
+  public int getBatchSize() {
+    return batchSize;
   }
 
   /**
@@ -133,7 +134,6 @@ public class AggregateOptions {
   }
 
   /**
-   *
    * @return the max await time in ms
    */
   public long getMaxAwaitTime() {

--- a/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
@@ -13,7 +13,7 @@ import io.vertx.core.json.JsonObject;
 @DataObject(generateConverter = true)
 public class AggregateOptions {
   /**
-   * The default value of batchSize = 10.
+   * The default value of batchSize = 20.
    */
   public static final int  DEFAULT_BATCH_SIZE     = 20;
   /**

--- a/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
@@ -1,0 +1,170 @@
+package io.vertx.ext.mongo;
+
+import java.util.Objects;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Options used to configure aggregate operations.
+ *
+ * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
+ */
+@DataObject(generateConverter = true)
+public class AggregateOptions {
+  /**
+   * The default value of batchSize = 10.
+   */
+  public static final int  DEFAULT_BATCH_SIZE     = 20;
+  /**
+   * The default value of maxTime = 0.
+   */
+  public static final long DEFAULT_MAX_TIME       = 0L;
+  /**
+   * The default value of maxAwaiTime = 0.
+   */
+  public static final long DEFAULT_MAX_AWAIT_TIME = 1000L;
+
+  private int     batchSize;
+  private long    maxTime;
+  private long    maxAwaitTime;
+  private Boolean allowDiskUse;
+
+  /**
+   * Default constructor
+   */
+  public AggregateOptions() {
+    this.batchSize = DEFAULT_BATCH_SIZE;
+    this.maxTime = DEFAULT_MAX_TIME;
+    this.maxAwaitTime = DEFAULT_MAX_AWAIT_TIME;
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param options the one to copy
+   */
+  public AggregateOptions(AggregateOptions options) {
+    this.batchSize = options.batchSize;
+    this.maxTime = options.maxTime;
+    this.maxAwaitTime = options.maxAwaitTime;
+    this.allowDiskUse = options.allowDiskUse;
+  }
+
+  /**
+   * Constructor from JSON
+   *
+   * @param options the JSON
+   */
+  public AggregateOptions(JsonObject options) {
+    this();
+    AggregateOptionsConverter.fromJson(options, this);
+  }
+
+  /**
+   * Convert to JSON
+   *
+   * @return the JSON
+   */
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    AggregateOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  /**
+   * Get the specified time limit in milliseconds for processing operations on a cursor.
+   * If you do not specify a value for maxTime, operations will not time out.
+   * A value of 0 explicitly specifies the default unbounded behavior.
+   *
+   * @return the specified time limit in milliseconds for processing operations on a cursor
+   */
+  public long getMaxTime() {
+    return maxTime;
+  }
+
+  /**
+   * Set the time limit in milliseconds for processing operations on a cursor.
+   *
+   * @param maxTime the time limit in milliseconds for processing operations on a cursor
+   * @return reference to this, for fluency
+   */
+  public AggregateOptions setMaxTime(long maxTime) {
+    this.maxTime = maxTime;
+    return this;
+  }
+
+  /**
+   * @return the batch size for methods loading found data in batches
+   */
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  /**
+   * Get the flag if writing to temporary files is enabled.
+   * When set to true, aggregation operations can write data to the _tmp subdirectory in the dbPath directory.
+   *
+   * @return true if writing to temporary files is enabled.
+   */
+  public Boolean getAllowDiskUse(){
+    return allowDiskUse;
+  }
+  /**
+   * Set the flag if writing to temporary files is enabled.
+   *
+   * @param allowDiskUse the flag indicating disk usage on aggregate or not.
+   * @return reference to this, for fluency
+   */
+  public AggregateOptions setAllowDiskUse(final Boolean allowDiskUse) {
+    this.allowDiskUse = allowDiskUse;
+    return this;
+  }
+
+  /**
+   * Set the batch size for methods loading found data in batches.
+   *
+   * @param batchSize the number of documents in a batch
+   * @return reference to this, for fluency
+   */
+  public AggregateOptions setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+    return this;
+  }
+
+  /**
+   *
+   * @return the max await time in ms
+   */
+  public long getMaxAwaitTime() {
+    return maxAwaitTime;
+  }
+
+  /**
+   * The maximum amount of time for the server to wait on new documents to satisfy a $changeStream aggregation.
+   *
+   * @param maxAwaitTime the max await time in ms
+   * @return reference to this, for fluency
+   */
+  public AggregateOptions setMaxAwaitTime(final long maxAwaitTime) {
+    this.maxAwaitTime = maxAwaitTime;
+    return this;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AggregateOptions that = (AggregateOptions) o;
+    return batchSize == that.batchSize && maxTime == that.maxTime && maxAwaitTime == that.maxAwaitTime && allowDiskUse == that.allowDiskUse;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(batchSize, maxTime, maxAwaitTime, allowDiskUse);
+  }
+}

--- a/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
@@ -75,7 +75,7 @@ public class AggregateOptions {
   /**
    * Get the specified time limit in milliseconds for processing operations on a cursor.
    * If you do not specify a value for maxTime, operations will not time out.
-   * A value of 0 explicitly specifies the default unbounded behavior.
+   * A value of 0 explicitly specifies the default unbounded behavior, which is not to time out.
    *
    * @return the specified time limit in milliseconds for processing operations on a cursor
    */

--- a/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -617,6 +617,24 @@ public interface MongoClient {
    */
   ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, int batchSize);
 
+
+  /**
+   * Run aggregate MongoDB command with default {@link AggregateOptions}.
+   *
+   * @param collection the collection
+   * @param pipeline   aggregation pipeline to be executed
+   */
+  ReadStream<JsonObject> aggregate(final String collection, final JsonArray pipeline);
+
+  /**
+   * Run aggregate MongoDB command.
+   *
+   * @param collection the collection
+   * @param pipeline   aggregation pipeline to be executed
+   * @param options    options to configure the aggregation command
+   */
+  ReadStream<JsonObject> aggregateWithOptions(String collection, final JsonArray pipeline, final AggregateOptions options);
+
   /**
    * Close the client and release its resources
    */

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -18,6 +18,7 @@ package io.vertx.ext.mongo.impl;
 
 import com.mongodb.WriteConcern;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.async.client.AggregateIterable;
 import com.mongodb.async.client.DistinctIterable;
 import com.mongodb.async.client.FindIterable;
 import com.mongodb.async.client.ListIndexesIterable;
@@ -53,6 +54,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.core.shareddata.Shareable;
 import io.vertx.core.streams.ReadStream;
+import io.vertx.ext.mongo.AggregateOptions;
 import io.vertx.ext.mongo.BulkOperation;
 import io.vertx.ext.mongo.BulkWriteOptions;
 import io.vertx.ext.mongo.FindOptions;
@@ -93,6 +95,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
 
   private static final UpdateOptions DEFAULT_UPDATE_OPTIONS = new UpdateOptions();
   private static final FindOptions DEFAULT_FIND_OPTIONS = new FindOptions();
+  private static final AggregateOptions DEFAULT_AGGREGATE_OPTIONS = new AggregateOptions();
   private static final BulkWriteOptions DEFAULT_BULK_WRITE_OPTIONS = new BulkWriteOptions();
   private static final String ID_FIELD = "_id";
 
@@ -689,6 +692,17 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     }
   }
 
+  @Override
+  public ReadStream<JsonObject> aggregate(final String collection, final JsonArray pipeline) {
+    return aggregateWithOptions(collection, pipeline, DEFAULT_AGGREGATE_OPTIONS);
+  }
+
+  @Override
+  public ReadStream<JsonObject> aggregateWithOptions(final String collection, final JsonArray pipeline, final AggregateOptions options) {
+      final MongoIterable<JsonObject> view = doAggregate(collection, pipeline, options);
+      return new MongoIterableStream(vertx.getOrCreateContext(), view, options.getBatchSize());
+  }
+
   private void convertMongoIterable(MongoIterable iterable, Handler<AsyncResult<JsonArray>> resultHandler) {
     List results = new ArrayList();
     try {
@@ -722,6 +736,28 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     return mongoCollection.distinct(fieldName, bquery, resultClass);
   }
 
+  private AggregateIterable<JsonObject> doAggregate(String collection, JsonArray pipeline, AggregateOptions options) {
+    requireNonNull(collection, "collection cannot be null");
+    requireNonNull(pipeline, "pipeline cannot be null");
+    final MongoCollection<JsonObject> coll = getCollection(collection);
+    final List<Bson> bpipeline = new ArrayList<>(pipeline.size());
+    pipeline.getList().forEach(entry -> bpipeline.add(wrap(JsonObject.mapFrom(entry))));
+    final AggregateIterable<JsonObject> aggregate = coll.aggregate(bpipeline, JsonObject.class);
+
+    if (options.getBatchSize() != -1) {
+      aggregate.batchSize(options.getBatchSize());
+    }
+    if (options.getMaxTime() > 0) {
+      aggregate.maxTime(options.getMaxTime(), TimeUnit.MILLISECONDS);
+    }
+    if (options.getMaxAwaitTime()  > 0) {
+      aggregate.maxAwaitTime(options.getMaxAwaitTime(), TimeUnit.MILLISECONDS);
+    }
+    if (options.getAllowDiskUse() != null) {
+      aggregate.allowDiskUse(options.getAllowDiskUse());
+    }
+    return aggregate;
+  }
 
   private JsonObject encodeKeyWhenUseObjectId(JsonObject json) {
     if (!useObjectId) return json;

--- a/src/main/kotlin/io/vertx/kotlin/ext/mongo/AggregateOptions.kt
+++ b/src/main/kotlin/io/vertx/kotlin/ext/mongo/AggregateOptions.kt
@@ -1,0 +1,37 @@
+package io.vertx.kotlin.ext.mongo
+
+import io.vertx.ext.mongo.AggregateOptions
+
+/**
+ * A function providing a DSL for building [io.vertx.ext.mongo.AggregateOptions] objects.
+ *
+ * Options used to configure aggregate operations.
+ *
+ * @param allowDiskUse  Set the flag if writing to temporary files is enabled.
+ * @param batchSize  Set the batch size for methods loading found data in batches.
+ * @param maxAwaitTime  The maximum amount of time for the server to wait on new documents to satisfy a $changeStream aggregation.
+ * @param maxTime  Set the time limit in milliseconds for processing operations on a cursor.
+ *
+ * <p/>
+ * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.AggregateOptions original] using Vert.x codegen.
+ */
+fun AggregateOptions(
+  allowDiskUse: Boolean? = null,
+  batchSize: Int? = null,
+  maxAwaitTime: Long? = null,
+  maxTime: Long? = null): AggregateOptions = io.vertx.ext.mongo.AggregateOptions().apply {
+
+  if (allowDiskUse != null) {
+    this.setAllowDiskUse(allowDiskUse)
+  }
+  if (batchSize != null) {
+    this.setBatchSize(batchSize)
+  }
+  if (maxAwaitTime != null) {
+    this.setMaxAwaitTime(maxAwaitTime)
+  }
+  if (maxTime != null) {
+    this.setMaxTime(maxTime)
+  }
+}
+

--- a/src/test/java/io/vertx/ext/mongo/AggregateOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/AggregateOptionsTest.java
@@ -1,0 +1,77 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.test.core.TestUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
+ */
+public class AggregateOptionsTest {
+  @Test
+  public void testOptions() {
+    AggregateOptions options = new AggregateOptions();
+
+    long maxAwaitTime = TestUtils.randomLong();
+    assertEquals(options, options.setMaxAwaitTime(maxAwaitTime));
+    assertEquals(maxAwaitTime, options.getMaxAwaitTime());
+
+    long maxTime = TestUtils.randomLong();
+    assertEquals(options, options.setMaxTime(maxTime));
+    assertEquals(maxTime, options.getMaxTime());
+  }
+
+  @Test
+  public void testDefaultOptions() {
+    AggregateOptions options = new AggregateOptions();
+    assertEquals(AggregateOptions.DEFAULT_MAX_AWAIT_TIME, options.getMaxAwaitTime());
+    assertEquals(AggregateOptions.DEFAULT_MAX_TIME, options.getMaxTime());
+  }
+
+  @Test
+  public void testOptionsJson() {
+    JsonObject json = new JsonObject();
+
+    long maxAwaitTime = TestUtils.randomLong();
+    json.put("maxAwaitTime", maxAwaitTime);
+
+    long maxTime = TestUtils.randomLong();
+    json.put("maxTime", maxTime);
+
+    AggregateOptions options = new AggregateOptions(json);
+    assertEquals(maxAwaitTime, options.getMaxAwaitTime());
+    assertEquals(maxTime, options.getMaxTime());
+  }
+
+  @Test
+  public void testDefaultOptionsJson() {
+    AggregateOptions options = new AggregateOptions(new JsonObject());
+    AggregateOptions def = new AggregateOptions();
+    assertEquals(def.getMaxAwaitTime(), options.getMaxAwaitTime());
+    assertEquals(def.getMaxTime(), options.getMaxTime());
+  }
+
+  @Test
+  public void testCopyOptions() {
+    AggregateOptions options = new AggregateOptions();
+    options.setMaxAwaitTime(TestUtils.randomLong());
+    options.setMaxTime(TestUtils.randomLong());
+
+    AggregateOptions copy = new AggregateOptions(options);
+    assertEquals(options.getMaxAwaitTime(), copy.getMaxAwaitTime());
+    assertEquals(options.getMaxTime(), copy.getMaxTime());
+  }
+
+  @Test
+  public void testToJson() {
+    AggregateOptions options = new AggregateOptions();
+    long maxAwaitTime = TestUtils.randomPositiveLong();
+    long maxTime = TestUtils.randomPositiveLong();
+    options.setMaxAwaitTime(maxAwaitTime);
+    options.setMaxTime(maxTime);
+
+    assertEquals(options, new AggregateOptions(options.toJson()));
+  }
+}

--- a/src/test/java/io/vertx/ext/mongo/AggregateOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/AggregateOptionsTest.java
@@ -5,6 +5,7 @@ import io.vertx.test.core.TestUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
@@ -12,27 +13,32 @@ import static org.junit.Assert.assertEquals;
 public class AggregateOptionsTest {
   @Test
   public void testOptions() {
-    AggregateOptions options = new AggregateOptions();
+    final AggregateOptions options = new AggregateOptions();
 
-    long maxAwaitTime = TestUtils.randomLong();
+    final long maxAwaitTime = TestUtils.randomLong();
     assertEquals(options, options.setMaxAwaitTime(maxAwaitTime));
     assertEquals(maxAwaitTime, options.getMaxAwaitTime());
 
-    long maxTime = TestUtils.randomLong();
+    final long maxTime = TestUtils.randomLong();
     assertEquals(options, options.setMaxTime(maxTime));
     assertEquals(maxTime, options.getMaxTime());
+
+    final boolean useDisk = TestUtils.randomBoolean();
+    assertEquals(options, options.setAllowDiskUse(useDisk));
+    assertEquals(useDisk, options.getAllowDiskUse());
   }
 
   @Test
   public void testDefaultOptions() {
-    AggregateOptions options = new AggregateOptions();
+    final AggregateOptions options = new AggregateOptions();
     assertEquals(AggregateOptions.DEFAULT_MAX_AWAIT_TIME, options.getMaxAwaitTime());
     assertEquals(AggregateOptions.DEFAULT_MAX_TIME, options.getMaxTime());
+    assertNull(options.getAllowDiskUse());
   }
 
   @Test
   public void testOptionsJson() {
-    JsonObject json = new JsonObject();
+    final JsonObject json = new JsonObject();
 
     long maxAwaitTime = TestUtils.randomLong();
     json.put("maxAwaitTime", maxAwaitTime);
@@ -40,37 +46,43 @@ public class AggregateOptionsTest {
     long maxTime = TestUtils.randomLong();
     json.put("maxTime", maxTime);
 
-    AggregateOptions options = new AggregateOptions(json);
+    boolean useDisk = TestUtils.randomBoolean();
+    json.put("allowDiskUse", useDisk);
+
+    final AggregateOptions options = new AggregateOptions(json);
     assertEquals(maxAwaitTime, options.getMaxAwaitTime());
     assertEquals(maxTime, options.getMaxTime());
+    assertEquals(useDisk, options.getAllowDiskUse());
   }
 
   @Test
   public void testDefaultOptionsJson() {
-    AggregateOptions options = new AggregateOptions(new JsonObject());
-    AggregateOptions def = new AggregateOptions();
+    final AggregateOptions options = new AggregateOptions(new JsonObject());
+    final AggregateOptions def = new AggregateOptions();
     assertEquals(def.getMaxAwaitTime(), options.getMaxAwaitTime());
     assertEquals(def.getMaxTime(), options.getMaxTime());
+    assertNull(options.getAllowDiskUse());
   }
 
   @Test
   public void testCopyOptions() {
-    AggregateOptions options = new AggregateOptions();
+    final AggregateOptions options = new AggregateOptions();
     options.setMaxAwaitTime(TestUtils.randomLong());
     options.setMaxTime(TestUtils.randomLong());
+    options.setAllowDiskUse(TestUtils.randomBoolean());
 
-    AggregateOptions copy = new AggregateOptions(options);
+    final AggregateOptions copy = new AggregateOptions(options);
     assertEquals(options.getMaxAwaitTime(), copy.getMaxAwaitTime());
     assertEquals(options.getMaxTime(), copy.getMaxTime());
+    assertEquals(options.getAllowDiskUse(), copy.getAllowDiskUse());
   }
 
   @Test
   public void testToJson() {
-    AggregateOptions options = new AggregateOptions();
-    long maxAwaitTime = TestUtils.randomPositiveLong();
-    long maxTime = TestUtils.randomPositiveLong();
-    options.setMaxAwaitTime(maxAwaitTime);
-    options.setMaxTime(maxTime);
+    final AggregateOptions options = new AggregateOptions();
+    options.setMaxAwaitTime(TestUtils.randomPositiveLong());
+    options.setMaxTime(TestUtils.randomPositiveLong());
+    options.setAllowDiskUse(TestUtils.randomBoolean());
 
     assertEquals(options, new AggregateOptions(options.toJson()));
   }

--- a/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
@@ -2,15 +2,14 @@ package io.vertx.ext.mongo;
 
 import com.mongodb.async.client.MongoClients;
 import com.mongodb.async.client.MongoDatabase;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.mongo.impl.codec.json.JsonObjectCodec;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 /**
@@ -100,6 +99,27 @@ public class MongoClientTest extends MongoClientTestBase {
         });
       }));
     await();
+  }
+
+  @Test
+  public void testAggregate() throws Exception {
+    int numDocs = 1000;
+
+    String collection = randomCollection();
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicLong count = new AtomicLong();
+    mongoClient.createCollection(collection, onSuccess(res -> {
+      insertDocs(mongoClient, collection, numDocs, onSuccess(res2 -> {
+        mongoClient.aggregate(collection,
+                              new JsonArray().add(new JsonObject().put("$match", new JsonObject().put("foo", new JsonObject().put("$regex", "bar1"))))
+                                             .add(new JsonObject().put("$count", "foo_starting_with_bar1")))
+                   .exceptionHandler(this::fail)
+                   .endHandler(v -> latch.countDown())
+                   .handler(result -> count.set(result.getLong("foo_starting_with_bar1")));
+      }));
+    }));
+    awaitLatch(latch);
+    assertEquals(111, count.longValue());
   }
 
   private void upsertDoc(String collection, JsonObject docToInsert, String expectedId, Consumer<JsonObject> doneFunction) {


### PR DESCRIPTION
As stated in https://github.com/vert-x3/vertx-mongo-client/issues/148 MongoDB has changed the handling of the aggregate command.
Would be great if you could have a look into it and tell me if you need something more to get this into the vertx-mongo-client.