### PR TITLE
remove aggregate maxTimeMS option

### DIFF
--- a/src/main/generated/io/vertx/ext/mongo/AggregateOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/AggregateOptionsConverter.java
@@ -17,26 +17,24 @@
 package io.vertx.ext.mongo;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
 
 /**
  * Converter for {@link io.vertx.ext.mongo.AggregateOptions}.
- * <p>
+ *
  * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.AggregateOptions} original class using Vert.x codegen.
  */
 public class AggregateOptionsConverter {
 
   public static void fromJson(JsonObject json, AggregateOptions obj) {
     if (json.getValue("allowDiskUse") instanceof Boolean) {
-      obj.setAllowDiskUse((Boolean) json.getValue("allowDiskUse"));
+      obj.setAllowDiskUse((Boolean)json.getValue("allowDiskUse"));
     }
     if (json.getValue("batchSize") instanceof Number) {
-      obj.setBatchSize(((Number) json.getValue("batchSize")).intValue());
-    }
-    if (json.getValue("maxAwaitTime") instanceof Number) {
-      obj.setMaxAwaitTime(((Number) json.getValue("maxAwaitTime")).longValue());
+      obj.setBatchSize(((Number)json.getValue("batchSize")).intValue());
     }
     if (json.getValue("maxTime") instanceof Number) {
-      obj.setMaxTime(((Number) json.getValue("maxTime")).longValue());
+      obj.setMaxTime(((Number)json.getValue("maxTime")).longValue());
     }
   }
 
@@ -45,7 +43,6 @@ public class AggregateOptionsConverter {
       json.put("allowDiskUse", obj.getAllowDiskUse());
     }
     json.put("batchSize", obj.getBatchSize());
-    json.put("maxAwaitTime", obj.getMaxAwaitTime());
     json.put("maxTime", obj.getMaxTime());
   }
 }

--- a/src/main/generated/io/vertx/ext/mongo/AggregateOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/AggregateOptionsConverter.java
@@ -17,24 +17,26 @@
 package io.vertx.ext.mongo;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.json.JsonArray;
 
 /**
  * Converter for {@link io.vertx.ext.mongo.AggregateOptions}.
- *
+ * <p>
  * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.AggregateOptions} original class using Vert.x codegen.
  */
 public class AggregateOptionsConverter {
 
   public static void fromJson(JsonObject json, AggregateOptions obj) {
     if (json.getValue("allowDiskUse") instanceof Boolean) {
-      obj.setAllowDiskUse((Boolean)json.getValue("allowDiskUse"));
+      obj.setAllowDiskUse((Boolean) json.getValue("allowDiskUse"));
     }
     if (json.getValue("batchSize") instanceof Number) {
-      obj.setBatchSize(((Number)json.getValue("batchSize")).intValue());
+      obj.setBatchSize(((Number) json.getValue("batchSize")).intValue());
+    }
+    if (json.getValue("maxAwaitTime") instanceof Number) {
+      obj.setMaxAwaitTime(((Number) json.getValue("maxAwaitTime")).longValue());
     }
     if (json.getValue("maxTime") instanceof Number) {
-      obj.setMaxTime(((Number)json.getValue("maxTime")).longValue());
+      obj.setMaxTime(((Number) json.getValue("maxTime")).longValue());
     }
   }
 
@@ -43,6 +45,7 @@ public class AggregateOptionsConverter {
       json.put("allowDiskUse", obj.getAllowDiskUse());
     }
     json.put("batchSize", obj.getBatchSize());
+    json.put("maxAwaitTime", obj.getMaxAwaitTime());
     json.put("maxTime", obj.getMaxTime());
   }
 }

--- a/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
@@ -20,14 +20,9 @@ public class AggregateOptions {
    * The default value of maxTime = 0.
    */
   public static final long DEFAULT_MAX_TIME       = 0L;
-  /**
-   * The default value of maxAwaiTime = 1000.
-   */
-  public static final long DEFAULT_MAX_AWAIT_TIME = 1000L;
 
   private int     batchSize;
   private long    maxTime;
-  private long    maxAwaitTime;
   private Boolean allowDiskUse;
 
   /**
@@ -36,7 +31,6 @@ public class AggregateOptions {
   public AggregateOptions() {
     this.batchSize = DEFAULT_BATCH_SIZE;
     this.maxTime = DEFAULT_MAX_TIME;
-    this.maxAwaitTime = DEFAULT_MAX_AWAIT_TIME;
   }
 
   /**
@@ -47,7 +41,6 @@ public class AggregateOptions {
   public AggregateOptions(AggregateOptions options) {
     this.batchSize = options.batchSize;
     this.maxTime = options.maxTime;
-    this.maxAwaitTime = options.maxAwaitTime;
     this.allowDiskUse = options.allowDiskUse;
   }
 
@@ -133,24 +126,6 @@ public class AggregateOptions {
     return this;
   }
 
-  /**
-   * @return the max await time in ms
-   */
-  public long getMaxAwaitTime() {
-    return maxAwaitTime;
-  }
-
-  /**
-   * The maximum amount of time for the server to wait on new documents to satisfy a $changeStream aggregation.
-   *
-   * @param maxAwaitTime the max await time in ms
-   * @return reference to this, for fluency
-   */
-  public AggregateOptions setMaxAwaitTime(final long maxAwaitTime) {
-    this.maxAwaitTime = maxAwaitTime;
-    return this;
-  }
-
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -160,11 +135,11 @@ public class AggregateOptions {
       return false;
     }
     final AggregateOptions that = (AggregateOptions) o;
-    return batchSize == that.batchSize && maxTime == that.maxTime && maxAwaitTime == that.maxAwaitTime && allowDiskUse == that.allowDiskUse;
+    return batchSize == that.batchSize && maxTime == that.maxTime  && allowDiskUse == that.allowDiskUse;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(batchSize, maxTime, maxAwaitTime, allowDiskUse);
+    return Objects.hash(batchSize, maxTime, allowDiskUse);
   }
 }

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -750,9 +750,6 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     if (options.getMaxTime() > 0) {
       aggregate.maxTime(options.getMaxTime(), TimeUnit.MILLISECONDS);
     }
-    if (options.getMaxAwaitTime()  > 0) {
-      aggregate.maxAwaitTime(options.getMaxAwaitTime(), TimeUnit.MILLISECONDS);
-    }
     if (options.getAllowDiskUse() != null) {
       aggregate.allowDiskUse(options.getAllowDiskUse());
     }

--- a/src/test/java/io/vertx/ext/mongo/AggregateOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/AggregateOptionsTest.java
@@ -15,10 +15,6 @@ public class AggregateOptionsTest {
   public void testOptions() {
     final AggregateOptions options = new AggregateOptions();
 
-    final long maxAwaitTime = TestUtils.randomLong();
-    assertEquals(options, options.setMaxAwaitTime(maxAwaitTime));
-    assertEquals(maxAwaitTime, options.getMaxAwaitTime());
-
     final long maxTime = TestUtils.randomLong();
     assertEquals(options, options.setMaxTime(maxTime));
     assertEquals(maxTime, options.getMaxTime());
@@ -31,7 +27,6 @@ public class AggregateOptionsTest {
   @Test
   public void testDefaultOptions() {
     final AggregateOptions options = new AggregateOptions();
-    assertEquals(AggregateOptions.DEFAULT_MAX_AWAIT_TIME, options.getMaxAwaitTime());
     assertEquals(AggregateOptions.DEFAULT_MAX_TIME, options.getMaxTime());
     assertNull(options.getAllowDiskUse());
   }
@@ -50,7 +45,6 @@ public class AggregateOptionsTest {
     json.put("allowDiskUse", useDisk);
 
     final AggregateOptions options = new AggregateOptions(json);
-    assertEquals(maxAwaitTime, options.getMaxAwaitTime());
     assertEquals(maxTime, options.getMaxTime());
     assertEquals(useDisk, options.getAllowDiskUse());
   }
@@ -59,7 +53,6 @@ public class AggregateOptionsTest {
   public void testDefaultOptionsJson() {
     final AggregateOptions options = new AggregateOptions(new JsonObject());
     final AggregateOptions def = new AggregateOptions();
-    assertEquals(def.getMaxAwaitTime(), options.getMaxAwaitTime());
     assertEquals(def.getMaxTime(), options.getMaxTime());
     assertNull(options.getAllowDiskUse());
   }
@@ -67,12 +60,10 @@ public class AggregateOptionsTest {
   @Test
   public void testCopyOptions() {
     final AggregateOptions options = new AggregateOptions();
-    options.setMaxAwaitTime(TestUtils.randomLong());
     options.setMaxTime(TestUtils.randomLong());
     options.setAllowDiskUse(TestUtils.randomBoolean());
 
     final AggregateOptions copy = new AggregateOptions(options);
-    assertEquals(options.getMaxAwaitTime(), copy.getMaxAwaitTime());
     assertEquals(options.getMaxTime(), copy.getMaxTime());
     assertEquals(options.getAllowDiskUse(), copy.getAllowDiskUse());
   }
@@ -80,7 +71,6 @@ public class AggregateOptionsTest {
   @Test
   public void testToJson() {
     final AggregateOptions options = new AggregateOptions();
-    options.setMaxAwaitTime(TestUtils.randomPositiveLong());
     options.setMaxTime(TestUtils.randomPositiveLong());
     options.setAllowDiskUse(TestUtils.randomBoolean());
 


### PR DESCRIPTION
sorry have to remove this option as running tests with it resulted in MongoDB error:
"maxTimeMS can only be used with getMore for tailable, awaitData cursors"

As an alternative I can also set the default to 0 if this is preffered.