### PR TITLE
remove aggregate maxTimeMS option

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -18,9 +18,6 @@ Set the flag if writing to temporary files is enabled.
 |[[batchSize]]`@batchSize`|`Number (int)`|+++
 Set the batch size for methods loading found data in batches.
 +++
-|[[maxAwaitTime]]`@maxAwaitTime`|`Number (long)`|+++
-The maximum amount of time for the server to wait on new documents to satisfy a $changeStream aggregation.
-+++
 |[[maxTime]]`@maxTime`|`Number (long)`|+++
 Set the time limit in milliseconds for processing operations on a cursor.
 +++

--- a/src/main/generated/io/vertx/ext/mongo/AggregateOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/AggregateOptionsConverter.java
@@ -24,11 +24,6 @@ public class AggregateOptionsConverter {
             obj.setBatchSize(((Number)member.getValue()).intValue());
           }
           break;
-        case "maxAwaitTime":
-          if (member.getValue() instanceof Number) {
-            obj.setMaxAwaitTime(((Number)member.getValue()).longValue());
-          }
-          break;
         case "maxTime":
           if (member.getValue() instanceof Number) {
             obj.setMaxTime(((Number)member.getValue()).longValue());
@@ -47,7 +42,6 @@ public class AggregateOptionsConverter {
       json.put("allowDiskUse", obj.getAllowDiskUse());
     }
     json.put("batchSize", obj.getBatchSize());
-    json.put("maxAwaitTime", obj.getMaxAwaitTime());
     json.put("maxTime", obj.getMaxTime());
   }
 }

--- a/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
@@ -15,19 +15,14 @@ public class AggregateOptions {
   /**
    * The default value of batchSize = 10.
    */
-  public static final int  DEFAULT_BATCH_SIZE     = 20;
+  public static final int  DEFAULT_BATCH_SIZE = 20;
   /**
    * The default value of maxTime = 0.
    */
-  public static final long DEFAULT_MAX_TIME       = 0L;
-  /**
-   * The default value of maxAwaiTime = 0.
-   */
-  public static final long DEFAULT_MAX_AWAIT_TIME = 1000L;
+  public static final long DEFAULT_MAX_TIME   = 0L;
 
   private int     batchSize;
   private long    maxTime;
-  private long    maxAwaitTime;
   private Boolean allowDiskUse;
 
   /**
@@ -36,7 +31,6 @@ public class AggregateOptions {
   public AggregateOptions() {
     this.batchSize = DEFAULT_BATCH_SIZE;
     this.maxTime = DEFAULT_MAX_TIME;
-    this.maxAwaitTime = DEFAULT_MAX_AWAIT_TIME;
   }
 
   /**
@@ -47,7 +41,6 @@ public class AggregateOptions {
   public AggregateOptions(AggregateOptions options) {
     this.batchSize = options.batchSize;
     this.maxTime = options.maxTime;
-    this.maxAwaitTime = options.maxAwaitTime;
     this.allowDiskUse = options.allowDiskUse;
   }
 
@@ -107,9 +100,10 @@ public class AggregateOptions {
    *
    * @return true if writing to temporary files is enabled.
    */
-  public Boolean getAllowDiskUse(){
+  public Boolean getAllowDiskUse() {
     return allowDiskUse;
   }
+
   /**
    * Set the flag if writing to temporary files is enabled.
    *
@@ -132,25 +126,6 @@ public class AggregateOptions {
     return this;
   }
 
-  /**
-   *
-   * @return the max await time in ms
-   */
-  public long getMaxAwaitTime() {
-    return maxAwaitTime;
-  }
-
-  /**
-   * The maximum amount of time for the server to wait on new documents to satisfy a $changeStream aggregation.
-   *
-   * @param maxAwaitTime the max await time in ms
-   * @return reference to this, for fluency
-   */
-  public AggregateOptions setMaxAwaitTime(final long maxAwaitTime) {
-    this.maxAwaitTime = maxAwaitTime;
-    return this;
-  }
-
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -160,11 +135,11 @@ public class AggregateOptions {
       return false;
     }
     final AggregateOptions that = (AggregateOptions) o;
-    return batchSize == that.batchSize && maxTime == that.maxTime && maxAwaitTime == that.maxAwaitTime && allowDiskUse == that.allowDiskUse;
+    return batchSize == that.batchSize && maxTime == that.maxTime && allowDiskUse == that.allowDiskUse;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(batchSize, maxTime, maxAwaitTime, allowDiskUse);
+    return Objects.hash(batchSize, maxTime, allowDiskUse);
   }
 }

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -751,9 +751,6 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient {
     if (aggregateOptions.getMaxTime() > 0) {
       aggregate.maxTime(aggregateOptions.getMaxTime(), TimeUnit.MILLISECONDS);
     }
-    if (aggregateOptions.getMaxAwaitTime()  > 0) {
-      aggregate.maxAwaitTime(aggregateOptions.getMaxAwaitTime(), TimeUnit.MILLISECONDS);
-    }
     if (aggregateOptions.getAllowDiskUse() != null) {
       aggregate.allowDiskUse(aggregateOptions.getAllowDiskUse());
     }

--- a/src/test/java/io/vertx/ext/mongo/AggregateOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/AggregateOptionsTest.java
@@ -14,10 +14,6 @@ public class AggregateOptionsTest {
   public void testOptions() {
     AggregateOptions options = new AggregateOptions();
 
-    long maxAwaitTime = TestUtils.randomLong();
-    assertEquals(options, options.setMaxAwaitTime(maxAwaitTime));
-    assertEquals(maxAwaitTime, options.getMaxAwaitTime());
-
     long maxTime = TestUtils.randomLong();
     assertEquals(options, options.setMaxTime(maxTime));
     assertEquals(maxTime, options.getMaxTime());
@@ -26,7 +22,6 @@ public class AggregateOptionsTest {
   @Test
   public void testDefaultOptions() {
     AggregateOptions options = new AggregateOptions();
-    assertEquals(AggregateOptions.DEFAULT_MAX_AWAIT_TIME, options.getMaxAwaitTime());
     assertEquals(AggregateOptions.DEFAULT_MAX_TIME, options.getMaxTime());
   }
 
@@ -41,7 +36,6 @@ public class AggregateOptionsTest {
     json.put("maxTime", maxTime);
 
     AggregateOptions options = new AggregateOptions(json);
-    assertEquals(maxAwaitTime, options.getMaxAwaitTime());
     assertEquals(maxTime, options.getMaxTime());
   }
 
@@ -49,18 +43,15 @@ public class AggregateOptionsTest {
   public void testDefaultOptionsJson() {
     AggregateOptions options = new AggregateOptions(new JsonObject());
     AggregateOptions def = new AggregateOptions();
-    assertEquals(def.getMaxAwaitTime(), options.getMaxAwaitTime());
     assertEquals(def.getMaxTime(), options.getMaxTime());
   }
 
   @Test
   public void testCopyOptions() {
     AggregateOptions options = new AggregateOptions();
-    options.setMaxAwaitTime(TestUtils.randomLong());
     options.setMaxTime(TestUtils.randomLong());
 
     AggregateOptions copy = new AggregateOptions(options);
-    assertEquals(options.getMaxAwaitTime(), copy.getMaxAwaitTime());
     assertEquals(options.getMaxTime(), copy.getMaxTime());
   }
 
@@ -69,7 +60,6 @@ public class AggregateOptionsTest {
     AggregateOptions options = new AggregateOptions();
     long maxAwaitTime = TestUtils.randomPositiveLong();
     long maxTime = TestUtils.randomPositiveLong();
-    options.setMaxAwaitTime(maxAwaitTime);
     options.setMaxTime(maxTime);
 
     assertEquals(options, new AggregateOptions(options.toJson()));


### PR DESCRIPTION
sorry have to remove this option as running tests with it resulted in MongoDB error:
"maxTimeMS can only be used with getMore for tailable, awaitData cursors"

As an alternative I can also set the default to 0 if this is preffered.