### PR TITLE
add equals & hashCode to IndexOptions

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/IndexOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/IndexOptions.java
@@ -2,8 +2,6 @@ package io.vertx.ext.mongo;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
-import org.bson.BsonDocument;
-import org.bson.conversions.Bson;
 
 import java.util.concurrent.TimeUnit;
 
@@ -512,4 +510,54 @@ public class IndexOptions {
         this.partialFilterExpression = partialFilterExpression;
         return this;
     }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    IndexOptions options = (IndexOptions) o;
+
+    if (background != options.background) return false;
+    if (unique != options.unique) return false;
+    if (name != null ? !name.equals(options.name) : options.name != null) return false;
+    if (sparse != options.sparse) return false;
+    if (expireAfterSeconds != null ? !expireAfterSeconds.equals(options.expireAfterSeconds) : options.expireAfterSeconds!= null) return false;
+    if (version != null ? !version.equals(options.version) : options.version != null) return false;
+    if (weights != null ? !weights.equals(options.weights) : options.weights != null) return false;
+    if (defaultLanguage != null ? !defaultLanguage.equals(options.defaultLanguage) : options.defaultLanguage != null) return false;
+    if (languageOverride != null ? !languageOverride.equals(options.languageOverride) : options.languageOverride != null) return false;
+    if (textVersion != null ? !textVersion.equals(options.textVersion) : options.textVersion != null) return false;
+    if (sphereVersion != null ? !sphereVersion.equals(options.sphereVersion) : options.sphereVersion != null) return false;
+    if (bits != null ? !bits.equals(options.bits) : options.bits != null) return false;
+    if (min != null ? !min.equals(options.min) : options.min != null) return false;
+    if (max != null ? !max.equals(options.max) : options.max != null) return false;
+    if (bucketSize != null ? !bucketSize.equals(options.bucketSize) : options.bucketSize != null) return false;
+    if (storageEngine != null ? !storageEngine.equals(options.storageEngine) : options.storageEngine != null) return false;
+    if (partialFilterExpression != null ? !partialFilterExpression.equals(options.partialFilterExpression) : options.partialFilterExpression != null) return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = background ? 1 : 0;
+    result = 31 * result + (unique ? 1 : 0);
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + (sparse ? 1 : 0);
+    result = 31 * result + (expireAfterSeconds != null ? expireAfterSeconds.hashCode() : 0);
+    result = 31 * result + (version != null ? version.hashCode() : 0);
+    result = 31 * result + (weights != null ? weights.hashCode() : 0);
+    result = 31 * result + (defaultLanguage != null ? defaultLanguage.hashCode() : 0);
+    result = 31 * result + (languageOverride != null ? languageOverride.hashCode() : 0);
+    result = 31 * result + (textVersion != null ? textVersion.hashCode() : 0);
+    result = 31 * result + (sphereVersion != null ? sphereVersion.hashCode() : 0);
+    result = 31 * result + (bits != null ? bits.hashCode() : 0);
+    result = 31 * result + (min != null ? min.hashCode() : 0);
+    result = 31 * result + (max != null ? max.hashCode() : 0);
+    result = 31 * result + (bucketSize != null ? bucketSize.hashCode() : 0);
+    result = 31 * result + (storageEngine != null ? storageEngine.hashCode() : 0);
+    result = 31 * result + (partialFilterExpression != null ? partialFilterExpression.hashCode() : 0);
+    return result;
+  }
 }

--- a/src/test/java/io/vertx/ext/mongo/IndexOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/IndexOptionsTest.java
@@ -1,0 +1,78 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class IndexOptionsTest {
+
+  @Test
+  public void testEquals() {
+    assertEquals(new IndexOptions(), new IndexOptions());
+
+    assertNotEqual((a, b) -> { a.background(true); b.background(false); });
+    assertNotEqual((a, b) -> { a.unique(true); b.unique(false); });
+    assertNotEqual((a, b) -> { a.name("a"); b.name("b"); });
+    assertNotEqual((a, b) -> { a.sparse(true); b.sparse(false); });
+    assertNotEqual((a, b) -> { a.expireAfter(4L, TimeUnit.SECONDS); b.expireAfter(3L, TimeUnit.SECONDS); });
+    assertNotEqual((a, b) -> { a.version(1); b.version(2); });
+    assertNotEqual((a, b) -> { a.weights(new JsonObject("{ \"f\": 3 }")); b.weights(new JsonObject()); });
+    assertNotEqual((a, b) -> { a.defaultLanguage("en"); b.defaultLanguage("de"); });
+    assertNotEqual((a, b) -> { a.languageOverride("en"); b.languageOverride("de"); });
+    assertNotEqual((a, b) -> { a.textVersion(2); b.textVersion(1); });
+    assertNotEqual((a, b) -> { a.sphereVersion(1); b.sphereVersion(3); });
+    assertNotEqual((a, b) -> { a.bits(5); b.bits(6); });
+    assertNotEqual((a, b) -> { a.min(2.3); b.min(2.4); });
+    assertNotEqual((a, b) -> { a.max(3.2); b.max(3.3); });
+    assertNotEqual((a, b) -> { a.bucketSize(23d); b.bucketSize(24d); });
+    assertNotEqual((a, b) -> { a.storageEngine(new JsonObject("{ \"f\": 3 }")); b.storageEngine(new JsonObject()); });
+    assertNotEqual((a, b) -> { a.partialFilterExpression(new JsonObject("{ \"f\": 3 }")); b.partialFilterExpression(new JsonObject()); });
+
+    assertNotEquals(new IndexOptions(), null);
+  }
+
+  @Test
+  public void testHashCode() {
+    IndexOptions a = new IndexOptions();
+    int hash = a.hashCode();
+
+    assertEquals(hash, new IndexOptions().hashCode());
+
+    assertNotEqual(hash, o -> o.background(true));
+    assertNotEqual(hash, o -> o.unique(true));
+    assertNotEqual(hash, o -> o.name("foobar"));
+    assertNotEqual(hash, o -> o.sparse(true));
+    assertNotEqual(hash, o -> o.expireAfter(6L, TimeUnit.SECONDS));
+    assertNotEqual(hash, o -> o.version(22));
+    assertNotEqual(hash, o -> o.weights(new JsonObject("{ \"f\": 42 }")));
+    assertNotEqual(hash, o -> o.defaultLanguage("pl"));
+    assertNotEqual(hash, o -> o.languageOverride("ru"));
+    assertNotEqual(hash, o -> o.textVersion(39));
+    assertNotEqual(hash, o -> o.sphereVersion(31));
+    assertNotEqual(hash, o -> o.bits(13));
+    assertNotEqual(hash, o -> o.min(2.5));
+    assertNotEqual(hash, o -> o.max(6.1));
+    assertNotEqual(hash, o -> o.bucketSize(12d));
+    assertNotEqual(hash, o -> o.storageEngine(new JsonObject("{ \"f\": 12 }")));
+    assertNotEqual(hash, o -> o.partialFilterExpression(new JsonObject("{ \"f\": 4 }")));
+  }
+
+  private static void assertNotEqual(BiConsumer<IndexOptions, IndexOptions> f) {
+    IndexOptions a = new IndexOptions();
+    IndexOptions b = new IndexOptions();
+    f.accept(a, b);
+    assertNotEquals(a, b);    
+  }
+
+  private static void assertNotEqual(int expected, Consumer<IndexOptions> f) {
+    IndexOptions o = new IndexOptions();
+    f.accept(o);
+    assertNotEquals(expected, o.hashCode());
+  }
+}


### PR DESCRIPTION
Add `equals` & `hashCode` methods to `IndexOptions`. Same semantics & style as in the other `*Options` objects.