### PR TITLE
add equals & hashCode to BulkWriteOptions

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/BulkWriteOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/BulkWriteOptions.java
@@ -120,4 +120,24 @@ public class BulkWriteOptions {
     this.ordered = ordered;
     return this;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    BulkWriteOptions options = (BulkWriteOptions) o;
+
+    if (writeOption != options.writeOption) return false;
+    if (ordered != options.ordered) return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = writeOption != null ? writeOption.hashCode() : 0;
+    result = 31 * result + (ordered ? 1 : 0);
+    return result;
+  }
 }

--- a/src/test/java/io/vertx/ext/mongo/BulkWriteOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/BulkWriteOptionsTest.java
@@ -1,0 +1,49 @@
+package io.vertx.ext.mongo;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class BulkWriteOptionsTest {
+
+  @Test
+  public void testEquals() {
+    BulkWriteOptions a = new BulkWriteOptions();
+    BulkWriteOptions b = new BulkWriteOptions();
+    assertEquals(a, b);
+
+    a.setWriteOption(WriteOption.ACKNOWLEDGED);
+    b.setWriteOption(WriteOption.JOURNALED);
+    assertNotEquals(a, b);
+
+    a.setWriteOption(WriteOption.MAJORITY);
+    b.setWriteOption(WriteOption.MAJORITY);
+    assertEquals(a, b);
+
+    a.setOrdered(true);
+    b.setOrdered(false);
+    assertNotEquals(a, b);
+
+    assertNotEquals(a, null);
+  }
+
+  @Test
+  public void testHashCode() {
+    BulkWriteOptions a = new BulkWriteOptions()
+      .setWriteOption(WriteOption.JOURNALED)
+      .setOrdered(false);
+    int hash = a.hashCode();
+
+    a.setWriteOption(WriteOption.ACKNOWLEDGED);
+    assertNotEquals(hash, a.hashCode());
+
+    a.setWriteOption(WriteOption.JOURNALED);
+    a.setOrdered(true);
+    assertNotEquals(hash, a.hashCode());
+
+    a.setWriteOption(WriteOption.JOURNALED);
+    a.setOrdered(false);
+    assertEquals(hash, a.hashCode());
+  }
+}


### PR DESCRIPTION
Add `equals` & `hashCode` methods to `BulkWriteOptions`. Same semantics & style as in the other `*Options` objects.