### PR TITLE
add equals & hashCode to BulkOperation

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/BulkOperation.java
+++ b/src/main/java/io/vertx/ext/mongo/BulkOperation.java
@@ -269,4 +269,27 @@ public class BulkOperation {
     return this;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    BulkOperation other = (BulkOperation) o;
+
+    if (type != other.type) return false;
+    if (filter != null ? !filter.equals(other.filter) : other.filter != null) return false;
+    if (document != null ? !document.equals(other.document) : other.document != null) return false;
+
+    return upsert == other.upsert && multi == other.multi;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = type.hashCode();
+    result = 31 * result + filter.hashCode();
+    result = 31 * result + document.hashCode();
+    result = 31 * result + (upsert ? 1 : 0);
+    result = 31 * result + (multi ? 1 : 0);
+    return result;
+  }
 }

--- a/src/test/java/io/vertx/ext/mongo/BulkOperationTest.java
+++ b/src/test/java/io/vertx/ext/mongo/BulkOperationTest.java
@@ -1,0 +1,79 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class BulkOperationTest {
+
+  @Test
+  public void testEquals() {
+    BulkOperation a = BulkOperation.createUpdate(new JsonObject(), new JsonObject());
+    BulkOperation b = BulkOperation.createUpdate(new JsonObject(), new JsonObject());
+
+    a.setType(BulkOperation.BulkOperationType.UPDATE);
+    b.setType(BulkOperation.BulkOperationType.INSERT);
+    assertNotEquals(a, b);
+    b.setType(BulkOperation.BulkOperationType.UPDATE);
+    assertEquals(a, b);
+
+    a.setFilter(new JsonObject().put("foo", "bar"));
+    b.setFilter(new JsonObject().put("foo", "eek"));
+    assertNotEquals(a, b);
+    b.setFilter(new JsonObject().put("foo", "bar"));
+    assertEquals(a, b);
+
+    a.setDocument(new JsonObject().put("bar", "foo"));
+    b.setDocument(new JsonObject().put("bar", "eek"));
+    assertNotEquals(a, b);
+    b.setDocument(new JsonObject().put("bar", "foo"));
+    assertEquals(a, b);
+
+    a.setMulti(true);
+    b.setMulti(false);
+    assertNotEquals(a, b);
+    b.setMulti(true);
+    assertEquals(a, b);
+
+    a.setUpsert(true);
+    b.setUpsert(false);
+    assertNotEquals(a, b);
+    b.setUpsert(true);
+    assertEquals(a, b);
+
+    assertNotEquals(a, null);
+  }
+
+  @Test
+  public void testHashCode() {
+    BulkOperation a = BulkOperation.createUpdate(new JsonObject().put("foo", "bar"), new JsonObject().put("bar", "foo"), true, true);
+    int hash = a.hashCode();
+
+    a.setType(BulkOperation.BulkOperationType.INSERT);
+    assertNotEquals(hash, a.hashCode());
+    a.setType(BulkOperation.BulkOperationType.UPDATE);
+    assertEquals(hash, a.hashCode());
+
+    a.setFilter(new JsonObject().put("foo", "eek"));
+    assertNotEquals(hash, a.hashCode());
+    a.setFilter(new JsonObject().put("foo", "bar"));
+    assertEquals(hash, a.hashCode());
+
+    a.setDocument(new JsonObject().put("bar", "eek"));
+    assertNotEquals(hash, a.hashCode());
+    a.setDocument(new JsonObject().put("bar", "foo"));
+    assertEquals(hash, a.hashCode());
+
+    a.setMulti(false);
+    assertNotEquals(hash, a.hashCode());
+    a.setMulti(true);
+    assertEquals(hash, a.hashCode());
+
+    a.setUpsert(false);
+    assertNotEquals(hash, a.hashCode());
+    a.setUpsert(true);
+    assertEquals(hash, a.hashCode());
+  }
+}


### PR DESCRIPTION
Add `equals` & `hashCode` methods to `BulkOperation`. Same semantics & style as in the other objects. And same motivation as in PR #168 and #169.