### PR TITLE
Fix #171: MongoIterableStream execute the EndHandler even there is a bunch of data remaining in the pending queue

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/impl/MongoIterableStream.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoIterableStream.java
@@ -94,11 +94,10 @@ class MongoIterableStream implements ReadStream<JsonObject> {
         return this;
       }
     }
+
+    queue.resume();
     if (queue.isEmpty() && closeShouldBeCalled) {
-      queue.resume();
       tryClose();
-    } else {
-      queue.resume();
     }
     return this;
   }
@@ -145,19 +144,18 @@ class MongoIterableStream implements ReadStream<JsonObject> {
     });
   }
 
-  private boolean tryClose() {
+  private synchronized void tryClose() {
     if (queue.isPaused()) {
       closeShouldBeCalled = true;
-      return false;
+      return;
     }
+
     if (queue.isEmpty()) {
       close();
       if (endHandler != null) {
         endHandler.handle(null);
       }
-      return true;
     }
-    return false;
   }
 
   // Always called from a synchronized method or block


### PR DESCRIPTION
Add a tryClose method which checks the inBound buffer before closing the stream by calling the endHandler