### PR TITLE
add trustAll and caPath option

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/impl/config/SSLSettingsParser.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/config/SSLSettingsParser.java
@@ -4,6 +4,13 @@ import com.mongodb.ConnectionString;
 import com.mongodb.connection.SslSettings;
 import io.vertx.core.json.JsonObject;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
 import java.util.Optional;
 
 /**
@@ -19,21 +26,42 @@ class SSLSettingsParser {
   }
 
   public SslSettings settings() {
-    return fromConnectionString().orElseGet(this::fromConfiguration);
+    final SslSettings.Builder builder = fromConnectionString().orElseGet(this::fromConfiguration);
+    if (config.getBoolean("trustAll", false)) {
+      try {
+        final SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, new TrustManager[]{new X509TrustManager() {
+          @Override
+          public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
+          }
+
+          @Override
+          public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
+          }
+
+          @Override
+          public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+          }
+        }}, new SecureRandom());
+        builder.context(context);
+      } catch (final NoSuchAlgorithmException | KeyManagementException e) {
+        //fail silently on error
+      }
+    }
+    return builder.build();
   }
 
-  private Optional<SslSettings> fromConnectionString() {
+  private Optional<SslSettings.Builder> fromConnectionString() {
     return Optional.ofNullable(connectionString).map(cs ->
       SslSettings.builder()
         .applyConnectionString(cs)
-        .build()
     );
   }
 
-  private SslSettings fromConfiguration() {
+  private SslSettings.Builder fromConfiguration() {
     return SslSettings.builder()
       .enabled(config.getBoolean("ssl", false))
-      .invalidHostNameAllowed(config.getBoolean("sslInvalidHostNameAllowed", false))
-      .build();
+      .invalidHostNameAllowed(config.getBoolean("sslInvalidHostNameAllowed", false));
   }
 }

--- a/src/test/java/io/vertx/ext/mongo/impl/config/ParsingSSLOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/config/ParsingSSLOptionsTest.java
@@ -3,11 +3,20 @@ package io.vertx.ext.mongo.impl.config;
 import com.mongodb.async.client.MongoClientSettings;
 import com.mongodb.connection.SslSettings;
 import io.vertx.core.json.JsonObject;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 
 import static org.junit.Assert.*;
 
 public class ParsingSSLOptionsTest {
+
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
 
   @Test
   public void ssl_should_be_disabled_by_default() {
@@ -96,5 +105,86 @@ public class ParsingSSLOptionsTest {
 
     // then
     assertNotNull(sslSettings.getContext());
+  }
+
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidCaPathProperty() {
+    // given
+    final JsonObject withSSLAndCaPath = new JsonObject()
+      .put("ssl", true)
+      .put("caPath", "notExisting.pem");
+
+    // then
+    new MongoClientOptionsParser(withSSLAndCaPath);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEmptyPemCertificate() throws IOException {
+    // given
+    final File tmpFile = tmpFolder.newFile("invalidCa.pem");
+    final JsonObject withSSLAndCaPath = new JsonObject()
+      .put("ssl", true)
+      .put("caPath", tmpFile.getAbsolutePath());
+
+    // when
+    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLAndCaPath)
+      .settings()
+      .getSslSettings();
+
+    // then
+    assertNotNull(sslSettings.getContext());
+  }
+
+  @Test
+  public void testValidPemCertificate() throws IOException {
+    // given
+    final File tmpFile = tmpFolder.newFile("validCa.pem");
+    try (final FileWriter tmpWriter = new FileWriter(tmpFile)) {
+      tmpWriter.write("-----BEGIN CERTIFICATE-----\n" +
+        "MIICljCCAfigAwIBAgIJAK0oe+f4DaojMAoGCCqGSM49BAMEMFkxCzAJBgNVBAYT\n" +
+        "AkFUMQ8wDQYDVQQIDAZWaWVubmExDjAMBgNVBAoMBU5vRW52MSkwJwYDVQQLDCBO\n" +
+        "b0VudiBSb290IENlcnRpZmljYXRlIEF1dGhvcml0eTAeFw0xNjEwMjcxNTAwNTFa\n" +
+        "Fw00NjEwMjAxNTAwNTFaMFkxCzAJBgNVBAYTAkFUMQ8wDQYDVQQIDAZWaWVubmEx\n" +
+        "DjAMBgNVBAoMBU5vRW52MSkwJwYDVQQLDCBOb0VudiBSb290IENlcnRpZmljYXRl\n" +
+        "IEF1dGhvcml0eTCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAHpsMQth12N0d+aE\n" +
+        "FIFRd8in4MTYZNSQEyQ4fuPDNq0Zb+4TXpUmedLZQJKkAQxorak8ESC/tXuQJDUL\n" +
+        "OoKa+R6NAT4EKR1aaVVd7clC9rfGqVwGYslppycy9zsN6O4XLUiripamQF78FzRF\n" +
+        "8wRZvkwYhzud+jpV6shgEMw3zmcwDSYKo2YwZDAdBgNVHQ4EFgQUD96n//91CReu\n" +
+        "Cz1K0qics6aNFV0wHwYDVR0jBBgwFoAUD96n//91CReuCz1K0qics6aNFV0wEgYD\n" +
+        "VR0TAQH/BAgwBgEB/wIBATAOBgNVHQ8BAf8EBAMCAYYwCgYIKoZIzj0EAwQDgYsA\n" +
+        "MIGHAkFOxsApSB7fn8ZnYG/EUscn/uAkjxHsvdEkPKCC+XYCKMssW4YP2kR6gZjo\n" +
+        "J8vaOAJZwNevBe/R9J8zMvsAWRJmWgJCAKLedGLnBuJOK9jjnKBwbVm5OIQfApMA\n" +
+        "I2mJVnNXvS12w4DTZlP0K1t63WxsykBBTOIVXnYdPkdZvvnoAIcfA7iM\n" +
+        "-----END CERTIFICATE-----");
+    }
+    final JsonObject withSSLAndCaPath = new JsonObject()
+      .put("ssl", true)
+      .put("caPath", tmpFile.getAbsolutePath());
+
+    // when
+    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLAndCaPath)
+      .settings()
+      .getSslSettings();
+
+    // then
+    assertNotNull(sslSettings.getContext());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidPemCertificate() throws IOException {
+    // given
+    final File tmpFile = tmpFolder.newFile("validCa.pem");
+    try (final FileWriter tmpWriter = new FileWriter(tmpFile)) {
+      tmpWriter.write("-----BEGIN CERTIFICATE-----\n" +
+        "MIICljCCAfigAwIBAgI...BROKEN...xsykBBTOIVXnYdPkdZvvnoAIcfA7iM\n" +
+        "-----END CERTIFICATE-----");
+    }
+    final JsonObject withSSLAndCaPath = new JsonObject()
+      .put("ssl", true)
+      .put("caPath", tmpFile.getAbsolutePath());
+
+    // then
+    new MongoClientOptionsParser(withSSLAndCaPath);
   }
 }

--- a/src/test/java/io/vertx/ext/mongo/impl/config/ParsingSSLOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/config/ParsingSSLOptionsTest.java
@@ -5,8 +5,7 @@ import com.mongodb.connection.SslSettings;
 import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ParsingSSLOptionsTest {
 
@@ -81,5 +80,21 @@ public class ParsingSSLOptionsTest {
 
     // then
     assertTrue(sslSettings.isInvalidHostNameAllowed());
+  }
+
+  @Test
+  public void testTrustAllProperty() {
+    // given
+    final JsonObject withSSLAndTrustAllEnabled = new JsonObject()
+      .put("ssl", true)
+      .put("trustAll", true);
+
+    // when
+    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLAndTrustAllEnabled)
+      .settings()
+      .getSslSettings();
+
+    // then
+    assertNotNull(sslSettings.getContext());
   }
 }


### PR DESCRIPTION
add a vertx compatible option to trust all certificates setting an empty trust store in the ssl context