### PR TITLE
fix MongoIterableStream

### DIFF
--- a/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
@@ -105,7 +105,7 @@ public class MongoClientTest extends MongoClientTestBase {
 
     String collection = randomCollection();
     CountDownLatch latch = new CountDownLatch(1);
-    AtomicReference<List<String>> foos = new AtomicReference();
+    AtomicReference<List<String>> foos = new AtomicReference<>();
     mongoClient.createCollection(collection, onSuccess(res -> {
       insertDocs(mongoClient, collection, numDocs, onSuccess(res2 -> {
         FindOptions findOptions = new FindOptions().setSort(new JsonObject().put("foo", 1));


### PR DESCRIPTION
fix for the following behavior

when `findBatchWithOptions` is piped to a slow WriteStream or delayed on purpose via `pause`/`resume` or `fetch`, the stream calls the endHandler already after getting an empty result from the database but ignores the fact that the `InboundBuffer` still holds some elements