### PR TITLE
add client certificate authentication

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -735,8 +735,16 @@ For more information on the format of the connection string please consult the d
   "receiveBufferSize" : 8192,  // int
 
   // Server Settings
-  "heartbeatFrequencyMS" :    1000 // long
-  "minHeartbeatFrequencyMS" : 500 // long
+  "heartbeatFrequencyMS"    : 1000, // long
+  "minHeartbeatFrequencyMS" :  500, // long
+
+  // SSL Settings
+  "ssl" : false,                       // boolean
+  "sslInvalidHostNameAllowed" : false, // boolean
+  "trustAll" : false,                  // boolean
+  "keyPath" : "key.pem",               // string
+  "certPath" : "cert.pem",             // string
+  "caPath" : "ca.pem"                  // string
 }
 ----
 
@@ -768,7 +776,10 @@ For more information on the format of the connection string please consult the d
 `heartbeatFrequencyMS`:: The frequency that the cluster monitor attempts to reach each server. Default is `5000` (5 seconds)
 `minHeartbeatFrequencyMS`:: The minimum heartbeat frequency. The default value is `1000` (1 second)
 `ssl`:: Enable ssl between the vertx-mongo-client and mongo
+`sslInvalidHostNameAllowed`:: Accept hostnames not included in the servers certificate
 `trustAll`:: When using ssl, trust _ALL_ certificates. *WARNING* - Trusting _ALL_ certificates will open you up to potential security issues such as MITM attacks.
+`keyPath`:: Set a path to a file that contains the client key that will be used to authenticate against the server when making SSL connections to mongo.
+`certPath`:: Set a path to a file that contains the certificate that will be used to authenticate against the server when making SSL connections to mongo.
 `caPath`:: Set a path to a file that contains a certificate that will be used as a source of trust when making SSL connections to mongo.
 
 

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -87,7 +87,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     Context context = vertx.getOrCreateContext();
     context.addCloseHook(this);
     this.holder = lookupHolder(dataSourceName, config);
-    this.mongo = holder.mongo();
+    this.mongo = holder.mongo(vertx);
     this.useObjectId = config.getBoolean("useObjectId", false);
   }
 
@@ -100,7 +100,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     Context context = vertx.getOrCreateContext();
     context.addCloseHook(this);
     this.holder = lookupHolder(dataSourceName, config);
-    this.mongo = holder.mongo(settings);
+    this.mongo = holder.mongo(vertx, settings);
     this.useObjectId = config.getBoolean("useObjectId", false);
   }
 
@@ -1052,18 +1052,18 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
       this.closeRunner = closeRunner;
     }
 
-    synchronized com.mongodb.reactivestreams.client.MongoClient mongo() {
+    synchronized com.mongodb.reactivestreams.client.MongoClient mongo(Vertx vertx) {
       if (mongo == null) {
-        MongoClientOptionsParser parser = new MongoClientOptionsParser(config);
+        MongoClientOptionsParser parser = new MongoClientOptionsParser(vertx, config);
         mongo = MongoClients.create(parser.settings());
         db = mongo.getDatabase(parser.database());
       }
       return mongo;
     }
 
-    synchronized com.mongodb.reactivestreams.client.MongoClient mongo(MongoClientSettings settings) {
+    synchronized com.mongodb.reactivestreams.client.MongoClient mongo(Vertx vertx, MongoClientSettings settings) {
       if (mongo == null) {
-        MongoClientOptionsParser parser = new MongoClientOptionsParser(config);
+        MongoClientOptionsParser parser = new MongoClientOptionsParser(vertx, config);
         mongo = MongoClients.create(settings);
         db = mongo.getDatabase(parser.database());
       }

--- a/src/main/java/io/vertx/ext/mongo/impl/config/CredentialListParser.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/config/CredentialListParser.java
@@ -20,23 +20,24 @@ class CredentialListParser {
 
   public CredentialListParser(JsonObject config) {
     String username = config.getString("username");
+    // AuthMechanism
+    AuthenticationMechanism mechanism = null;
+    String authMechanism = config.getString("authMechanism");
+    if (authMechanism != null) {
+      mechanism = getAuthenticationMechanism(authMechanism);
+    }
+    credentials = new ArrayList<>();
     if (username == null) {
-      credentials = Collections.emptyList();
+      if (mechanism == MONGODB_X509) {
+        credentials.add(MongoCredential.createMongoX509Credential());
+      }
     } else {
-      credentials = new ArrayList<>();
       String passwd = config.getString("password");
       char[] password = (passwd == null) ? null : passwd.toCharArray();
       // See https://github.com/vert-x3/vertx-mongo-client/issues/46 - 'admin' as default is a security
       // concern, use  the 'db_name' if none is set.
       String authSource = config.getString("authSource",
         config.getString("db_name", MongoClientImpl.DEFAULT_DB_NAME));
-
-      // AuthMechanism
-      AuthenticationMechanism mechanism = null;
-      String authMechanism = config.getString("authMechanism");
-      if (authMechanism != null) {
-        mechanism = getAuthenticationMechanism(authMechanism);
-      }
 
       // MongoCredential
       String gssapiServiceName = config.getString("gssapiServiceName");

--- a/src/main/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParser.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParser.java
@@ -3,6 +3,7 @@ package io.vertx.ext.mongo.impl.config;
 import com.mongodb.*;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.connection.*;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.MongoClient;
 import io.vertx.ext.mongo.impl.codec.json.JsonObjectCodec;
@@ -24,7 +25,7 @@ public class MongoClientOptionsParser {
   private final MongoClientSettings settings;
   private final String database;
 
-  public MongoClientOptionsParser(JsonObject config) {
+  public MongoClientOptionsParser(Vertx vertx, JsonObject config) {
     Objects.requireNonNull(config);
 
     MongoClientSettings.Builder options = MongoClientSettings.builder();
@@ -60,7 +61,7 @@ public class MongoClientOptionsParser {
     new StreamTypeParser(config).streamFactory().ifPresent(options::streamFactoryFactory);
 
     // SSLSettings
-    SslSettings sslSettings = new SSLSettingsParser(connectionString, config).settings();
+    SslSettings sslSettings = new SSLSettingsParser(connectionString, config).settings(vertx);
     options.applyToSslSettings(builder -> builder.applySettings(sslSettings));
 
     // WriteConcern

--- a/src/main/java/io/vertx/ext/mongo/impl/config/SSLSettingsParser.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/config/SSLSettingsParser.java
@@ -2,29 +2,22 @@ package io.vertx.ext.mongo.impl.config;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.connection.SslSettings;
-import io.vertx.core.impl.logging.Logger;
-import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.core.net.impl.KeyStoreHelper;
 import io.vertx.core.net.impl.TrustAllTrustManager;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.util.Optional;
+import javax.net.ssl.*;
+import java.security.*;
 
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
+ * @author Lukas Prettenthaler
  */
 class SSLSettingsParser {
   private static final Logger log = LoggerFactory.getLogger(SSLSettingsParser.class);
@@ -36,60 +29,55 @@ class SSLSettingsParser {
     this.config = config;
   }
 
-  public SslSettings settings() {
-    final SslSettings.Builder builder = fromConnectionString().orElseGet(this::fromConfiguration);
-    if (config.getBoolean("trustAll", false)) {
-      log.warn("Mongo client has been set to trust ALL certificates, this can open you up to security issues. Make sure you know the risks.");
-      try {
-        final SSLContext context = SSLContext.getInstance("TLS");
-        context.init(null, new TrustManager[]{TrustAllTrustManager.INSTANCE}, new SecureRandom());
-        builder.context(context);
-      } catch (final NoSuchAlgorithmException | KeyManagementException e) {
-        //fail silently on error
-      }
+  public SslSettings settings(Vertx vertx) {
+    final SslSettings.Builder builder = SslSettings.builder();
+    fromConnectionString(builder);
+    fromConfiguration(builder);
+
+    final SslSettings settings = builder.build();
+    if (!settings.isEnabled()) {
+      return settings;
     }
+    final PemKeyCertOptions pemKeyCertOptions = new PemKeyCertOptions();
+    final PemTrustOptions pemTrustOptions = new PemTrustOptions();
     if (config.containsKey("caPath")) {
-      final String caPath = config.getString("caPath");
-      try {
-        final TrustManagerFactory tmf = buildTrustManagerFactory(caPath);
-        final SSLContext context = SSLContext.getInstance("TLS");
-        context.init(null, tmf.getTrustManagers(), new SecureRandom());
-        builder.context(context);
-      } catch (final FileNotFoundException e) {
-        throw new IllegalArgumentException("Invalid caPath " + e.getMessage());
-      } catch (final NoSuchAlgorithmException | CertificateException | KeyStoreException | IOException | KeyManagementException e) {
-        throw new IllegalArgumentException("Unable to load certificate from caPath '" + caPath + "' " + e.getMessage());
+      pemTrustOptions.addCertPath(config.getString("caPath"));
+    }
+    if (config.containsKey("keyPath") && config.containsKey("certPath")) {
+      pemKeyCertOptions.addKeyPath(config.getString("keyPath"));
+      pemKeyCertOptions.addCertPath(config.getString("certPath"));
+    }
+    try {
+      final TrustManager[] tms;
+      if (config.getBoolean("trustAll", false)) {
+        log.warn("Mongo client has been set to trust ALL certificates, this can open you up to security issues. Make sure you know the risks.");
+        tms = new TrustManager[]{TrustAllTrustManager.INSTANCE};
+      } else {
+        final KeyStoreHelper pemTrustStore = KeyStoreHelper.create((VertxInternal) vertx, pemTrustOptions);
+        tms = pemTrustStore.getTrustMgrs((VertxInternal) vertx);
       }
+      final KeyStoreHelper pemKeyCertStore = KeyStoreHelper.create((VertxInternal) vertx, pemKeyCertOptions);
+      final SSLContext context = SSLContext.getInstance("TLS");
+      context.init(pemKeyCertStore.getKeyMgr(), tms, new SecureRandom());
+      builder.context(context);
+    } catch (final Exception e) {
+      throw new IllegalArgumentException(e);
     }
     return builder.build();
   }
 
-  private Optional<SslSettings.Builder> fromConnectionString() {
-    return Optional.ofNullable(connectionString).map(cs ->
-      SslSettings.builder()
-        .applyConnectionString(cs)
-    );
+  private void fromConnectionString(SslSettings.Builder builder) {
+    if (connectionString != null) {
+      builder.applyConnectionString(connectionString);
+    }
   }
 
-  private SslSettings.Builder fromConfiguration() {
-    return SslSettings.builder()
-      .enabled(config.getBoolean("ssl", false))
-      .invalidHostNameAllowed(config.getBoolean("sslInvalidHostNameAllowed", false));
-  }
-
-  private static TrustManagerFactory buildTrustManagerFactory(final String caPath)
-    throws NoSuchAlgorithmException, CertificateException, KeyStoreException, IOException {
-    final CertificateFactory fact = CertificateFactory.getInstance("X.509");
-    final FileInputStream is = new FileInputStream(caPath);
-    final X509Certificate cert = (X509Certificate) fact.generateCertificate(is);
-
-    final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-    ks.load(null, null);
-    ks.setCertificateEntry("1", cert);
-
-    final TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-    trustManagerFactory.init(ks);
-
-    return trustManagerFactory;
+  private void fromConfiguration(SslSettings.Builder builder) {
+    if (config.containsKey("ssl")) {
+      builder.enabled(config.getBoolean("ssl", false));
+    }
+    if (config.containsKey("sslInvalidHostNameAllowed")) {
+      builder.invalidHostNameAllowed(config.getBoolean("sslInvalidHostNameAllowed", false));
+    }
   }
 }

--- a/src/test/java/io/vertx/ext/mongo/impl/config/CredentialListParserTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/config/CredentialListParserTest.java
@@ -129,6 +129,22 @@ public class CredentialListParserTest {
   }
 
   @Test
+  public void testAuth_MONGODB_X509_without_username() {
+    JsonObject config = new JsonObject();
+    String authSource = TestUtils.randomAlphaString(10);
+    config.put("authSource", authSource);
+    config.put("authMechanism", "MONGODB-X509");
+
+    List<MongoCredential> credentials = new CredentialListParser(config).credentials();
+    assertEquals(1, credentials.size());
+    MongoCredential credential = credentials.get(0);
+    assertNull(credential.getUserName());
+    assertNotEquals(authSource, credential.getSource()); // It should ignore the source we pass in
+
+    assertEquals(AuthenticationMechanism.MONGODB_X509, credential.getAuthenticationMechanism());
+  }
+
+  @Test
   public void testAuth_SCRAM_SHA_1() {
     JsonObject config = new JsonObject();
     String username = TestUtils.randomAlphaString(8);

--- a/src/test/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParserTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParserTest.java
@@ -1,17 +1,32 @@
 package io.vertx.ext.mongo.impl.config;
 
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 public class MongoClientOptionsParserTest {
+  private Vertx vertx;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void tearDown() {
+    vertx.close();
+  }
+
   @Test
   public void testConnStringDbName() {
     String connectionString = "mongodb://localhost:27017/mydb";
     JsonObject config = new JsonObject().put("connection_string", connectionString).put("db_name", "unused_db");
 
-    MongoClientOptionsParser parser = new MongoClientOptionsParser(config);
+    MongoClientOptionsParser parser = new MongoClientOptionsParser(vertx, config);
     assertEquals("mydb", parser.database());
   }
 
@@ -20,7 +35,7 @@ public class MongoClientOptionsParserTest {
     String connectionString = "mongodb://localhost:27017/";
     JsonObject config = new JsonObject().put("connection_string", connectionString).put("db_name", "my_db");
 
-    MongoClientOptionsParser parser = new MongoClientOptionsParser(config);
+    MongoClientOptionsParser parser = new MongoClientOptionsParser(vertx, config);
     assertEquals("my_db", parser.database());
   }
 }

--- a/src/test/java/io/vertx/ext/mongo/impl/config/ParsingReadConcernLevelTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/config/ParsingReadConcernLevelTest.java
@@ -1,9 +1,12 @@
 package io.vertx.ext.mongo.impl.config;
 
 import com.mongodb.ReadConcern;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -11,6 +14,17 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(JUnitParamsRunner.class)
 public class ParsingReadConcernLevelTest {
+  private Vertx vertx;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void tearDown() {
+    vertx.close();
+  }
 
   @Parameters(method = "validReadConcernValues")
   @Test
@@ -22,7 +36,7 @@ public class ParsingReadConcernLevelTest {
     );
 
     // when
-    final ReadConcern parsedReadConcern = new MongoClientOptionsParser(configWithConnectionString)
+    final ReadConcern parsedReadConcern = new MongoClientOptionsParser(vertx, configWithConnectionString)
       .settings()
       .getReadConcern();
 
@@ -39,7 +53,7 @@ public class ParsingReadConcernLevelTest {
     );
 
     // when
-    new MongoClientOptionsParser(configWithConnectionString).settings().getReadConcern();
+    new MongoClientOptionsParser(vertx, configWithConnectionString).settings().getReadConcern();
   }
 
   @Parameters(method = "validReadConcernValues")
@@ -51,7 +65,7 @@ public class ParsingReadConcernLevelTest {
       .put("readConcernLevel", readConcernString);
 
     // when
-    final ReadConcern parsedReadConcern = new MongoClientOptionsParser(configWithReadConcernAsSeparateProperty)
+    final ReadConcern parsedReadConcern = new MongoClientOptionsParser(vertx, configWithReadConcernAsSeparateProperty)
       .settings()
       .getReadConcern();
 
@@ -67,7 +81,7 @@ public class ParsingReadConcernLevelTest {
       .put("readConcernLevel", "unrecognized");
 
     // when
-    new MongoClientOptionsParser(configWithReadConcernAsSeparateProperty).settings().getReadConcern();
+    new MongoClientOptionsParser(vertx, configWithReadConcernAsSeparateProperty).settings().getReadConcern();
   }
 
   @Test
@@ -79,7 +93,7 @@ public class ParsingReadConcernLevelTest {
     );
 
     // when
-    final ReadConcern parsedReadConcern = new MongoClientOptionsParser(configWithConnectionString)
+    final ReadConcern parsedReadConcern = new MongoClientOptionsParser(vertx, configWithConnectionString)
       .settings()
       .getReadConcern();
 
@@ -95,7 +109,7 @@ public class ParsingReadConcernLevelTest {
       .put("readConcernLevel", "linearizable");
 
     // when
-    final ReadConcern parsedReadConcern = new MongoClientOptionsParser(configWithReadConcernPassedTwice)
+    final ReadConcern parsedReadConcern = new MongoClientOptionsParser(vertx, configWithReadConcernPassedTwice)
       .settings()
       .getReadConcern();
 

--- a/src/test/java/io/vertx/ext/mongo/impl/config/ParsingSSLOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/config/ParsingSSLOptionsTest.java
@@ -2,7 +2,10 @@ package io.vertx.ext.mongo.impl.config;
 
 import com.mongodb.MongoClientSettings;
 import com.mongodb.connection.SslSettings;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -14,6 +17,17 @@ import java.io.IOException;
 import static org.junit.Assert.*;
 
 public class ParsingSSLOptionsTest {
+  private Vertx vertx;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void tearDown() {
+    vertx.close();
+  }
 
   @Rule
   public TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -26,7 +40,7 @@ public class ParsingSSLOptionsTest {
     );
 
     // when
-    final MongoClientSettings parsedSettings = new MongoClientOptionsParser(configWithoutSSLInfo).settings();
+    final MongoClientSettings parsedSettings = new MongoClientOptionsParser(vertx, configWithoutSSLInfo).settings();
 
     // then
     assertFalse(parsedSettings.getSslSettings().isEnabled());
@@ -41,7 +55,7 @@ public class ParsingSSLOptionsTest {
     );
 
     // when
-    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLEnabled).settings().getSslSettings();
+    final SslSettings sslSettings = new MongoClientOptionsParser(vertx, withSSLEnabled).settings().getSslSettings();
 
     // then
     assertTrue(sslSettings.isEnabled());
@@ -53,7 +67,7 @@ public class ParsingSSLOptionsTest {
     final JsonObject withSSLEnabled = new JsonObject().put("ssl", true);
 
     // when
-    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLEnabled).settings().getSslSettings();
+    final SslSettings sslSettings = new MongoClientOptionsParser(vertx, withSSLEnabled).settings().getSslSettings();
 
     // then
     assertTrue(sslSettings.isEnabled());
@@ -67,7 +81,7 @@ public class ParsingSSLOptionsTest {
     );
 
     // when
-    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLAndInvalidHostnameEnabled)
+    final SslSettings sslSettings = new MongoClientOptionsParser(vertx, withSSLAndInvalidHostnameEnabled)
       .settings()
       .getSslSettings();
 
@@ -83,7 +97,7 @@ public class ParsingSSLOptionsTest {
       .put("sslInvalidHostNameAllowed", true);
 
     // when
-    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLAndInvalidHostnameEnabled)
+    final SslSettings sslSettings = new MongoClientOptionsParser(vertx, withSSLAndInvalidHostnameEnabled)
       .settings()
       .getSslSettings();
 
@@ -99,7 +113,7 @@ public class ParsingSSLOptionsTest {
       .put("trustAll", true);
 
     // when
-    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLAndTrustAllEnabled)
+    final SslSettings sslSettings = new MongoClientOptionsParser(vertx, withSSLAndTrustAllEnabled)
       .settings()
       .getSslSettings();
 
@@ -116,11 +130,11 @@ public class ParsingSSLOptionsTest {
       .put("caPath", "notExisting.pem");
 
     // then
-    new MongoClientOptionsParser(withSSLAndCaPath);
+    new MongoClientOptionsParser(vertx, withSSLAndCaPath);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testEmptyPemCertificate() throws IOException {
+  public void testEmptyCaPemCertificate() throws IOException {
     // given
     final File tmpFile = tmpFolder.newFile("invalidCa.pem");
     final JsonObject withSSLAndCaPath = new JsonObject()
@@ -128,16 +142,16 @@ public class ParsingSSLOptionsTest {
       .put("caPath", tmpFile.getAbsolutePath());
 
     // when
-    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLAndCaPath)
+    final SslSettings sslSettings = new MongoClientOptionsParser(vertx, withSSLAndCaPath)
       .settings()
       .getSslSettings();
 
     // then
-    assertNotNull(sslSettings.getContext());
+    assertNull(sslSettings.getContext());
   }
 
   @Test
-  public void testValidPemCertificate() throws IOException {
+  public void testValidCaPemCertificate() throws IOException {
     // given
     final File tmpFile = tmpFolder.newFile("validCa.pem");
     try (final FileWriter tmpWriter = new FileWriter(tmpFile)) {
@@ -163,7 +177,69 @@ public class ParsingSSLOptionsTest {
       .put("caPath", tmpFile.getAbsolutePath());
 
     // when
-    final SslSettings sslSettings = new MongoClientOptionsParser(withSSLAndCaPath)
+    final SslSettings sslSettings = new MongoClientOptionsParser(vertx, withSSLAndCaPath)
+      .settings()
+      .getSslSettings();
+
+    // then
+    assertNotNull(sslSettings.getContext());
+  }
+
+  @Test
+  public void testValidCaPemCertificateChain() throws IOException {
+    // given
+    final File tmpFile = tmpFolder.newFile("validCa.pem");
+    try (final FileWriter tmpWriter = new FileWriter(tmpFile)) {
+      tmpWriter.write("-----BEGIN CERTIFICATE-----\n" +
+        "MIICljCCAfigAwIBAgIJAK0oe+f4DaojMAoGCCqGSM49BAMEMFkxCzAJBgNVBAYT\n" +
+        "AkFUMQ8wDQYDVQQIDAZWaWVubmExDjAMBgNVBAoMBU5vRW52MSkwJwYDVQQLDCBO\n" +
+        "b0VudiBSb290IENlcnRpZmljYXRlIEF1dGhvcml0eTAeFw0xNjEwMjcxNTAwNTFa\n" +
+        "Fw00NjEwMjAxNTAwNTFaMFkxCzAJBgNVBAYTAkFUMQ8wDQYDVQQIDAZWaWVubmEx\n" +
+        "DjAMBgNVBAoMBU5vRW52MSkwJwYDVQQLDCBOb0VudiBSb290IENlcnRpZmljYXRl\n" +
+        "IEF1dGhvcml0eTCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAHpsMQth12N0d+aE\n" +
+        "FIFRd8in4MTYZNSQEyQ4fuPDNq0Zb+4TXpUmedLZQJKkAQxorak8ESC/tXuQJDUL\n" +
+        "OoKa+R6NAT4EKR1aaVVd7clC9rfGqVwGYslppycy9zsN6O4XLUiripamQF78FzRF\n" +
+        "8wRZvkwYhzud+jpV6shgEMw3zmcwDSYKo2YwZDAdBgNVHQ4EFgQUD96n//91CReu\n" +
+        "Cz1K0qics6aNFV0wHwYDVR0jBBgwFoAUD96n//91CReuCz1K0qics6aNFV0wEgYD\n" +
+        "VR0TAQH/BAgwBgEB/wIBATAOBgNVHQ8BAf8EBAMCAYYwCgYIKoZIzj0EAwQDgYsA\n" +
+        "MIGHAkFOxsApSB7fn8ZnYG/EUscn/uAkjxHsvdEkPKCC+XYCKMssW4YP2kR6gZjo\n" +
+        "J8vaOAJZwNevBe/R9J8zMvsAWRJmWgJCAKLedGLnBuJOK9jjnKBwbVm5OIQfApMA\n" +
+        "I2mJVnNXvS12w4DTZlP0K1t63WxsykBBTOIVXnYdPkdZvvnoAIcfA7iM\n" +
+        "-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\n" +
+        "MIIE0zCCA7ugAwIBAgIQGNrRniZ96LtKIVjNzGs7SjANBgkqhkiG9w0BAQUFADCB\n" +
+        "yjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQL\n" +
+        "ExZWZXJpU2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwNiBWZXJp\n" +
+        "U2lnbiwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MUUwQwYDVQQDEzxW\n" +
+        "ZXJpU2lnbiBDbGFzcyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0\n" +
+        "aG9yaXR5IC0gRzUwHhcNMDYxMTA4MDAwMDAwWhcNMzYwNzE2MjM1OTU5WjCByjEL\n" +
+        "MAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQLExZW\n" +
+        "ZXJpU2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwNiBWZXJpU2ln\n" +
+        "biwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MUUwQwYDVQQDEzxWZXJp\n" +
+        "U2lnbiBDbGFzcyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0aG9y\n" +
+        "aXR5IC0gRzUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCvJAgIKXo1\n" +
+        "nmAMqudLO07cfLw8RRy7K+D+KQL5VwijZIUVJ/XxrcgxiV0i6CqqpkKzj/i5Vbex\n" +
+        "t0uz/o9+B1fs70PbZmIVYc9gDaTY3vjgw2IIPVQT60nKWVSFJuUrjxuf6/WhkcIz\n" +
+        "SdhDY2pSS9KP6HBRTdGJaXvHcPaz3BJ023tdS1bTlr8Vd6Gw9KIl8q8ckmcY5fQG\n" +
+        "BO+QueQA5N06tRn/Arr0PO7gi+s3i+z016zy9vA9r911kTMZHRxAy3QkGSGT2RT+\n" +
+        "rCpSx4/VBEnkjWNHiDxpg8v+R70rfk/Fla4OndTRQ8Bnc+MUCH7lP59zuDMKz10/\n" +
+        "NIeWiu5T6CUVAgMBAAGjgbIwga8wDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8E\n" +
+        "BAMCAQYwbQYIKwYBBQUHAQwEYTBfoV2gWzBZMFcwVRYJaW1hZ2UvZ2lmMCEwHzAH\n" +
+        "BgUrDgMCGgQUj+XTGoasjY5rw8+AatRIGCx7GS4wJRYjaHR0cDovL2xvZ28udmVy\n" +
+        "aXNpZ24uY29tL3ZzbG9nby5naWYwHQYDVR0OBBYEFH/TZafC3ey78DAJ80M5+gKv\n" +
+        "MzEzMA0GCSqGSIb3DQEBBQUAA4IBAQCTJEowX2LP2BqYLz3q3JktvXf2pXkiOOzE\n" +
+        "p6B4Eq1iDkVwZMXnl2YtmAl+X6/WzChl8gGqCBpH3vn5fJJaCGkgDdk+bW48DW7Y\n" +
+        "5gaRQBi5+MHt39tBquCWIMnNZBU4gcmU7qKEKQsTb47bDN0lAtukixlE0kF6BWlK\n" +
+        "WE9gyn6CagsCqiUXObXbf+eEZSqVir2G3l6BFoMtEMze/aiCKm0oHw0LxOXnGiYZ\n" +
+        "4fQRbxC1lfznQgUy286dUV4otp6F01vvpX1FQHKOtw5rDgb7MzVIcbidJ4vEZV8N\n" +
+        "hnacRHr2lVz2XTIIM6RUthg/aFzyQkqFOFSDX9HoLPKsEdao7WNq\n" +
+        "-----END CERTIFICATE-----\n");
+    }
+    final JsonObject withSSLAndCaPath = new JsonObject()
+      .put("ssl", true)
+      .put("caPath", tmpFile.getAbsolutePath());
+
+    // when
+    final SslSettings sslSettings = new MongoClientOptionsParser(vertx, withSSLAndCaPath)
       .settings()
       .getSslSettings();
 
@@ -174,7 +250,7 @@ public class ParsingSSLOptionsTest {
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidPemCertificate() throws IOException {
     // given
-    final File tmpFile = tmpFolder.newFile("validCa.pem");
+    final File tmpFile = tmpFolder.newFile("brokenCa.pem");
     try (final FileWriter tmpWriter = new FileWriter(tmpFile)) {
       tmpWriter.write("-----BEGIN CERTIFICATE-----\n" +
         "MIICljCCAfigAwIBAgI...BROKEN...xsykBBTOIVXnYdPkdZvvnoAIcfA7iM\n" +
@@ -185,6 +261,161 @@ public class ParsingSSLOptionsTest {
       .put("caPath", tmpFile.getAbsolutePath());
 
     // then
-    new MongoClientOptionsParser(withSSLAndCaPath);
+    new MongoClientOptionsParser(vertx, withSSLAndCaPath);
+  }
+
+  @Test
+  public void testValidKeyAndCertificate() throws IOException {
+    // given
+    final File tmpKeyFile = tmpFolder.newFile("validKey.pem");
+    try (final FileWriter tmpKeyWriter = new FileWriter(tmpKeyFile)) {
+      tmpKeyWriter.write("-----BEGIN PRIVATE KEY-----\n" +
+        "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDVmCecLdUZU917\n" +
+        "hweVz4JqvZ9vZEi1rH+BG98HYfRR/h3QaobxPImZu3hzKHZ+MPbm94HunLPAVA9y\n" +
+        "ZhvZMToNfOuD4TUPBPloBuNzwBfZk2O4CaXeG4ailVWUfm5t/l+RD/55zYKuhw1/\n" +
+        "Vl9lcOryF2XAmPQ2F1gwEKK7wt1Ak8zw8/yeYgBv1/F+ibCMvR6FVj9ABBEfTM+o\n" +
+        "Os4oy51otUv0h63GqYgXMJyLX7q+AGWdC3srwwLQROtkzi7y00g/YryXUoIqdXEI\n" +
+        "7CrNL35rZXcZ5LfGRwFX9evX11PpT3OShYlsJBcFE9KMatRoIWd6xUKlxTk0yLjo\n" +
+        "OUE2tsMJAgMBAAECggEAdewZAjqzidYpU0eLQoRcBj5GRaNiGRrxEgCnM1Y7IwFe\n" +
+        "yG/nrEu11DASIdHXCXhS99Tx4SCWhLpkBM6m1VQ+LrAm/ppZRr+CSpJzBLaq9C5R\n" +
+        "QYviDSu5Ow2jP+ZFZWiorlfcMLbrTRu2sfSnmkOrEpkkTh6jxTFCONcWYP8GU93D\n" +
+        "YCA3hSH0li7CueS+GYJ1JB2Cd7buu+tOhl36AhBD96miExlgNn0YGpTJJ3I0Hb+O\n" +
+        "lKIIQy+KK8f9TXrSeZC3OYlTtJaIr9ejspTXxIYN11EIit5MFEwnnkCglcsePjsx\n" +
+        "qeOFRumJ5Nj5H8qyCNZ5MtzwbLkyktJzlumvnyr+AQKBgQDv/QfGKZJFeoCEWpoj\n" +
+        "f+078JxSYyPVNXxbbr2NuN/V79hJBol87ukycz2CZkDCubIKfubc50eXDmhWCp4p\n" +
+        "aJgl6BMhnovftYrIrGWJLwqXnwFwsKJSrJJqHlHDJDRGfUSQEWNclNeaB3Mr8W46\n" +
+        "Zcaadeikstvka9xKA1LOCG3oIQKBgQDj2FFOxZK27KhY/9Oz1dUsPtAYYbLOor/P\n" +
+        "Rbne3jICQStH3dnUEmWKIKrdYV1u2saw5djn3ujwB0xEXydRvRgiSF0qxYjbm9CG\n" +
+        "TJaiHhTsQDjWkYMZaxk3gc7Yfh8DHF0wlvWpu1wMXNsCJ6jxqW2e+jSRioZICPK6\n" +
+        "McWWmArd6QKBgDWjoHEyKXdOAhuTBJCarzOOe+IONpwY8EqfXc6nW6A9k2H/DAvY\n" +
+        "elbEWyMiJ6deSeT+qCsHpoCkv707ck5fCmKulFgXT7wYn4Rqw+b9lKh+6Zt+X0mL\n" +
+        "OM5vKGctWGHI7eIlgMfYnLfYom1X8QMsbE9puy3UrEFJulrwkzlpuOcBAoGAVRNV\n" +
+        "sNsXIFSXu7uyueizU3UU0LXSRVQB2QxJDg3bkHnzBj+xcX15Cq2N/2G2uIjaPf1l\n" +
+        "E5dpVQ70jGcXUG8SDuMEXs8pfg7dOvhoGpqu51RHpN7qm9ggr1g5+x6Ex+2UYmtL\n" +
+        "yZfbFAasBE74x1ujQgRdEqct4sHsmFezVrro+9kCgYEAgl70mKk9yK/f7515OaO0\n" +
+        "Y39tgVzpAG6RN1NKnY6NR5VNNemZx5jhKfk5byaYxX4XBjygD0sQ5KTpaZmoQIIX\n" +
+        "FxuwhLRRMn6vtsEf1HexJAtRd82aL5wKS62l0AXG/CVLAygn4aSSqLrgTyFFVUR3\n" +
+        "cASPpPIdZaKZG6q4Hmcpl58=\n" +
+        "-----END PRIVATE KEY-----");
+    }
+    final File tmpCertFile = tmpFolder.newFile("validCert.pem");
+    try (final FileWriter tmpCertWriter = new FileWriter(tmpCertFile)) {
+      tmpCertWriter.write("-----BEGIN CERTIFICATE-----\n" +
+        "MIICwTCCAamgAwIBAgIEBeVm4jANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZj\n" +
+        "bGllbnQwHhcNMTgwNTI2MTEzNjUxWhcNMjEwNTI1MTEzNjUxWjARMQ8wDQYDVQQD\n" +
+        "EwZjbGllbnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVmCecLdUZ\n" +
+        "U917hweVz4JqvZ9vZEi1rH+BG98HYfRR/h3QaobxPImZu3hzKHZ+MPbm94HunLPA\n" +
+        "VA9yZhvZMToNfOuD4TUPBPloBuNzwBfZk2O4CaXeG4ailVWUfm5t/l+RD/55zYKu\n" +
+        "hw1/Vl9lcOryF2XAmPQ2F1gwEKK7wt1Ak8zw8/yeYgBv1/F+ibCMvR6FVj9ABBEf\n" +
+        "TM+oOs4oy51otUv0h63GqYgXMJyLX7q+AGWdC3srwwLQROtkzi7y00g/YryXUoIq\n" +
+        "dXEI7CrNL35rZXcZ5LfGRwFX9evX11PpT3OShYlsJBcFE9KMatRoIWd6xUKlxTk0\n" +
+        "yLjoOUE2tsMJAgMBAAGjITAfMB0GA1UdDgQWBBQ6xJBQsJCJdj/u0iTLYYD2qQsB\n" +
+        "DDANBgkqhkiG9w0BAQsFAAOCAQEAfoquV375+eAGmfnlLxB30v9VhsFckrxFVpYs\n" +
+        "XXC6h2G8MtXLpIEpgJo+4SZ4YjNwf/8m9J5j/duU8RukYanyzJdgkFFqKDBYCX7U\n" +
+        "SD1nQP7729KnQgxtbR/+i3zkNgo7FATdkLq+HOxklNOEE24Ldenya39bsG779B9n\n" +
+        "Sskcbq++7rMM+onDYBv6PbUKCm6nfqPspq809CLxSaUJg9+9ykut6hiyke/i7GEP\n" +
+        "XIZHrM+mEvG00ES/zBIdV6TE0AIBP7q2MN7ylT509Ko9sUBMOZdEzikYp5GaRdiv\n" +
+        "zG9q6rqK5COK614BwJFOD1DKV1BoDFsgugvfvm/mrc3QfIUPDA==\n" +
+        "-----END CERTIFICATE-----");
+    }
+    final JsonObject withSSLAndCertKeyPath = new JsonObject()
+      .put("ssl", true)
+      .put("keyPath", tmpKeyFile.getAbsolutePath())
+      .put("certPath", tmpCertFile.getAbsolutePath());
+
+    // when
+    final SslSettings sslSettings = new MongoClientOptionsParser(vertx, withSSLAndCertKeyPath)
+      .settings()
+      .getSslSettings();
+
+    // then
+    assertNotNull(sslSettings.getContext());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidKey() throws IOException {
+    // given
+    final File tmpKeyFile = tmpFolder.newFile("brokenKey.pem");
+    try (final FileWriter tmpKeyWriter = new FileWriter(tmpKeyFile)) {
+      tmpKeyWriter.write("-----BEGIN CERTIFICATE-----\n" +
+        "MIICljCCAfigAwIBAgI...BROKEN...xsykBBTOIVXnYdPkdZvvnoAIcfA7iM\n" +
+        "-----END CERTIFICATE-----");
+    }
+    final File tmpCertFile = tmpFolder.newFile("validCert.pem");
+    try (final FileWriter tmpCertWriter = new FileWriter(tmpCertFile)) {
+      tmpCertWriter.write("-----BEGIN CERTIFICATE-----\n" +
+        "MIICwTCCAamgAwIBAgIEBeVm4jANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZj\n" +
+        "bGllbnQwHhcNMTgwNTI2MTEzNjUxWhcNMjEwNTI1MTEzNjUxWjARMQ8wDQYDVQQD\n" +
+        "EwZjbGllbnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVmCecLdUZ\n" +
+        "U917hweVz4JqvZ9vZEi1rH+BG98HYfRR/h3QaobxPImZu3hzKHZ+MPbm94HunLPA\n" +
+        "VA9yZhvZMToNfOuD4TUPBPloBuNzwBfZk2O4CaXeG4ailVWUfm5t/l+RD/55zYKu\n" +
+        "hw1/Vl9lcOryF2XAmPQ2F1gwEKK7wt1Ak8zw8/yeYgBv1/F+ibCMvR6FVj9ABBEf\n" +
+        "TM+oOs4oy51otUv0h63GqYgXMJyLX7q+AGWdC3srwwLQROtkzi7y00g/YryXUoIq\n" +
+        "dXEI7CrNL35rZXcZ5LfGRwFX9evX11PpT3OShYlsJBcFE9KMatRoIWd6xUKlxTk0\n" +
+        "yLjoOUE2tsMJAgMBAAGjITAfMB0GA1UdDgQWBBQ6xJBQsJCJdj/u0iTLYYD2qQsB\n" +
+        "DDANBgkqhkiG9w0BAQsFAAOCAQEAfoquV375+eAGmfnlLxB30v9VhsFckrxFVpYs\n" +
+        "XXC6h2G8MtXLpIEpgJo+4SZ4YjNwf/8m9J5j/duU8RukYanyzJdgkFFqKDBYCX7U\n" +
+        "SD1nQP7729KnQgxtbR/+i3zkNgo7FATdkLq+HOxklNOEE24Ldenya39bsG779B9n\n" +
+        "Sskcbq++7rMM+onDYBv6PbUKCm6nfqPspq809CLxSaUJg9+9ykut6hiyke/i7GEP\n" +
+        "XIZHrM+mEvG00ES/zBIdV6TE0AIBP7q2MN7ylT509Ko9sUBMOZdEzikYp5GaRdiv\n" +
+        "zG9q6rqK5COK614BwJFOD1DKV1BoDFsgugvfvm/mrc3QfIUPDA==\n" +
+        "-----END CERTIFICATE-----");
+    }
+    final JsonObject withSSLAndCertKeyPath = new JsonObject()
+      .put("ssl", true)
+      .put("keyPath", tmpKeyFile.getAbsolutePath())
+      .put("certPath", tmpCertFile.getAbsolutePath());
+
+    // then
+    new MongoClientOptionsParser(vertx, withSSLAndCertKeyPath);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidCertificate() throws IOException {
+    // given
+    final File tmpKeyFile = tmpFolder.newFile("validKey.pem");
+    try (final FileWriter tmpKeyWriter = new FileWriter(tmpKeyFile)) {
+      tmpKeyWriter.write("-----BEGIN PRIVATE KEY-----\n" +
+        "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDVmCecLdUZU917\n" +
+        "hweVz4JqvZ9vZEi1rH+BG98HYfRR/h3QaobxPImZu3hzKHZ+MPbm94HunLPAVA9y\n" +
+        "ZhvZMToNfOuD4TUPBPloBuNzwBfZk2O4CaXeG4ailVWUfm5t/l+RD/55zYKuhw1/\n" +
+        "Vl9lcOryF2XAmPQ2F1gwEKK7wt1Ak8zw8/yeYgBv1/F+ibCMvR6FVj9ABBEfTM+o\n" +
+        "Os4oy51otUv0h63GqYgXMJyLX7q+AGWdC3srwwLQROtkzi7y00g/YryXUoIqdXEI\n" +
+        "7CrNL35rZXcZ5LfGRwFX9evX11PpT3OShYlsJBcFE9KMatRoIWd6xUKlxTk0yLjo\n" +
+        "OUE2tsMJAgMBAAECggEAdewZAjqzidYpU0eLQoRcBj5GRaNiGRrxEgCnM1Y7IwFe\n" +
+        "yG/nrEu11DASIdHXCXhS99Tx4SCWhLpkBM6m1VQ+LrAm/ppZRr+CSpJzBLaq9C5R\n" +
+        "QYviDSu5Ow2jP+ZFZWiorlfcMLbrTRu2sfSnmkOrEpkkTh6jxTFCONcWYP8GU93D\n" +
+        "YCA3hSH0li7CueS+GYJ1JB2Cd7buu+tOhl36AhBD96miExlgNn0YGpTJJ3I0Hb+O\n" +
+        "lKIIQy+KK8f9TXrSeZC3OYlTtJaIr9ejspTXxIYN11EIit5MFEwnnkCglcsePjsx\n" +
+        "qeOFRumJ5Nj5H8qyCNZ5MtzwbLkyktJzlumvnyr+AQKBgQDv/QfGKZJFeoCEWpoj\n" +
+        "f+078JxSYyPVNXxbbr2NuN/V79hJBol87ukycz2CZkDCubIKfubc50eXDmhWCp4p\n" +
+        "aJgl6BMhnovftYrIrGWJLwqXnwFwsKJSrJJqHlHDJDRGfUSQEWNclNeaB3Mr8W46\n" +
+        "Zcaadeikstvka9xKA1LOCG3oIQKBgQDj2FFOxZK27KhY/9Oz1dUsPtAYYbLOor/P\n" +
+        "Rbne3jICQStH3dnUEmWKIKrdYV1u2saw5djn3ujwB0xEXydRvRgiSF0qxYjbm9CG\n" +
+        "TJaiHhTsQDjWkYMZaxk3gc7Yfh8DHF0wlvWpu1wMXNsCJ6jxqW2e+jSRioZICPK6\n" +
+        "McWWmArd6QKBgDWjoHEyKXdOAhuTBJCarzOOe+IONpwY8EqfXc6nW6A9k2H/DAvY\n" +
+        "elbEWyMiJ6deSeT+qCsHpoCkv707ck5fCmKulFgXT7wYn4Rqw+b9lKh+6Zt+X0mL\n" +
+        "OM5vKGctWGHI7eIlgMfYnLfYom1X8QMsbE9puy3UrEFJulrwkzlpuOcBAoGAVRNV\n" +
+        "sNsXIFSXu7uyueizU3UU0LXSRVQB2QxJDg3bkHnzBj+xcX15Cq2N/2G2uIjaPf1l\n" +
+        "E5dpVQ70jGcXUG8SDuMEXs8pfg7dOvhoGpqu51RHpN7qm9ggr1g5+x6Ex+2UYmtL\n" +
+        "yZfbFAasBE74x1ujQgRdEqct4sHsmFezVrro+9kCgYEAgl70mKk9yK/f7515OaO0\n" +
+        "Y39tgVzpAG6RN1NKnY6NR5VNNemZx5jhKfk5byaYxX4XBjygD0sQ5KTpaZmoQIIX\n" +
+        "FxuwhLRRMn6vtsEf1HexJAtRd82aL5wKS62l0AXG/CVLAygn4aSSqLrgTyFFVUR3\n" +
+        "cASPpPIdZaKZG6q4Hmcpl58=\n" +
+        "-----END PRIVATE KEY-----");
+    }
+    final File tmpCertFile = tmpFolder.newFile("brokenCert.pem");
+    try (final FileWriter tmpCertWriter = new FileWriter(tmpCertFile)) {
+      tmpCertWriter.write("-----BEGIN CERTIFICATE-----\n" +
+        "MIICwTCCAamgAwIBA...BROKEN...FOD1DKV1BoDFsgugvfvm/mrc3QfIUPDA==\n" +
+        "-----END CERTIFICATE-----");
+    }
+    final JsonObject withSSLAndCertKeyPath = new JsonObject()
+      .put("ssl", true)
+      .put("keyPath", tmpKeyFile.getAbsolutePath())
+      .put("certPath", tmpCertFile.getAbsolutePath());
+
+    // then
+    new MongoClientOptionsParser(vertx, withSSLAndCertKeyPath);
   }
 }

--- a/src/test/java/io/vertx/ext/mongo/impl/config/ParsingStreamTypeTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/config/ParsingStreamTypeTest.java
@@ -4,9 +4,12 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.connection.AsynchronousSocketChannelStreamFactoryFactory;
 import com.mongodb.connection.StreamFactoryFactory;
 import com.mongodb.connection.netty.NettyStreamFactoryFactory;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -15,6 +18,17 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(JUnitParamsRunner.class)
 public class ParsingStreamTypeTest {
+  private Vertx vertx;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void tearDown() {
+    vertx.close();
+  }
 
   @Test
   public void should_not_include_any_stream_type_by_default_for_backwards_compatibility() {
@@ -24,7 +38,7 @@ public class ParsingStreamTypeTest {
     );
 
     // when
-    final MongoClientSettings parsedSettings = new MongoClientOptionsParser(noStreamTypeProvided).settings();
+    final MongoClientSettings parsedSettings = new MongoClientOptionsParser(vertx, noStreamTypeProvided).settings();
 
     // then
     assertNull(parsedSettings.getStreamFactoryFactory());
@@ -37,7 +51,7 @@ public class ParsingStreamTypeTest {
     final JsonObject cfgWithStreamTypeProvided = new JsonObject().put("streamType", streamTypeString);
 
     // when
-    final MongoClientSettings parsedSettings = new MongoClientOptionsParser(cfgWithStreamTypeProvided).settings();
+    final MongoClientSettings parsedSettings = new MongoClientOptionsParser(vertx, cfgWithStreamTypeProvided).settings();
 
     // then
     assertThat(parsedSettings.getStreamFactoryFactory(), instanceOf(streamType));
@@ -49,7 +63,7 @@ public class ParsingStreamTypeTest {
     final JsonObject withInvalidStreamType = new JsonObject().put("streamType", "unrecognized");
 
     // expect thrown
-    new MongoClientOptionsParser(withInvalidStreamType).settings();
+    new MongoClientOptionsParser(vertx, withInvalidStreamType).settings();
   }
 
   private Object[] validSteamTypes() {


### PR DESCRIPTION
* update credential option parser to support x509 without username
* refactor caPath to support certificate chains as well
* add keyPath and certPath
* refactor ssl impl to use vertx ssl helpers
* update docs and tests