### PR TITLE
upgrade mongo driver to 4.1.0, upgrade mongo mock to use 4.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
-    <mongodb.driver.reactivestreams.version>4.0.2</mongodb.driver.reactivestreams.version>
+    <mongodb.driver.reactivestreams.version>4.1.0</mongodb.driver.reactivestreams.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 

--- a/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
@@ -244,7 +244,7 @@ public class MongoClientTest extends MongoClientTestBase {
 
   private void upsertDoc(String collection, JsonObject docToInsert, String expectedId, Consumer<JsonObject> doneFunction) {
     JsonObject insertStatement = new JsonObject()
-      .put("$set", docToInsert);
+      .put("$setOnInsert", docToInsert);
 
     upsertDoc(collection, docToInsert, insertStatement, expectedId, doneFunction);
   }

--- a/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
@@ -168,10 +168,11 @@ public abstract class MongoClientTestBase extends MongoTestBase {
 
     JsonObject command = new JsonObject()
       .put("aggregate", "collection_name")
-      .put("pipeline", new JsonArray());
+      .put("pipeline", new JsonArray())
+      .put("cursor", new JsonObject());
 
     mongoClient.runCommand("aggregate", command, onSuccess(resultObj -> {
-      JsonArray resArr = resultObj.getJsonArray("result");
+      JsonArray resArr = resultObj.getJsonObject("cursor").getJsonArray("firstBatch");
       assertNotNull(resArr);
       assertEquals(0, resArr.size());
       testComplete();

--- a/src/test/java/io/vertx/ext/mongo/MongoTestBase.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoTestBase.java
@@ -21,7 +21,10 @@ import de.flapdoodle.embed.mongo.MongodStarter;
 import de.flapdoodle.embed.mongo.config.IMongodConfig;
 import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Feature;
+import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
 import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.mongo.distribution.Versions;
 import de.flapdoodle.embed.process.runtime.Network;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -70,7 +73,7 @@ public abstract class MongoTestBase extends VertxTestBase {
   public static void startMongo() throws Exception {
     String uri = getConnectionString();
     if (uri == null ) {
-      Version.Main version = Version.Main.V3_4;
+      Version.Main version = Version.Main.V4_0;
       int port = 27018;
       System.out.println("Starting Mongo " + version + " on port " + port);
       IMongodConfig config = new MongodConfigBuilder().


### PR DESCRIPTION
Motivation:

* mongo 4.4.0 was released and needs driver 4.1.x for compatibility
* mongo mock still used 3.4 server version which is really old
  upgrade to mongo 4.4.0 was not possible as this mongo mock does only support <4.0.x