### PR TITLE
add equals & hashCode to IndexModel

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/IndexModel.java
+++ b/src/main/java/io/vertx/ext/mongo/IndexModel.java
@@ -3,6 +3,8 @@ package io.vertx.ext.mongo;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
+import java.util.Objects;
+
 @DataObject
 public class IndexModel {
   private JsonObject key;
@@ -43,5 +45,19 @@ public class IndexModel {
       + "keys="+key
       + ", options="+options
       + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    IndexModel that = (IndexModel) o;
+    return Objects.equals(key, that.key) &&
+      Objects.equals(options, that.options);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, options);
   }
 }

--- a/src/test/java/io/vertx/ext/mongo/IndexModelTest.java
+++ b/src/test/java/io/vertx/ext/mongo/IndexModelTest.java
@@ -1,0 +1,43 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class IndexModelTest {
+
+  private IndexModel a, b, c, d;
+
+  @Before
+  public void setup() {
+    a = new IndexModel(new JsonObject().put("foo", "bar"));
+    b = new IndexModel(new JsonObject().put("foo", "bar"));
+    c = new IndexModel(new JsonObject().put("bar", "eek"), new IndexOptions().name("bar"));
+    d = new IndexModel(new JsonObject().put("bar", "eek"), new IndexOptions().name("foo"));
+  }
+
+  @Test
+  public void testEquals() {
+    assertNotEquals(a, null);
+    assertEquals(a, b);
+    assertNotEquals(a, c);
+    assertNotEquals(a, d);
+    assertNotEquals(b, null);
+    assertNotEquals(b, c);
+    assertNotEquals(b, d);
+    assertNotEquals(c, d);
+  }
+
+  @Test
+  public void testHashCode() {
+    assertEquals(a.hashCode(), b.hashCode());
+    assertNotEquals(a.hashCode(), c.hashCode());
+    assertNotEquals(a.hashCode(), d.hashCode());
+    assertNotEquals(b.hashCode(), c.hashCode());
+    assertNotEquals(b.hashCode(), d.hashCode());
+    assertNotEquals(c.hashCode(), d.hashCode());
+  }
+}


### PR DESCRIPTION
Add `equals` & `hashCode` methods to `IndexModel`. Same reasoning as for #168 and #169.