### PR TITLE
fix from/to json of IndexModel

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -137,7 +137,7 @@ Set the sort document
 |===
 ^|Name | Type ^| Description
 |[[key]]`@key`|`Json object`|+++
-Get the index key
+Sets the index key
 +++
 |===
 

--- a/src/main/generated/io/vertx/ext/mongo/IndexModelConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/IndexModelConverter.java
@@ -1,0 +1,45 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.ext.mongo.IndexModel}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.IndexModel} original class using Vert.x codegen.
+ */
+public class IndexModelConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, IndexModel obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "key":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setKey(((JsonObject)member.getValue()).copy());
+          }
+          break;
+        case "options":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setOptions(new io.vertx.ext.mongo.IndexOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(IndexModel obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(IndexModel obj, java.util.Map<String, Object> json) {
+    if (obj.getKey() != null) {
+      json.put("key", obj.getKey());
+    }
+    if (obj.getOptions() != null) {
+      json.put("options", obj.getOptions().toJson());
+    }
+  }
+}

--- a/src/main/java/io/vertx/ext/mongo/IndexModel.java
+++ b/src/main/java/io/vertx/ext/mongo/IndexModel.java
@@ -2,6 +2,7 @@ package io.vertx.ext.mongo;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+
 import java.util.Objects;
 
 @DataObject(generateConverter = true)
@@ -17,6 +18,7 @@ public class IndexModel {
 
   /**
    * Json constructor
+   *
    * @param json - the json object
    */
   public IndexModel(JsonObject json) {
@@ -30,12 +32,16 @@ public class IndexModel {
 
   /**
    * Get the index key
+   *
    * @return - the index keys
    */
-  public JsonObject getKey() { return key; }
+  public JsonObject getKey() {
+    return key;
+  }
 
   /**
    * Sets the index key
+   *
    * @param key - the index keys
    * @return this for fluency
    */
@@ -46,12 +52,16 @@ public class IndexModel {
 
   /**
    * Get the index options
+   *
    * @return - the index options
    */
-  public IndexOptions getOptions() { return options; }
+  public IndexOptions getOptions() {
+    return options;
+  }
 
   /**
    * Sets the index options
+   *
    * @param options - the index options
    * @return this for fluency
    */
@@ -62,6 +72,7 @@ public class IndexModel {
 
   /**
    * Convert to JSON
+   *
    * @return the JSON
    */
   public JsonObject toJson() {
@@ -73,8 +84,8 @@ public class IndexModel {
   @Override
   public String toString() {
     return "IndexModel{"
-      + "keys="+key
-      + ", options="+options
+      + "keys=" + key
+      + ", options=" + options
       + '}';
   }
 

--- a/src/main/java/io/vertx/ext/mongo/IndexModel.java
+++ b/src/main/java/io/vertx/ext/mongo/IndexModel.java
@@ -2,20 +2,25 @@ package io.vertx.ext.mongo;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
-
 import java.util.Objects;
 
-@DataObject
+@DataObject(generateConverter = true)
 public class IndexModel {
   private JsonObject key;
   private IndexOptions options;
 
   /**
-   * Construct an isntance with the given key
-   * @param key - the index key
+   * Default constructor
    */
-  public IndexModel(final JsonObject key) {
-    this.key = key;
+  public IndexModel() {
+  }
+
+  /**
+   * Json constructor
+   * @param json - the json object
+   */
+  public IndexModel(JsonObject json) {
+    IndexModelConverter.fromJson(json, this);
   }
 
   public IndexModel(final JsonObject key, final IndexOptions options) {
@@ -30,13 +35,39 @@ public class IndexModel {
   public JsonObject getKey() { return key; }
 
   /**
+   * Sets the index key
+   * @param key - the index keys
+   * @return this for fluency
+   */
+  public IndexModel setKey(JsonObject key) {
+    this.key = key;
+    return this;
+  }
+
+  /**
    * Get the index options
    * @return - the index options
    */
   public IndexOptions getOptions() { return options; }
 
+  /**
+   * Sets the index options
+   * @param options - the index options
+   * @return this for fluency
+   */
+  public IndexModel setOptions(IndexOptions options) {
+    this.options = options;
+    return this;
+  }
+
+  /**
+   * Convert to JSON
+   * @return the JSON
+   */
   public JsonObject toJson() {
-    return key;
+    JsonObject json = new JsonObject();
+    IndexModelConverter.toJson(this, json);
+    return json;
   }
 
   @Override

--- a/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
@@ -94,11 +94,11 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     mongoClient.createCollection(collection, onSuccess(res -> {
       List<IndexModel> indexes = new ArrayList<>();
       JsonObject key = new JsonObject().put("field", 1);
-      IndexModel index = new IndexModel(key);
+      IndexModel index = new IndexModel().setKey(key);
       indexes.add(index);
 
       JsonObject key2 = new JsonObject().put("field1", 1);
-      IndexModel index2 = new IndexModel(key2);
+      IndexModel index2 = new IndexModel().setKey(key2);
       indexes.add(index2);
 
       mongoClient.createIndexes(collection, indexes, onSuccess(res2 -> {


### PR DESCRIPTION
Converting an `IndexModel` from and to json is not fully implemented, the `IndexOptions` are ignored. This PR fixes this by using a generated `IndexModelConverter`.