### PR TITLE
SSL: Use default trust for empty trust options

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/impl/config/SSLSettingsParser.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/config/SSLSettingsParser.java
@@ -50,8 +50,10 @@ class SSLSettingsParser {
       if (config.getBoolean("trustAll", false)) {
         log.warn("Mongo client has been set to trust ALL certificates, this can open you up to security issues. Make sure you know the risks.");
         tms = new TrustManager[]{TrustAllTrustManager.INSTANCE};
+      } else if (!pemTrustOptions.getCertPaths().isEmpty()) {
+        tms = pemTrustOptions.getTrustManagerFactory(vertx).getTrustManagers();
       } else {
-        tms = pemTrustOptions.getTrustManagerFactory((Vertx) vertx).getTrustManagers();
+        tms = null;
       }
       final SSLContext context = SSLContext.getInstance("TLS");
       KeyManager[] mgr = pemKeyCertOptions.getKeyManagerFactory(vertx).getKeyManagers();

--- a/src/test/java/io/vertx/ext/mongo/impl/config/ParsingSSLOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/config/ParsingSSLOptionsTest.java
@@ -121,6 +121,19 @@ public class ParsingSSLOptionsTest {
     assertNotNull(sslSettings.getContext());
   }
 
+  @Test
+  public void testEmptyCaPathProperty() {
+    // given
+    final JsonObject withSSLwithoutCaPath = new JsonObject().put("ssl", true);
+
+    // when
+    final SslSettings sslSettings = new MongoClientOptionsParser(vertx, withSSLwithoutCaPath)
+      .settings()
+      .getSslSettings();
+
+    // then
+    assertNotNull(sslSettings.getContext());
+  }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidCaPathProperty() {


### PR DESCRIPTION
When `ssl` is set to `true` but `caPath` is *not* set, a TrustManager with an empty KeyStore is created which causes the driver to fail when creating SSL connections because it doesn't trust *anybody*:
  
```
java.lang.RuntimeException: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty
  at java.base/sun.security.validator.PKIXValidator.<init>(PKIXValidator.java:101)
  at java.base/sun.security.validator.Validator.getInstance(Validator.java:181)
  at java.base/sun.security.ssl.X509TrustManagerImpl.getValidator(X509TrustManagerImpl.java:309)
  at java.base/sun.security.ssl.X509TrustManagerImpl.checkTrustedInit(X509TrustManagerImpl.java:183)
  at java.base/sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:255)
  at java.base/sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:144)
  at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1335)
  at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.onConsumeCertificate(CertificateMessage.java:1232)
  at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.consume(CertificateMessage.java:1175)
  at java.base/sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:396)
  at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:480)
  at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1267)
  at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1254)
  at java.base/java.security.AccessController.doPrivileged(AccessController.java:691)
  at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask.run(SSLEngineImpl.java:1199)
  at com.mongodb.internal.connection.tlschannel.impl.TlsChannelImpl.handleTask(TlsChannelImpl.java:260)
  at com.mongodb.internal.connection.tlschannel.impl.TlsChannelImpl.handshakeLoop(TlsChannelImpl.java:592)
  at com.mongodb.internal.connection.tlschannel.impl.TlsChannelImpl.handshake(TlsChannelImpl.java:554)
  at com.mongodb.internal.connection.tlschannel.impl.TlsChannelImpl.doHandshake(TlsChannelImpl.java:529)
  at com.mongodb.internal.connection.tlschannel.impl.TlsChannelImpl.handshake(TlsChannelImpl.java:515)
  at com.mongodb.internal.connection.tlschannel.impl.TlsChannelImpl.write(TlsChannelImpl.java:375)
  at com.mongodb.internal.connection.tlschannel.ClientTlsChannel.write(ClientTlsChannel.java:184)
  at com.mongodb.internal.connection.tlschannel.async.AsynchronousTlsChannelGroup.writeHandlingTasks(AsynchronousTlsChannelGroup.java:533)
  at com.mongodb.internal.connection.tlschannel.async.AsynchronousTlsChannelGroup.doWrite(AsynchronousTlsChannelGroup.java:491)
  at com.mongodb.internal.connection.tlschannel.async.AsynchronousTlsChannelGroup.lambda$processWrite$4(AsynchronousTlsChannelGroup.java:452)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
  at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty
  at java.base/java.security.cert.PKIXParameters.setTrustAnchors(PKIXParameters.java:200)
  at java.base/java.security.cert.PKIXParameters.<init>(PKIXParameters.java:120)
  at java.base/java.security.cert.PKIXBuilderParameters.<init>(PKIXBuilderParameters.java:104)
  at java.base/sun.security.validator.PKIXValidator.<init>(PKIXValidator.java:98)
  ... 27 common frames omitted
```

This PR fixes this by checking if a `caPath` was set and if not passing `null` to `SSLContext.init` which in turn lets java choose the appropriate implementation. The java default then trusts certificates that are known to the JDK for example.
