### PR TITLE
fix(javadoc): Fix documentation for default batchSize value

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/FindOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/FindOptions.java
@@ -22,7 +22,7 @@ public class FindOptions {
   public static final int DEFAULT_SKIP = 0;
 
   /**
-   * The default value of batchSize = 10.
+   * The default value of batchSize = 20.
    */
   public static final int DEFAULT_BATCH_SIZE = 20;
 


### PR DESCRIPTION
Motivation:

Correct Javadoc for variable DEFAULT_BATCH_SIZE.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
