### PR TITLE
update reference link

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -11,7 +11,7 @@ as it natively handles JSON (BSON) documents.
 * Supports a majority of the configuration options from the MongoDB Java Driver
 
 This client is based on the
-http://mongodb.github.io/mongo-java-driver/3.2/driver-async/getting-started[MongoDB Async Driver].
+https://mongodb.github.io/mongo-java-driver/4.1/driver-reactive/getting-started/quick-start/[MongoDB ReactiveStreams Driver].
 
 == Using Vert.x MongoDB Client
 


### PR DESCRIPTION
Motivation:
Just read the official documentation and noticed that the dependend driver was referenced wrong. Since we are not using only the Vert.x MongoClient, it had some impact for me. I try to fix that trivial issue so others are not confused.