### PR TITLE
add ConnectionString to CredentialListParser

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/impl/config/CredentialListParser.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/config/CredentialListParser.java
@@ -1,12 +1,12 @@
 package io.vertx.ext.mongo.impl.config;
 
 import com.mongodb.AuthenticationMechanism;
+import com.mongodb.ConnectionString;
 import com.mongodb.MongoCredential;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.impl.MongoClientImpl;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static com.mongodb.AuthenticationMechanism.*;
@@ -18,49 +18,54 @@ class CredentialListParser {
 
   private final List<MongoCredential> credentials;
 
-  public CredentialListParser(JsonObject config) {
-    String username = config.getString("username");
-    // AuthMechanism
-    AuthenticationMechanism mechanism = null;
-    String authMechanism = config.getString("authMechanism");
-    if (authMechanism != null) {
-      mechanism = getAuthenticationMechanism(authMechanism);
-    }
+  public CredentialListParser(ConnectionString connectionString, JsonObject config) {
     credentials = new ArrayList<>();
-    if (username == null) {
-      if (mechanism == MONGODB_X509) {
-        credentials.add(MongoCredential.createMongoX509Credential());
-      }
+    if (connectionString != null && connectionString.getCredential() != null) {
+      credentials.add(connectionString.getCredential());
     } else {
-      String passwd = config.getString("password");
-      char[] password = (passwd == null) ? null : passwd.toCharArray();
-      // See https://github.com/vert-x3/vertx-mongo-client/issues/46 - 'admin' as default is a security
-      // concern, use  the 'db_name' if none is set.
-      String authSource = config.getString("authSource",
-        config.getString("db_name", MongoClientImpl.DEFAULT_DB_NAME));
-
-      // MongoCredential
-      String gssapiServiceName = config.getString("gssapiServiceName");
-      MongoCredential credential;
-      if (mechanism == GSSAPI) {
-        credential = MongoCredential.createGSSAPICredential(username);
-        credential = getMongoCredential(gssapiServiceName, credential);
-      } else if (mechanism == PLAIN) {
-        credential = MongoCredential.createPlainCredential(username, authSource, password);
-      } else if (mechanism == MONGODB_X509) {
-        credential = MongoCredential.createMongoX509Credential(username);
-      } else if (mechanism == SCRAM_SHA_1) {
-        credential = MongoCredential.createScramSha1Credential(username, authSource, password);
-      } else if (mechanism == SCRAM_SHA_256) {
-        credential = MongoCredential.createScramSha256Credential(username, authSource, password);
-      } else if (mechanism == null) {
-        credential = MongoCredential.createCredential(username, authSource, password);
-      } else {
-        throw new IllegalArgumentException("Unsupported authentication mechanism " + mechanism);
+      String username = config.getString("username");
+      // AuthMechanism
+      AuthenticationMechanism mechanism = null;
+      String authMechanism = config.getString("authMechanism");
+      if (authMechanism != null) {
+        mechanism = getAuthenticationMechanism(authMechanism);
       }
+      if (username == null) {
+        if (mechanism == MONGODB_X509) {
+          credentials.add(MongoCredential.createMongoX509Credential());
+        }
+      } else {
+        String passwd = config.getString("password");
+        char[] password = (passwd == null) ? null : passwd.toCharArray();
+        // See https://github.com/vert-x3/vertx-mongo-client/issues/46 - 'admin' as default is a security
+        // concern, use  the 'db_name' if none is set.
+        String authSource = config.getString("authSource",
+          config.getString("db_name", MongoClientImpl.DEFAULT_DB_NAME));
 
-      credentials.add(credential);
+        // MongoCredential
+        String gssapiServiceName = config.getString("gssapiServiceName");
+        MongoCredential credential;
+        if (mechanism == GSSAPI) {
+          credential = MongoCredential.createGSSAPICredential(username);
+          credential = getMongoCredential(gssapiServiceName, credential);
+        } else if (mechanism == PLAIN) {
+          credential = MongoCredential.createPlainCredential(username, authSource, password);
+        } else if (mechanism == MONGODB_X509) {
+          credential = MongoCredential.createMongoX509Credential(username);
+        } else if (mechanism == SCRAM_SHA_1) {
+          credential = MongoCredential.createScramSha1Credential(username, authSource, password);
+        } else if (mechanism == SCRAM_SHA_256) {
+          credential = MongoCredential.createScramSha256Credential(username, authSource, password);
+        } else if (mechanism == null) {
+          credential = MongoCredential.createCredential(username, authSource, password);
+        } else {
+          throw new IllegalArgumentException("Unsupported authentication mechanism " + mechanism);
+        }
+
+        credentials.add(credential);
+      }
     }
+
   }
 
   private MongoCredential getMongoCredential(String gssapiServiceName, MongoCredential credential) {

--- a/src/main/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParser.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParser.java
@@ -1,7 +1,6 @@
 package io.vertx.ext.mongo.impl.config;
 
 import com.mongodb.*;
-import com.mongodb.MongoClientSettings;
 import com.mongodb.connection.*;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -49,7 +48,7 @@ public class MongoClientOptionsParser {
     // The previous mongo client supported credentials list but their new implementation supports only
     // one credentials. The deprecated code path resorts to using the last credentials if a list is passed
     // we are doing the same here.
-    List<MongoCredential> credentials = new CredentialListParser(config).credentials();
+    List<MongoCredential> credentials = new CredentialListParser(connectionString, config).credentials();
     if (!credentials.isEmpty())
       options.credential(credentials.get(credentials.size() - 1));
 

--- a/src/test/java/io/vertx/ext/mongo/impl/config/CredentialListParserTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/config/CredentialListParserTest.java
@@ -1,6 +1,7 @@
 package io.vertx.ext.mongo.impl.config;
 
 import com.mongodb.AuthenticationMechanism;
+import com.mongodb.ConnectionString;
 import com.mongodb.MongoCredential;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.TestUtils;
@@ -14,6 +15,28 @@ import static org.junit.Assert.*;
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
 public class CredentialListParserTest {
+
+  @Test
+  public void testConnectionString() {
+    String username = TestUtils.randomAlphaString(8);
+    String password = TestUtils.randomAlphaString(20);
+
+    ConnectionString connectionString = new ConnectionString(
+      String.format(
+        "mongodb://%s:%s@%s/%s",
+        username,
+        password,
+        "localhost:27017",
+        "my-datasource"));
+
+    List<MongoCredential> credentials = new CredentialListParser(connectionString, null).credentials();
+    assertEquals(1, credentials.size());
+    MongoCredential credential = credentials.get(0);
+    assertEquals(username, credential.getUserName());
+    assertArrayEquals(password.toCharArray(), credential.getPassword());
+    assertEquals("my-datasource", credential.getSource());
+  }
+
   @Test
   public void testSimpleAuth() {
     JsonObject config = new JsonObject().put("db_name", "my-datasource");
@@ -23,7 +46,7 @@ public class CredentialListParserTest {
     config.put("password", password);
 
 
-    List<MongoCredential> credentials = new CredentialListParser(config).credentials();
+    List<MongoCredential> credentials = new CredentialListParser(null, config).credentials();
     assertEquals(1, credentials.size());
     MongoCredential credential = credentials.get(0);
     assertEquals(username, credential.getUserName());
@@ -42,7 +65,7 @@ public class CredentialListParserTest {
     config.put("password", password);
     config.put("authSource", authSource);
 
-    List<MongoCredential> credentials = new CredentialListParser(config).credentials();
+    List<MongoCredential> credentials = new CredentialListParser(null, config).credentials();
     assertEquals(1, credentials.size());
     MongoCredential credential = credentials.get(0);
     assertEquals(username, credential.getUserName());
@@ -59,7 +82,7 @@ public class CredentialListParserTest {
     config.put("authSource", authSource);
     config.put("authMechanism", "GSSAPI");
 
-    List<MongoCredential> credentials = new CredentialListParser(config).credentials();
+    List<MongoCredential> credentials = new CredentialListParser(null, config).credentials();
     assertEquals(1, credentials.size());
     MongoCredential credential = credentials.get(0);
     assertEquals(username, credential.getUserName());
@@ -79,7 +102,7 @@ public class CredentialListParserTest {
     config.put("authMechanism", "GSSAPI");
     config.put("gssapiServiceName", serviceName);
 
-    List<MongoCredential> credentials = new CredentialListParser(config).credentials();
+    List<MongoCredential> credentials = new CredentialListParser(null, config).credentials();
     assertEquals(1, credentials.size());
     MongoCredential credential = credentials.get(0);
     assertEquals(username, credential.getUserName());
@@ -100,7 +123,7 @@ public class CredentialListParserTest {
     config.put("authSource", authSource);
     config.put("authMechanism", "PLAIN");
 
-    List<MongoCredential> credentials = new CredentialListParser(config).credentials();
+    List<MongoCredential> credentials = new CredentialListParser(null, config).credentials();
     assertEquals(1, credentials.size());
     MongoCredential credential = credentials.get(0);
     assertEquals(username, credential.getUserName());
@@ -119,7 +142,7 @@ public class CredentialListParserTest {
     config.put("authSource", authSource);
     config.put("authMechanism", "MONGODB-X509");
 
-    List<MongoCredential> credentials = new CredentialListParser(config).credentials();
+    List<MongoCredential> credentials = new CredentialListParser(null, config).credentials();
     assertEquals(1, credentials.size());
     MongoCredential credential = credentials.get(0);
     assertEquals(username, credential.getUserName());
@@ -135,7 +158,7 @@ public class CredentialListParserTest {
     config.put("authSource", authSource);
     config.put("authMechanism", "MONGODB-X509");
 
-    List<MongoCredential> credentials = new CredentialListParser(config).credentials();
+    List<MongoCredential> credentials = new CredentialListParser(null, config).credentials();
     assertEquals(1, credentials.size());
     MongoCredential credential = credentials.get(0);
     assertNull(credential.getUserName());
@@ -155,7 +178,7 @@ public class CredentialListParserTest {
     config.put("authSource", authSource);
     config.put("authMechanism", "SCRAM-SHA-1");
 
-    List<MongoCredential> credentials = new CredentialListParser(config).credentials();
+    List<MongoCredential> credentials = new CredentialListParser(null, config).credentials();
     assertEquals(1, credentials.size());
     MongoCredential credential = credentials.get(0);
     assertEquals(username, credential.getUserName());
@@ -176,7 +199,7 @@ public class CredentialListParserTest {
     config.put("authSource", authSource);
     config.put("authMechanism", "SCRAM-SHA-256");
 
-    List<MongoCredential> credentials = new CredentialListParser(config).credentials();
+    List<MongoCredential> credentials = new CredentialListParser(null, config).credentials();
     assertEquals(1, credentials.size());
     MongoCredential credential = credentials.get(0);
     assertEquals(username, credential.getUserName());
@@ -197,7 +220,7 @@ public class CredentialListParserTest {
     config.put("authSource", authSource);
     config.put("authMechanism", "FOO-BAR");
 
-    new CredentialListParser(config).credentials();
+    new CredentialListParser(null, config).credentials();
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -206,6 +229,6 @@ public class CredentialListParserTest {
     String username = TestUtils.randomAlphaString(8);
     config.put("username", username);
 
-    new CredentialListParser(config).credentials();
+    new CredentialListParser(null, config).credentials();
   }
 }


### PR DESCRIPTION
Motivation:

Tried to use vertx-mongo-client with a connectionString. Noticed that username and password are not used from connectionstring. See also issue 248:
https://github.com/vert-x3/vertx-mongo-client/issues/248

Conformance:

Should be conform
