### PR TITLE
Add hint support for search request

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -230,6 +230,7 @@ This has the following fields:
 `sort`:: The fields to sort by. Defaults to `null`.
 `limit`:: The limit of the number of results to return. Default to `-1`, meaning all results will be returned.
 `skip`:: The number of documents to skip before returning the results. Defaults to `0`.
+`hint`:: The index to use. Defaults to empty String.
 
 === Finding documents in batches
 

--- a/src/main/generated/io/vertx/ext/mongo/FindOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/FindOptionsConverter.java
@@ -26,6 +26,11 @@ public class FindOptionsConverter {
             obj.setFields(((JsonObject)member.getValue()).copy());
           }
           break;
+        case "hint":
+          if (member.getValue() instanceof String) {
+            obj.setHint((String)member.getValue());
+          }
+          break;
         case "limit":
           if (member.getValue() instanceof Number) {
             obj.setLimit(((Number)member.getValue()).intValue());
@@ -41,11 +46,6 @@ public class FindOptionsConverter {
             obj.setSort(((JsonObject)member.getValue()).copy());
           }
           break;
-        case "hint":
-          if (member.getValue() instanceof String) {
-            obj.setHint("");
-          }
-          break;
       }
     }
   }
@@ -59,13 +59,13 @@ public class FindOptionsConverter {
     if (obj.getFields() != null) {
       json.put("fields", obj.getFields());
     }
+    if (obj.getHint() != null) {
+      json.put("hint", obj.getHint());
+    }
     json.put("limit", obj.getLimit());
     json.put("skip", obj.getSkip());
     if (obj.getSort() != null) {
       json.put("sort", obj.getSort());
-    }
-    if (!obj.getHint().isEmpty()) {
-      json.put("hint", obj.getHint());
     }
   }
 }

--- a/src/main/generated/io/vertx/ext/mongo/FindOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/FindOptionsConverter.java
@@ -41,6 +41,11 @@ public class FindOptionsConverter {
             obj.setSort(((JsonObject)member.getValue()).copy());
           }
           break;
+        case "hint":
+          if (member.getValue() instanceof String) {
+            obj.setHint("");
+          }
+          break;
       }
     }
   }
@@ -58,6 +63,9 @@ public class FindOptionsConverter {
     json.put("skip", obj.getSkip());
     if (obj.getSort() != null) {
       json.put("sort", obj.getSort());
+    }
+    if (!obj.getHint().isEmpty()) {
+      json.put("hint", obj.getHint());
     }
   }
 }

--- a/src/main/java/io/vertx/ext/mongo/FindOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/FindOptions.java
@@ -208,7 +208,7 @@ public class FindOptions {
     if (skip != that.skip) return false;
     if (batchSize != that.batchSize) return false;
     if (fields != null ? !fields.equals(that.fields) : that.fields != null) return false;
-    if (!hint.equals(that.hint)) return false;
+    if (hint != null ? !hint.equals(that.hint) : that.hint != null) return false;
     return sort != null ? sort.equals(that.sort) : that.sort == null;
   }
 
@@ -219,7 +219,7 @@ public class FindOptions {
     result = 31 * result + limit;
     result = 31 * result + skip;
     result = 31 * result + batchSize;
-    result = 31 * result + hint.hashCode();
+    result = 31 * result + (hint != null ? hint.hashCode() : 0);
     return result;
   }
 }

--- a/src/main/java/io/vertx/ext/mongo/FindOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/FindOptions.java
@@ -31,6 +31,7 @@ public class FindOptions {
   private int limit;
   private int skip;
   private int batchSize;
+  private String hint;
 
   /**
    * Default constructor
@@ -41,6 +42,7 @@ public class FindOptions {
     this.limit = DEFAULT_LIMIT;
     this.skip = DEFAULT_SKIP;
     this.batchSize = DEFAULT_BATCH_SIZE;
+    this.hint = new String();
   }
 
   /**
@@ -54,6 +56,7 @@ public class FindOptions {
     this.limit = options.limit;
     this.skip = options.skip;
     this.batchSize = options.batchSize;
+    this.hint = options.hint;
   }
 
   /**
@@ -174,6 +177,26 @@ public class FindOptions {
     return this;
   }
 
+  /**
+   * Get the hint. This determines the index to use.
+   *
+   * @return  the hint
+   */
+  public String getHint() {
+    return hint;
+  }
+
+  /**
+   * Set the hint
+   *
+   * @param hint  the hint
+   * @return reference to this, for fluency
+   */
+  public FindOptions setHint(String hint) {
+    this.hint = hint;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -185,6 +208,7 @@ public class FindOptions {
     if (skip != that.skip) return false;
     if (batchSize != that.batchSize) return false;
     if (fields != null ? !fields.equals(that.fields) : that.fields != null) return false;
+    if (!hint.equals(that.hint)) return false;
     return sort != null ? sort.equals(that.sort) : that.sort == null;
   }
 
@@ -195,6 +219,7 @@ public class FindOptions {
     result = 31 * result + limit;
     result = 31 * result + skip;
     result = 31 * result + batchSize;
+    result = 31 * result + hint.hashCode();
     return result;
   }
 }

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -975,7 +975,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     if (options.getFields() != null) {
       find.projection(wrap(options.getFields()));
     }
-    if (!options.getHint().isEmpty()) {
+    if (options.getHint() != null && !options.getHint().isEmpty()) {
       find.hintString(options.getHint());
     }
     return find;

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -975,6 +975,9 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     if (options.getFields() != null) {
       find.projection(wrap(options.getFields()));
     }
+    if (!options.getHint().isEmpty()) {
+      find.hintString(options.getHint());
+    }
     return find;
   }
 


### PR DESCRIPTION
Vertx mongo client doesn't support the hint() helper method and we need it to optimize our queries by using specific index.
