### PR TITLE
Support ReadPreference Option For Find

### DIFF
--- a/src/main/generated/io/vertx/ext/mongo/FindOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/FindOptionsConverter.java
@@ -36,6 +36,11 @@ public class FindOptionsConverter {
             obj.setLimit(((Number)member.getValue()).intValue());
           }
           break;
+        case "readPreference":
+          if (member.getValue() instanceof String) {
+            obj.setReadPreference((String)member.getValue());
+          }
+          break;
         case "skip":
           if (member.getValue() instanceof Number) {
             obj.setSkip(((Number)member.getValue()).intValue());
@@ -63,6 +68,9 @@ public class FindOptionsConverter {
       json.put("hint", obj.getHint());
     }
     json.put("limit", obj.getLimit());
+    if (obj.getReadPreference() != null) {
+      json.put("readPreference", obj.getReadPreference());
+    }
     json.put("skip", obj.getSkip());
     if (obj.getSort() != null) {
       json.put("sort", obj.getSort());

--- a/src/main/java/io/vertx/ext/mongo/FindOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/FindOptions.java
@@ -1,7 +1,10 @@
 package io.vertx.ext.mongo;
 
+import com.mongodb.ReadPreference;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+
+import java.util.Objects;
 
 /**
  * Options used to configure find operations.
@@ -32,6 +35,7 @@ public class FindOptions {
   private int skip;
   private int batchSize;
   private String hint;
+  private ReadPreference readPreference;
 
   /**
    * Default constructor
@@ -43,6 +47,7 @@ public class FindOptions {
     this.skip = DEFAULT_SKIP;
     this.batchSize = DEFAULT_BATCH_SIZE;
     this.hint = new String();
+    this.readPreference = null;
   }
 
   /**
@@ -57,6 +62,7 @@ public class FindOptions {
     this.skip = options.skip;
     this.batchSize = options.batchSize;
     this.hint = options.hint;
+    this.readPreference = options.readPreference;
   }
 
   /**
@@ -197,6 +203,33 @@ public class FindOptions {
     return this;
   }
 
+  /**
+   * Get the readPreference. This determines the operation readPreference to use.
+   *
+   * @return the readPreference
+   */
+  public ReadPreference getReadPreference(boolean returnObj) {
+    return readPreference;
+  }
+  public String getReadPreference() {
+    return readPreference == null ? null : readPreference.getName();
+  }
+
+  /**
+   * Set the readPreference
+   *
+   * @param readPreference the readPreference
+   * @return reference to this, for fluency
+   */
+  public FindOptions setReadPreference(ReadPreference readPreference) {
+    this.readPreference = readPreference;
+    return this;
+  }
+  public FindOptions setReadPreference(String readPreferenceName) {
+    this.readPreference = (readPreferenceName == null ? null : ReadPreference.valueOf(readPreferenceName));
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -209,6 +242,7 @@ public class FindOptions {
     if (batchSize != that.batchSize) return false;
     if (fields != null ? !fields.equals(that.fields) : that.fields != null) return false;
     if (hint != null ? !hint.equals(that.hint) : that.hint != null) return false;
+    if (!Objects.equals(readPreference, that.readPreference)) return false;
     return sort != null ? sort.equals(that.sort) : that.sort == null;
   }
 
@@ -220,6 +254,7 @@ public class FindOptions {
     result = 31 * result + skip;
     result = 31 * result + batchSize;
     result = 31 * result + (hint != null ? hint.hashCode() : 0);
+    result = 31 * result + (readPreference != null ? readPreference.hashCode() : 0);
     return result;
   }
 }

--- a/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -1,6 +1,7 @@
 package io.vertx.ext.mongo;
 
 import com.mongodb.MongoClientSettings;
+import com.mongodb.ReadPreference;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
@@ -310,6 +311,19 @@ public interface MongoClient {
    * Like {@link #findOne(String, JsonObject, JsonObject, Handler)} but returns a {@code Future} of the asynchronous result
    */
   Future<@Nullable JsonObject> findOne(String collection, JsonObject query, @Nullable JsonObject fields);
+
+  /**
+   * Like {@link #findOne(String, JsonObject, JsonObject, Handler)} but give an option to set ReadPreference
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  MongoClient findOne(String collection, JsonObject query, @Nullable JsonObject fields, @Nullable ReadPreference readPreference, Handler<AsyncResult<@Nullable JsonObject>> resultHandler);
+
+  /**
+   * Like {@link #findOne(String, JsonObject, JsonObject)} but give an option to set ReadPreference
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Future<@Nullable JsonObject> findOne(String collection, JsonObject query, @Nullable JsonObject fields, @Nullable ReadPreference readPreference);
 
   /**
    * Find a single matching document in the specified collection and update it.

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.mongo.impl;
 
 import com.mongodb.MongoClientSettings;
+import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.model.*;
@@ -353,6 +354,18 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
 
   @Override
   public Future<@Nullable JsonObject> findOne(String collection, JsonObject query, @Nullable JsonObject fields) {
+    return findOne(collection, query, fields, (ReadPreference) null);
+  }
+
+  @Override
+  public MongoClient findOne(String collection, JsonObject query, @Nullable JsonObject fields, @Nullable ReadPreference readPreference, Handler<AsyncResult<@Nullable JsonObject>> resultHandler) {
+    Future<JsonObject> future = findOne(collection, query, fields, readPreference);
+    setHandler(future, resultHandler);
+    return this;
+  }
+
+  @Override
+  public Future<@Nullable JsonObject> findOne(String collection, JsonObject query, @Nullable JsonObject fields, @Nullable ReadPreference readPreference) {
     requireNonNull(collection, "collection cannot be null");
     requireNonNull(query, "query cannot be null");
 
@@ -360,8 +373,13 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
 
     Bson bquery = wrap(encodedQuery);
     Bson bfields = wrap(fields);
+
     Promise<JsonObject> promise = vertx.promise();
-    getCollection(collection).find(bquery).projection(bfields).first().subscribe(new SingleResultSubscriber<>(promise));
+    MongoCollection<JsonObject> coll = getCollection(collection);
+    if (readPreference != null) {
+      coll = coll.withReadPreference(readPreference);
+    }
+    coll.find(bquery).projection(bfields).first().subscribe(new SingleResultSubscriber<>(promise));
     return promise.future().map(object -> object == null ? null : decodeKeyWhenUseObjectId(object));
   }
 
@@ -983,6 +1001,9 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
   private FindPublisher<JsonObject> doFind(String collection, JsonObject query, FindOptions options) {
     MongoCollection<JsonObject> coll = getCollection(collection);
     Bson bquery = wrap(encodeKeyWhenUseObjectId(query));
+    if (options.getReadPreference() != null) {
+      coll = coll.withReadPreference(options.getReadPreference(true));
+    }
     FindPublisher<JsonObject> find = coll.find(bquery, JsonObject.class);
     if (options.getLimit() != -1) {
       find.limit(options.getLimit());


### PR DESCRIPTION
As my current project requires ReadPreference setting on operation level, I add this feature to Vertx Mongo Client.

This is adding support of ReadPreference  for findOne, findWithOptions and findBatchWithOptions.