### PR TITLE
[#259] Update Java driver to version 3.12.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <stack.version>3.9.9-SNAPSHOT</stack.version>
-    <mongo.async.version>3.10.1</mongo.async.version>
+    <mongo.async.version>3.12.8</mongo.async.version>
   </properties>
 
   <dependencyManagement>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <version>2.0.3</version>
+      <version>2.2.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
@@ -244,8 +244,12 @@ public class MongoClientTest extends MongoClientTestBase {
   }
 
   private void upsertDoc(String collection, JsonObject docToInsert, String expectedId, Consumer<JsonObject> doneFunction) {
+    JsonObject updatesToApply = docToInsert.copy();
+    // remove _id field because Mongo DB >= 3.6 will reject
+    // attempts to update the _id field of an existing document
+    updatesToApply.remove(MongoClientUpdateResult.ID_FIELD);
     JsonObject insertStatement = new JsonObject()
-      .put("$set", docToInsert);
+      .put("$set", updatesToApply);
 
     upsertDoc(collection, docToInsert, insertStatement, expectedId, doneFunction);
   }

--- a/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
@@ -141,10 +141,16 @@ public abstract class MongoClientTestBase extends MongoTestBase {
 
     JsonObject command = new JsonObject()
       .put("aggregate", "collection_name")
+      // the aggregate function requires the cursor option
+      // to be specified in Mongo >= 3.6,
+      // use a cursor with default batch size as we expect
+      // the collection to be empty anyway
+      .put("cursor", new JsonObject())
       .put("pipeline", new JsonArray());
 
     mongoClient.runCommand("aggregate", command, onSuccess(resultObj -> {
-      JsonArray resArr = resultObj.getJsonArray("result");
+      JsonObject cursor = resultObj.getJsonObject("cursor");
+      JsonArray resArr = cursor.getJsonArray("firstBatch");
       assertNotNull(resArr);
       assertEquals(0, resArr.size());
       testComplete();

--- a/src/test/java/io/vertx/ext/mongo/MongoTestBase.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoTestBase.java
@@ -70,7 +70,7 @@ public abstract class MongoTestBase extends VertxTestBase {
   public static void startMongo() throws Exception {
     String uri = getConnectionString();
     if (uri == null ) {
-      Version.Main version = Version.Main.V3_4;
+      Version.Main version = Version.Main.V3_6;
       int port = 27018;
       System.out.println("Starting Mongo " + version + " on port " + port);
       IMongodConfig config = new MongodConfigBuilder().


### PR DESCRIPTION
The (legacy async) Mongo Java driver being used has been updated to the
latest version of the 3.x branch.

The test cases have been updated to be able to run them successfully
with Mongo DB 3.5 and 3.6 instead of 3.4 only. The Mongo DB version used
for running the tests has been updated to 3.6.

The flapdoodle library which is used to start an embedded Mongo DB
server to run the test cases against has also been updated to a more
recent version.
