### PR TITLE
Add support for providing CollationOptions

### DIFF
--- a/src/main/generated/io/vertx/ext/mongo/AggregateOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/AggregateOptionsConverter.java
@@ -30,6 +30,11 @@ public class AggregateOptionsConverter {
             obj.setBatchSize(((Number)member.getValue()).intValue());
           }
           break;
+        case "collationOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setCollationOptions(new io.vertx.ext.mongo.CollationOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
         case "maxTime":
           if (member.getValue() instanceof Number) {
             obj.setMaxTime(((Number)member.getValue()).longValue());
@@ -48,6 +53,9 @@ public class AggregateOptionsConverter {
       json.put("allowDiskUse", obj.getAllowDiskUse());
     }
     json.put("batchSize", obj.getBatchSize());
+    if (obj.getCollationOptions() != null) {
+      json.put("collationOptions", obj.getCollationOptions().toJson());
+    }
     json.put("maxTime", obj.getMaxTime());
   }
 }

--- a/src/main/generated/io/vertx/ext/mongo/CollationOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/CollationOptionsConverter.java
@@ -1,0 +1,95 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.ext.mongo.CollationOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.CollationOptions} original class using Vert.x codegen.
+ */
+public class CollationOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, CollationOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "alternate":
+          if (member.getValue() instanceof String) {
+            obj.setAlternate((String)member.getValue());
+          }
+          break;
+        case "backwards":
+          if (member.getValue() instanceof Boolean) {
+            obj.setBackwards((Boolean)member.getValue());
+          }
+          break;
+        case "caseFirst":
+          if (member.getValue() instanceof String) {
+            obj.setCaseFirst(io.vertx.ext.mongo.CaseFirst.valueOf((String)member.getValue()));
+          }
+          break;
+        case "caseLevel":
+          if (member.getValue() instanceof Boolean) {
+            obj.setCaseLevel((Boolean)member.getValue());
+          }
+          break;
+        case "locale":
+          if (member.getValue() instanceof String) {
+            obj.setLocale((String)member.getValue());
+          }
+          break;
+        case "maxVariable":
+          if (member.getValue() instanceof String) {
+            obj.setMaxVariable(io.vertx.ext.mongo.MaxVariable.valueOf((String)member.getValue()));
+          }
+          break;
+        case "normalization":
+          if (member.getValue() instanceof Boolean) {
+            obj.setNormalization((Boolean)member.getValue());
+          }
+          break;
+        case "numericOrdering":
+          if (member.getValue() instanceof Boolean) {
+            obj.setNumericOrdering((Boolean)member.getValue());
+          }
+          break;
+        case "strength":
+          if (member.getValue() instanceof Number) {
+            obj.setStrength(((Number)member.getValue()).intValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(CollationOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(CollationOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getAlternate() != null) {
+      json.put("alternate", obj.getAlternate());
+    }
+    json.put("backwards", obj.isBackwards());
+    if (obj.getCaseFirst() != null) {
+      json.put("caseFirst", obj.getCaseFirst().name());
+    }
+    json.put("caseLevel", obj.isCaseLevel());
+    if (obj.getLocale() != null) {
+      json.put("locale", obj.getLocale());
+    }
+    if (obj.getMaxVariable() != null) {
+      json.put("maxVariable", obj.getMaxVariable().name());
+    }
+    json.put("normalization", obj.isNormalization());
+    json.put("numericOrdering", obj.isNumericOrdering());
+    json.put("strength", obj.getStrength());
+  }
+}

--- a/src/main/generated/io/vertx/ext/mongo/CountOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/CountOptionsConverter.java
@@ -8,36 +8,31 @@ import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 
 /**
- * Converter and mapper for {@link io.vertx.ext.mongo.FindOptions}.
- * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.FindOptions} original class using Vert.x codegen.
+ * Converter and mapper for {@link io.vertx.ext.mongo.CountOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.CountOptions} original class using Vert.x codegen.
  */
-public class FindOptionsConverter {
+public class CountOptionsConverter {
 
 
   private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
   private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
 
-  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, FindOptions obj) {
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, CountOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "batchSize":
-          if (member.getValue() instanceof Number) {
-            obj.setBatchSize(((Number)member.getValue()).intValue());
-          }
-          break;
         case "collation":
           if (member.getValue() instanceof JsonObject) {
             obj.setCollation(new io.vertx.ext.mongo.CollationOptions((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
-        case "fields":
+        case "hint":
           if (member.getValue() instanceof JsonObject) {
-            obj.setFields(((JsonObject)member.getValue()).copy());
+            obj.setHint(((JsonObject)member.getValue()).copy());
           }
           break;
-        case "hint":
+        case "hintString":
           if (member.getValue() instanceof String) {
-            obj.setHint((String)member.getValue());
+            obj.setHintString((String)member.getValue());
           }
           break;
         case "limit":
@@ -45,39 +40,36 @@ public class FindOptionsConverter {
             obj.setLimit(((Number)member.getValue()).intValue());
           }
           break;
+        case "maxTime":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxTime(((Number)member.getValue()).longValue());
+          }
+          break;
         case "skip":
           if (member.getValue() instanceof Number) {
             obj.setSkip(((Number)member.getValue()).intValue());
-          }
-          break;
-        case "sort":
-          if (member.getValue() instanceof JsonObject) {
-            obj.setSort(((JsonObject)member.getValue()).copy());
           }
           break;
       }
     }
   }
 
-  public static void toJson(FindOptions obj, JsonObject json) {
+  public static void toJson(CountOptions obj, JsonObject json) {
     toJson(obj, json.getMap());
   }
 
-  public static void toJson(FindOptions obj, java.util.Map<String, Object> json) {
-    json.put("batchSize", obj.getBatchSize());
+  public static void toJson(CountOptions obj, java.util.Map<String, Object> json) {
     if (obj.getCollation() != null) {
       json.put("collation", obj.getCollation().toJson());
-    }
-    if (obj.getFields() != null) {
-      json.put("fields", obj.getFields());
     }
     if (obj.getHint() != null) {
       json.put("hint", obj.getHint());
     }
-    json.put("limit", obj.getLimit());
-    json.put("skip", obj.getSkip());
-    if (obj.getSort() != null) {
-      json.put("sort", obj.getSort());
+    if (obj.getHintString() != null) {
+      json.put("hintString", obj.getHintString());
     }
+    json.put("limit", obj.getLimit());
+    json.put("maxTime", obj.getMaxTime());
+    json.put("skip", obj.getSkip());
   }
 }

--- a/src/main/generated/io/vertx/ext/mongo/CreateCollectionOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/CreateCollectionOptionsConverter.java
@@ -1,0 +1,83 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.ext.mongo.CreateCollectionOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.CreateCollectionOptions} original class using Vert.x codegen.
+ */
+public class CreateCollectionOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, CreateCollectionOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "capped":
+          if (member.getValue() instanceof Boolean) {
+            obj.setCapped((Boolean)member.getValue());
+          }
+          break;
+        case "collation":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setCollation(new io.vertx.ext.mongo.CollationOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "indexOptionDefaults":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setIndexOptionDefaults(((JsonObject)member.getValue()).copy());
+          }
+          break;
+        case "maxDocuments":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxDocuments(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "sizeInBytes":
+          if (member.getValue() instanceof Number) {
+            obj.setSizeInBytes(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "storageEngineOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setStorageEngineOptions(((JsonObject)member.getValue()).copy());
+          }
+          break;
+        case "validationOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setValidationOptions(new io.vertx.ext.mongo.ValidationOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(CreateCollectionOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(CreateCollectionOptions obj, java.util.Map<String, Object> json) {
+    json.put("capped", obj.isCapped());
+    if (obj.getCollation() != null) {
+      json.put("collation", obj.getCollation().toJson());
+    }
+    if (obj.getIndexOptionDefaults() != null) {
+      json.put("indexOptionDefaults", obj.getIndexOptionDefaults());
+    }
+    json.put("maxDocuments", obj.getMaxDocuments());
+    json.put("sizeInBytes", obj.getSizeInBytes());
+    if (obj.getStorageEngineOptions() != null) {
+      json.put("storageEngineOptions", obj.getStorageEngineOptions());
+    }
+    if (obj.getValidationOptions() != null) {
+      json.put("validationOptions", obj.getValidationOptions().toJson());
+    }
+  }
+}

--- a/src/main/generated/io/vertx/ext/mongo/DistinctOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/DistinctOptionsConverter.java
@@ -1,0 +1,41 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.ext.mongo.DistinctOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.DistinctOptions} original class using Vert.x codegen.
+ */
+public class DistinctOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DistinctOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "collation":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setCollation(new io.vertx.ext.mongo.CollationOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(DistinctOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(DistinctOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getCollation() != null) {
+      json.put("collation", obj.getCollation().toJson());
+    }
+  }
+}

--- a/src/main/generated/io/vertx/ext/mongo/IndexOptionDefaultsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/IndexOptionDefaultsConverter.java
@@ -1,0 +1,41 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.ext.mongo.IndexOptionDefaults}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.IndexOptionDefaults} original class using Vert.x codegen.
+ */
+public class IndexOptionDefaultsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, IndexOptionDefaults obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "storageEngine":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setStorageEngine(((JsonObject)member.getValue()).copy());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(IndexOptionDefaults obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(IndexOptionDefaults obj, java.util.Map<String, Object> json) {
+    if (obj.getStorageEngine() != null) {
+      json.put("storageEngine", obj.getStorageEngine());
+    }
+  }
+}

--- a/src/main/generated/io/vertx/ext/mongo/ValidationOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/ValidationOptionsConverter.java
@@ -1,0 +1,57 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.ext.mongo.ValidationOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.mongo.ValidationOptions} original class using Vert.x codegen.
+ */
+public class ValidationOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ValidationOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "validationAction":
+          if (member.getValue() instanceof String) {
+            obj.setValidationAction(com.mongodb.client.model.ValidationAction.valueOf((String)member.getValue()));
+          }
+          break;
+        case "validationLevel":
+          if (member.getValue() instanceof String) {
+            obj.setValidationLevel(com.mongodb.client.model.ValidationLevel.valueOf((String)member.getValue()));
+          }
+          break;
+        case "validator":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setValidator(((JsonObject)member.getValue()).copy());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(ValidationOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(ValidationOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getValidationAction() != null) {
+      json.put("validationAction", obj.getValidationAction().name());
+    }
+    if (obj.getValidationLevel() != null) {
+      json.put("validationLevel", obj.getValidationLevel().name());
+    }
+    if (obj.getValidator() != null) {
+      json.put("validator", obj.getValidator());
+    }
+  }
+}

--- a/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/AggregateOptions.java
@@ -1,9 +1,9 @@
 package io.vertx.ext.mongo;
 
-import java.util.Objects;
-
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+
+import java.util.Objects;
 
 /**
  * Options used to configure aggregate operations.
@@ -15,11 +15,11 @@ public class AggregateOptions {
   /**
    * The default value of batchSize = 10.
    */
-  public static final int  DEFAULT_BATCH_SIZE     = 20;
+  public static final int DEFAULT_BATCH_SIZE = 20;
   /**
    * The default value of maxTime = 0.
    */
-  public static final long DEFAULT_MAX_TIME       = 0L;
+  public static final long DEFAULT_MAX_TIME = 0L;
   /**
    * The default value of maxAwaitTime = 1000.
    */
@@ -29,6 +29,7 @@ public class AggregateOptions {
   private long    maxTime;
   private long    maxAwaitTime;
   private Boolean allowDiskUse;
+  private CollationOptions collationOptions;
 
   /**
    * Default constructor
@@ -37,6 +38,7 @@ public class AggregateOptions {
     this.batchSize = DEFAULT_BATCH_SIZE;
     this.maxTime = DEFAULT_MAX_TIME;
     this.maxAwaitTime = DEFAULT_MAX_AWAIT_TIME;
+    this.collationOptions = null;
   }
 
   /**
@@ -49,6 +51,7 @@ public class AggregateOptions {
     this.maxTime = options.maxTime;
     this.maxAwaitTime = options.maxAwaitTime;
     this.allowDiskUse = options.allowDiskUse;
+    this.collationOptions = options.collationOptions;
   }
 
   /**
@@ -59,6 +62,27 @@ public class AggregateOptions {
   public AggregateOptions(JsonObject options) {
     this();
     AggregateOptionsConverter.fromJson(options, this);
+  }
+
+  /**
+   * @return Configured collationOptions
+   */
+  public CollationOptions getCollationOptions() {
+    return collationOptions;
+  }
+
+  /**
+   * Optional.
+   *
+   * Specifies the collation to use for the operation.
+   *
+   * Collation allows users to specify language-specific rules for string comparison, such as rules for lettercase and accent marks.
+   * @param collationOptions
+   * @return reference to this, for fluency
+   */
+  public AggregateOptions setCollationOptions(CollationOptions collationOptions) {
+    this.collationOptions = collationOptions;
+    return this;
   }
 
   /**
@@ -102,14 +126,26 @@ public class AggregateOptions {
   }
 
   /**
+   * Set the batch size for methods loading found data in batches.
+   *
+   * @param batchSize the number of documents in a batch
+   * @return reference to this, for fluency
+   */
+  public AggregateOptions setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+    return this;
+  }
+
+  /**
    * Get the flag if writing to temporary files is enabled.
    * When set to true, aggregation operations can write data to the _tmp subdirectory in the dbPath directory.
    *
    * @return true if writing to temporary files is enabled.
    */
-  public Boolean getAllowDiskUse(){
+  public Boolean getAllowDiskUse() {
     return allowDiskUse;
   }
+
   /**
    * Set the flag if writing to temporary files is enabled.
    *
@@ -118,17 +154,6 @@ public class AggregateOptions {
    */
   public AggregateOptions setAllowDiskUse(final Boolean allowDiskUse) {
     this.allowDiskUse = allowDiskUse;
-    return this;
-  }
-
-  /**
-   * Set the batch size for methods loading found data in batches.
-   *
-   * @param batchSize the number of documents in a batch
-   * @return reference to this, for fluency
-   */
-  public AggregateOptions setBatchSize(int batchSize) {
-    this.batchSize = batchSize;
     return this;
   }
 

--- a/src/main/java/io/vertx/ext/mongo/Alternate.java
+++ b/src/main/java/io/vertx/ext/mongo/Alternate.java
@@ -1,0 +1,31 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+import java.util.Locale;
+
+@VertxGen
+public enum Alternate {
+  NON_IGNORABLE("non-ignorable"), SHIFTED("shifted");
+  private final String value;
+
+  Alternate(String value) {
+    this.value = value;
+  }
+
+  public static Alternate fromString(String alternateValue) {
+    if (alternateValue != null) {
+      if (NON_IGNORABLE.value.equals(alternateValue.toLowerCase(Locale.ROOT))) {
+        return NON_IGNORABLE;
+      } else if (SHIFTED.value.equals(alternateValue.toLowerCase(Locale.ROOT))) {
+        return SHIFTED;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return this.value;
+  }
+}

--- a/src/main/java/io/vertx/ext/mongo/BulkOperation.java
+++ b/src/main/java/io/vertx/ext/mongo/BulkOperation.java
@@ -7,7 +7,6 @@ import io.vertx.core.json.JsonObject;
  * Contains all data needed for one operation of a bulk write operation.
  *
  * @author sschmitt
- *
  */
 @DataObject
 public class BulkOperation {
@@ -28,11 +27,20 @@ public class BulkOperation {
   private boolean upsert;
   private boolean multi;
 
+  public CollationOptions getCollation() {
+    return collation;
+  }
+
+  public void setCollation(CollationOptions collation) {
+    this.collation = collation;
+  }
+
+  private CollationOptions collation;
+
   /**
    * Constructor for a new instance with the given type
    *
-   * @param type
-   *          the type
+   * @param type the type
    */
   private BulkOperation(BulkOperationType type) {
     this.type = type;
@@ -45,8 +53,7 @@ public class BulkOperation {
   /**
    * Json constructor
    *
-   * @param json
-   *          the json object
+   * @param json the json object
    */
   public BulkOperation(JsonObject json) {
     String typeValue = json.getString("type");
@@ -76,8 +83,7 @@ public class BulkOperation {
   /**
    * Create a new delete operation with the given filter
    *
-   * @param filter
-   *          the filter
+   * @param filter the filter
    * @return a new delete operation instance
    */
   public static BulkOperation createDelete(JsonObject filter) {
@@ -87,8 +93,7 @@ public class BulkOperation {
   /**
    * Create a new insert operation with the given document
    *
-   * @param document
-   *          the document to insert
+   * @param document the document to insert
    * @return a new insert operation instance
    */
   public static BulkOperation createInsert(JsonObject document) {
@@ -98,10 +103,8 @@ public class BulkOperation {
   /**
    * Create a new replace operation with the given filter and replace document
    *
-   * @param filter
-   *          the filter
-   * @param document
-   *          the replace document
+   * @param filter   the filter
+   * @param document the replace document
    * @return a new replace operation instance
    */
   public static BulkOperation createReplace(JsonObject filter, JsonObject document) {
@@ -111,12 +114,9 @@ public class BulkOperation {
   /**
    * Create a new replace operation with the given filter, replace document, and the upsert flag
    *
-   * @param filter
-   *          the filter
-   * @param document
-   *          the replace document
-   * @param upsert
-   *          the upsert flag
+   * @param filter   the filter
+   * @param document the replace document
+   * @param upsert   the upsert flag
    * @return a new replace operation instance
    */
   public static BulkOperation createReplace(JsonObject filter, JsonObject document, boolean upsert) {
@@ -126,10 +126,8 @@ public class BulkOperation {
   /**
    * Create a new update operation with the given filter and update document
    *
-   * @param filter
-   *          the filter
-   * @param document
-   *          the update document
+   * @param filter   the filter
+   * @param document the update document
    * @return a new update operation instance
    */
   public static BulkOperation createUpdate(JsonObject filter, JsonObject document) {
@@ -139,19 +137,15 @@ public class BulkOperation {
   /**
    * Create a new update operation with the given filter, update document, the upsert flag, and multi flag
    *
-   * @param filter
-   *          the filter
-   * @param document
-   *          the update document
-   * @param upsert
-   *          the upsert flag
-   * @param multi
-   *          the multi flag
+   * @param filter   the filter
+   * @param document the update document
+   * @param upsert   the upsert flag
+   * @param multi    the multi flag
    * @return a new update operation instance
    */
   public static BulkOperation createUpdate(JsonObject filter, JsonObject document, boolean upsert, boolean multi) {
     return new BulkOperation(BulkOperationType.UPDATE).setFilter(filter).setDocument(document).setUpsert(upsert)
-        .setMulti(multi);
+      .setMulti(multi);
   }
 
   /**
@@ -166,8 +160,7 @@ public class BulkOperation {
   /**
    * Sets the operation type
    *
-   * @param type
-   *          the operation type
+   * @param type the operation type
    * @return this for fluency
    */
   public BulkOperation setType(BulkOperationType type) {
@@ -187,8 +180,7 @@ public class BulkOperation {
   /**
    * Sets the filter document, used by replace, update, and delete operations
    *
-   * @param filter
-   *          the filter document
+   * @param filter the filter document
    * @return this for fluency
    */
   public BulkOperation setFilter(JsonObject filter) {
@@ -208,8 +200,7 @@ public class BulkOperation {
   /**
    * Sets the document, used by insert, replace, and update operations
    *
-   * @param document
-   *          the document
+   * @param document the document
    * @return this for fluency
    */
   public BulkOperation setDocument(JsonObject document) {
@@ -229,8 +220,7 @@ public class BulkOperation {
   /**
    * Sets the upsert flag, used by update and replace operations
    *
-   * @param upsert
-   *          the upsert flag
+   * @param upsert the upsert flag
    * @return this for fluency
    */
   public BulkOperation setUpsert(boolean upsert) {
@@ -250,8 +240,7 @@ public class BulkOperation {
   /**
    * Sets the multi flag, used by update and delete operations
    *
-   * @param multi
-   *          the mutli flag
+   * @param multi the mutli flag
    * @return this for fluency
    */
   public BulkOperation setMulti(boolean multi) {

--- a/src/main/java/io/vertx/ext/mongo/CaseFirst.java
+++ b/src/main/java/io/vertx/ext/mongo/CaseFirst.java
@@ -1,0 +1,8 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+public enum CaseFirst {
+  upper, lower, off;
+}

--- a/src/main/java/io/vertx/ext/mongo/CollationOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/CollationOptions.java
@@ -1,0 +1,368 @@
+package io.vertx.ext.mongo;
+
+import com.mongodb.client.model.*;
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Options used to configure collation options.
+ *
+ * @author <a href="mailto:christoph.spoerk@gmail.com">Christoph Spörk</a>
+ */
+@DataObject(generateConverter = true)
+public class CollationOptions {
+  public static final Boolean DEFAULT_CASE_LEVEL = false;
+  public static final CaseFirst DEFAULT_CASE_FIRST = CaseFirst.off;
+  public static final Alternate DEFAULT_ALTERNATE = Alternate.NON_IGNORABLE;
+  public static final Integer DEFAULT_STRENGTH = 3;
+  public static final Boolean DEFAULT_NUMERIC_ORDERING = false;
+  public static final Boolean DEFAULT_BACKWARDS = false;
+  public static final Boolean DEFAULT_NORMALIZATION = false;
+  public static final MaxVariable DEFAULT_MAX_VARIABLE = MaxVariable.punct;
+  private static final String DEFAULT_LOCALE = Locale.getDefault().toString();
+
+  private String locale;
+  private boolean caseLevel;
+  private CaseFirst caseFirst;
+  private int strength;
+  private boolean numericOrdering;
+  private String alternate;
+  private MaxVariable maxVariable;
+  private boolean backwards;
+  private boolean normalization;
+
+  /**
+   * Default constructor for setting
+   */
+  public CollationOptions() {
+    this.locale = DEFAULT_LOCALE;
+    caseLevel = DEFAULT_CASE_LEVEL;
+    caseFirst = DEFAULT_CASE_FIRST;
+    strength = DEFAULT_STRENGTH;
+    numericOrdering = DEFAULT_NUMERIC_ORDERING;
+    backwards = DEFAULT_BACKWARDS;
+    maxVariable = DEFAULT_MAX_VARIABLE;
+    normalization = DEFAULT_NORMALIZATION;
+    alternate = DEFAULT_ALTERNATE.toString();
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param options
+   */
+  public CollationOptions(CollationOptions options) {
+    locale = options.locale;
+    caseLevel = options.caseLevel;
+    caseFirst = options.caseFirst;
+    strength = options.strength;
+    numericOrdering = options.numericOrdering;
+    alternate = options.alternate;
+    maxVariable = options.maxVariable;
+    backwards = options.backwards;
+    normalization = options.normalization;
+  }
+
+  public Collation toMongoDriverObject() {
+    return Collation.builder()
+      .collationAlternate(CollationAlternate.fromString(getAlternate()))
+      .backwards(isBackwards())
+      .caseLevel(isCaseLevel())
+      .collationCaseFirst(CollationCaseFirst.fromString(getCaseFirst().name()))
+      .collationMaxVariable(CollationMaxVariable.fromString(getMaxVariable().name()))
+      .collationStrength(CollationStrength.fromInt(getStrength()))
+      .locale(getLocale())
+      .numericOrdering(isNumericOrdering())
+      .collationAlternate(CollationAlternate.fromString(getAlternate()))
+      .normalization(isNormalization())
+      .build();
+  }
+
+  /**
+   * Constructing from a JsonObject with provided attributes
+   *
+   * @param json containing collation options
+   */
+  public CollationOptions(JsonObject json) {
+    CollationOptionsConverter.fromJson(json, this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CollationOptions that = (CollationOptions) o;
+    return isCaseLevel() == that.isCaseLevel() && getStrength() == that.getStrength() && isNumericOrdering() == that.isNumericOrdering() && isBackwards() == that.isBackwards() && isNormalization() == that.isNormalization() && Objects.equals(getLocale(), that.getLocale()) && getCaseFirst() == that.getCaseFirst() && getAlternate() == that.getAlternate() && getMaxVariable() == that.getMaxVariable();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getLocale(), isCaseLevel(), getCaseFirst(), getStrength(), isNumericOrdering(), getAlternate(), getMaxVariable(), isBackwards(), isNormalization());
+  }
+
+  public boolean isNormalization() {
+    return normalization;
+  }
+
+  /**
+   * Optional. Flag that determines whether to check if text require normalization and to perform normalization. Generally, majority of text does not require this normalization processing.
+   * <p>
+   * If true, check if fully normalized and perform normalization to compare text.
+   * If false, does not check.
+   * <p>
+   * The default value is false.
+   *
+   * @param normalization
+   * @return CollationOption
+   * @see <a href="http://userguide.icu-project.org/collation/concepts#TOC-Normalization">TOC Normalization</a> for details.
+   */
+  public CollationOptions setNormalization(boolean normalization) {
+    this.normalization = normalization;
+    return this;
+  }
+
+  /**
+   * Convert to JSON
+   *
+   * @return CollationOption as JSON
+   */
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    CollationOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  /**
+   * Get the locale
+   *
+   * @return locale string
+   */
+  public String getLocale() {
+    return locale;
+  }
+
+  /**
+   * The ICU locale. See <a href="https://docs.mongodb.com/manual/reference/collation-locales-defaults/#std-label-collation-languages-locales">Supported Languages and Locales</a>
+   * for a list of supported locales.
+   * <p>
+   * To specify simple binary comparison, specify locale value of "simple".
+   *
+   * @param locale string
+   * @return collationOption
+   * @see <a href="https://docs.mongodb.com/manual/reference/collation-locales-defaults/#std-label-collation-languages-locales">Supported Languages and Locales</a>
+   */
+  public CollationOptions setLocale(String locale) {
+    this.locale = locale;
+    return this;
+  }
+
+  /**
+   * Get case level
+   *
+   * @return caseLevel
+   */
+  public boolean isCaseLevel() {
+    return caseLevel;
+  }
+
+  /**
+   * Optional. Flag that determines whether to include case comparison at strength level 1 or 2.
+   * <p>
+   * If true, include case comparison; i.e.
+   * <p>
+   * When used with strength:1, collation compares base characters and case.
+   * When used with strength:2, collation compares base characters, diacritics (and possible other secondary differences) and case.
+   * If false, do not include case comparison at level 1 or 2. The default is false.
+   *
+   * @param caseLevel
+   * @return CollationOption
+   * @see <a href="http://userguide.icu-project.org/collation/concepts#TOC-CaseLevel">ICU Collation: Case Level</a>
+   */
+  public CollationOptions setCaseLevel(boolean caseLevel) {
+    this.caseLevel = caseLevel;
+    return this;
+  }
+
+  /**
+   * Get case first
+   *
+   * @return case first
+   */
+  public CaseFirst getCaseFirst() {
+    return caseFirst;
+  }
+
+  /**
+   * Optional. A field that determines sort order of case differences during tertiary level comparisons.
+   * <p>
+   * Possible values are:
+   * "upper" Uppercase sorts before lowercase.
+   * "lower" Lowercase sorts before uppercase.
+   * "off"   Default value. Similar to "lower" with slight differences.
+   * See <a href="http://userguide.icu-project.org/collation/customization">Collation customization</a> for details of differences.
+   *
+   * @param caseFirst one of UPPER, LOWER, OFF
+   * @return CollationOption
+   * @see <a href="http://userguide.icu-project.org/collation/customization">Collation customization</a>
+   */
+  public CollationOptions setCaseFirst(CaseFirst caseFirst) {
+    this.caseFirst = caseFirst;
+    return this;
+  }
+
+  /**
+   * Get strength level
+   *
+   * @return strength level
+   */
+  public int getStrength() {
+    return strength;
+  }
+
+  /**
+   * Optional. The level of comparison to perform. Corresponds to ICU Comparison Levels. Possible values are:
+   * <p>
+   * Value
+   * Description
+   * 1 Primary level of comparison. Collation performs comparisons of the base characters only, ignoring other differences such as diacritics and case.
+   * 2 Secondary level of comparison. Collation performs comparisons up to secondary differences, such as diacritics. That is, collation performs comparisons of base characters (primary differences) and diacritics (secondary differences). Differences between base characters takes precedence over secondary differences.
+   * 3 Tertiary level of comparison. Collation performs comparisons up to tertiary differences, such as case and letter variants. That is, collation performs comparisons of base characters (primary differences), diacritics (secondary differences), and case and variants (tertiary differences). Differences between base characters takes precedence over secondary differences, which takes precedence over tertiary differences.
+   * This is the default level.
+   * <p>
+   * 4 Quaternary Level. Limited for specific use case to consider punctuation when levels 1-3 ignore punctuation or for processing Japanese text.
+   * 5 Identical Level. Limited for specific use case of tie breaker.
+   *
+   * @param strength level
+   * @return CollationOption
+   * @see <a href="http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels">ICU Collation: Comparison Levels</a>
+   */
+  public CollationOptions setStrength(int strength) {
+    if (strength < 1 || strength > 5) {
+      throw new IllegalArgumentException("Unsupported strength level: Must be 1-5");
+    }
+    this.strength = strength;
+    return this;
+  }
+
+  /**
+   * Get numeric ordering
+   *
+   * @return Numeric ordering
+   */
+  public boolean isNumericOrdering() {
+    return numericOrdering;
+  }
+
+  /**
+   * Optional. Flag that determines whether to compare numeric strings as numbers or as strings.
+   * <p>
+   * If true, compare as numbers; i.e. "10" is greater than "2".
+   * If false, compare as strings; i.e. "10" is less than "2".
+   * <p>
+   * Default is false.
+   *
+   * @param numericOrdering value
+   * @return CollationOption
+   */
+  public CollationOptions setNumericOrdering(boolean numericOrdering) {
+    this.numericOrdering = numericOrdering;
+    return this;
+  }
+
+  /**
+   * Get alternate
+   *
+   * @return alternate
+   */
+  public String getAlternate() {
+    return alternate;
+  }
+
+  /**
+   * Get alternate
+   *
+   * @return alternate
+   */
+  Alternate alternate() {
+    return Alternate.fromString(alternate);
+  }
+
+  /**
+   * Optional. Field that determines whether collation should consider whitespace and punctuation as base characters for purposes of comparison.
+   * <p>
+   * Possible values are:
+   * "non-ignorable" Whitespace and punctuation are considered base characters.
+   * "shifted" Whitespace and punctuation are not considered base characters and are only distinguished at strength levels greater than 3.
+   * See <a href="http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels">ICU Collation: Comparison Levels</a> for more information.
+   * <p>
+   * Default is "non-ignorable".
+   *
+   * @param alternate either of NON_IGNORABLE, SHIFTED
+   * @return CollationOption
+   * @see <a href="http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels">ICU Collation: Comparison Levels</a>
+   */
+  public CollationOptions setAlternate(String alternate) {
+    this.alternate = alternate;
+    return this;
+  }
+
+  @GenIgnore
+  CollationOptions alternate(Alternate alternate) {
+    this.alternate = alternate.toString();
+    return this;
+  }
+
+  /**
+   * Get max variable
+   *
+   * @return max variable
+   */
+  public MaxVariable getMaxVariable() {
+    return maxVariable;
+  }
+
+  /**
+   * Optional. Field that determines up to which characters are considered ignorable when alternate: "shifted". Has no effect if alternate: "non-ignorable"
+   * <p>
+   * Possible values are:
+   * "punct" Both whitespace and punctuation are "ignorable", i.e. not considered base characters.
+   * "space" Whitespace are "ignorable", i.e. not considered base characters.
+   *
+   * @param maxVariable either of PUNCT, SPACE
+   * @return CollationOption
+   */
+  public CollationOptions setMaxVariable(MaxVariable maxVariable) {
+    this.maxVariable = maxVariable;
+    return this;
+  }
+
+  /**
+   * Get backwards
+   *
+   * @return backwards
+   */
+  public boolean isBackwards() {
+    return backwards;
+  }
+
+  /**
+   * Optional. Flag that determines whether strings with diacritics sort from back of the string, such as with some French dictionary ordering.
+   * <p>
+   * If true, compare from back to front.
+   * If false, compare from front to back.
+   * <p>
+   * The default value is false.
+   *
+   * @param backwards
+   * @return CollationOption
+   */
+  public CollationOptions setBackwards(boolean backwards) {
+    this.backwards = backwards;
+    return this;
+  }
+
+}

--- a/src/main/java/io/vertx/ext/mongo/CountOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/CountOptions.java
@@ -1,0 +1,207 @@
+package io.vertx.ext.mongo;
+
+
+import com.mongodb.assertions.Assertions;
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.impl.JsonObjectBsonAdapter;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+@DataObject(generateConverter = true)
+public class CountOptions {
+  private static final TimeUnit DEFAULT_MAX_TIME_TIMEUNIT = TimeUnit.MILLISECONDS;
+  private JsonObject hint;
+  private String hintString;
+  private int limit;
+  private int skip;
+  private long maxTime;
+  private CollationOptions collation;
+
+  public CountOptions() {
+  }
+
+  public CountOptions(CountOptions countOptions) {
+    this.hint = countOptions.getHint();
+    this.hintString = countOptions.getHintString();
+    this.limit = countOptions.getLimit();
+    this.skip = countOptions.getSkip();
+    this.maxTime = countOptions.getMaxTime(DEFAULT_MAX_TIME_TIMEUNIT);
+    this.collation = countOptions.getCollation();
+  }
+
+  public CountOptions(JsonObject json) {
+    CountOptionsConverter.fromJson(json, this);
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    CountOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CountOptions that = (CountOptions) o;
+    return getLimit() == that.getLimit() && getSkip() == that.getSkip() && maxTime == that.maxTime && Objects.equals(getHint(), that.getHint()) && Objects.equals(getHintString(), that.getHintString()) && Objects.equals(getCollation(), that.getCollation());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getHint(), getHintString(), getLimit(), getSkip(), maxTime, getCollation());
+  }
+
+  /**
+   * Returns the mongo-java-driver specific object.
+   * @return com.mongodb.client.model.CountOptions
+   */
+  public com.mongodb.client.model.CountOptions toMongoDriverObject() {
+    com.mongodb.client.model.CountOptions options = new com.mongodb.client.model.CountOptions();
+    if (collation != null) {
+      options.collation(collation.toMongoDriverObject());
+    }
+
+    return options
+      .hint(hint == null ? null : new JsonObjectBsonAdapter(hint))
+      .hintString(hintString)
+      .limit(limit)
+      .skip(skip)
+      .maxTime(maxTime, DEFAULT_MAX_TIME_TIMEUNIT);
+  }
+
+  /**
+   * Gets the hint to apply.
+   * @return the hint, which should describe an existing
+   */
+  public JsonObject getHint() {
+    return this.hint;
+  }
+
+  /**
+   * Gets the hint string to apply.
+   * @return the hint string, which should be the name of an existing index
+   */
+  public String getHintString() {
+    return this.hintString;
+  }
+
+  /**
+   * Optional. The index to use. Specify either the index name as a string or the index specification document.
+   * @param hint
+   * @return CountOptions
+   */
+  public CountOptions setHint(JsonObject hint) {
+    this.hint = hint;
+    return this;
+  }
+
+  /**
+   * Sets the hint to apply.
+   * Note: If hint is set, that will be used instead of any hint string.
+   * @param hint the name of the index which should be used for the operation
+   * @return CountOptions
+   */
+  public CountOptions setHintString(String hint) {
+    this.hintString = hint;
+    return this;
+  }
+
+  /**
+   * Gets the limit to apply. The default is 0, which means there is no limit.
+   * @return the limit
+   */
+  public int getLimit() {
+    return this.limit;
+  }
+
+  /**
+   * Sets the limit to apply.
+   * @param limit the limit
+   * @return CountOptions
+   */
+  public CountOptions setLimit(int limit) {
+    this.limit = limit;
+    return this;
+  }
+
+  /**
+   * Gets the number of documents to skip. The default is 0.
+   * @return the number of documents to skip
+   */
+  public int getSkip() {
+    return this.skip;
+  }
+
+  /**
+   * Optional. The number of matching documents to skip before returning results.
+   * @param skip
+   * @return
+   */
+  public CountOptions setSkip(int skip) {
+    this.skip = skip;
+    return this;
+  }
+
+  /**
+   * Gets the maximum execution time in milliseconds on the server for this operation.
+   * The default is 0, which places no limit on the execution time.
+   * @return the maximum execution time in milliseconds in the given time unit
+   */
+  public long getMaxTime() {
+    return getMaxTime(DEFAULT_MAX_TIME_TIMEUNIT);
+  }
+
+  /**
+   * Sets the maximum execution time in milliseconds on the server for this operation.
+   * @param maxTimeMS the max time in milliseconds
+   * @return CountOptions
+   */
+  public CountOptions setMaxTime(long maxTimeMS) {
+    return setMaxTime(maxTimeMS, DEFAULT_MAX_TIME_TIMEUNIT);
+  }
+
+  /**
+   * Gets the maximum execution time on the server for this operation. The default is 0, which places no limit on the execution time.
+   * @param timeUnit the time unit to return the result in
+   * @return the maximum execution time in the given time unit
+   */
+  @GenIgnore
+  public long getMaxTime(TimeUnit timeUnit) {
+    Assertions.notNull("timeUnit", timeUnit);
+    return timeUnit.convert(this.maxTime, DEFAULT_MAX_TIME_TIMEUNIT);
+  }
+
+  /**
+   * Sets the maximum execution time on the server for this operation.
+   * @param maxTime the max time
+   * @param timeUnit the time unit, which may not be null
+   * @return CountOptions
+   */
+  @GenIgnore
+  public CountOptions setMaxTime(long maxTime, TimeUnit timeUnit) {
+    Assertions.notNull("timeUnit", timeUnit);
+    this.maxTime = DEFAULT_MAX_TIME_TIMEUNIT.convert(maxTime, timeUnit);
+    return this;
+  }
+
+  public CollationOptions getCollation() {
+    return this.collation;
+  }
+
+  /**
+   * Sets the collation options
+   * @return CollationOptions
+   */
+  public CountOptions setCollation(CollationOptions collation) {
+    this.collation = collation;
+    return this;
+  }
+
+  public String toString() {
+    return "CountOptions{hint=" + this.hint + ", hintString='" + this.hintString + '\'' + ", limit=" + this.limit + ", skip=" + this.skip + ", maxTimeMS=" + this.maxTime + ", collation=" + this.collation + '}';
+  }
+}

--- a/src/main/java/io/vertx/ext/mongo/CreateCollectionOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/CreateCollectionOptions.java
@@ -1,0 +1,186 @@
+package io.vertx.ext.mongo;
+
+import com.mongodb.assertions.Assertions;
+import com.mongodb.client.model.IndexOptionDefaults;
+import com.mongodb.lang.Nullable;
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Objects;
+
+/**
+ * Options for creating a collection
+ */
+@DataObject(generateConverter = true)
+public class CreateCollectionOptions {
+  private long maxDocuments;
+  private boolean capped;
+  private long sizeInBytes;
+  private JsonObject storageEngineOptions = new JsonObject();
+  private JsonObject indexOptionDefaults = new JsonObject();
+  private ValidationOptions validationOptions = new ValidationOptions();
+  private CollationOptions collation;
+
+  public CreateCollectionOptions() {
+  }
+
+  public CreateCollectionOptions(CreateCollectionOptions createCollectionOptions) {
+    this.maxDocuments = createCollectionOptions.getMaxDocuments();
+    this.capped = createCollectionOptions.isCapped();
+    this.sizeInBytes = createCollectionOptions.getSizeInBytes();
+    this.storageEngineOptions = createCollectionOptions.getStorageEngineOptions();
+    this.indexOptionDefaults = createCollectionOptions.getIndexOptionDefaults();
+    this.validationOptions = createCollectionOptions.getValidationOptions();
+    this.collation = createCollectionOptions.getCollation();
+  }
+
+  public CreateCollectionOptions(JsonObject json) {
+    CreateCollectionOptionsConverter.fromJson(json, this);
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    CreateCollectionOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  public long getMaxDocuments() {
+    return this.maxDocuments;
+  }
+
+  /**
+   * Optional. The maximum number of documents allowed in the capped collection.
+   *           The size limit takes precedence over this limit.
+   *           If a capped collection reaches the size limit before it reaches the maximum number of documents,
+   *           MongoDB removes old documents.
+   *           If you prefer to use the max limit, ensure that the size limit,
+   *           which is required for a capped collection, is sufficient to contain the maximum number of documents.
+   * @param maxDocuments
+   * @return CreateCollectionOptions
+   */
+  public CreateCollectionOptions setMaxDocuments(long maxDocuments) {
+    this.maxDocuments = maxDocuments;
+    return this;
+  }
+
+  /**
+   * Returns the mongo-java-driver specific object.
+   * @return com.mongodb.client.model.CreateCollectionOptions
+   */
+  public com.mongodb.client.model.CreateCollectionOptions toMongoDriverObject() {
+    return new com.mongodb.client.model.CreateCollectionOptions()
+      .collation(collation.toMongoDriverObject())
+      .capped(capped)
+      .indexOptionDefaults(new IndexOptionDefaults()
+        .storageEngine(org.bson.BsonDocument.parse(indexOptionDefaults.encode()))
+      )
+      .validationOptions(validationOptions.toMongoDriverObject())
+      .storageEngineOptions(org.bson.BsonDocument.parse(storageEngineOptions.encode()))
+      .maxDocuments(maxDocuments)
+      .sizeInBytes(sizeInBytes);
+  }
+
+  public boolean isCapped() {
+    return this.capped;
+  }
+
+  /**
+   * Optional. To create a capped collection, specify true. If you specify true, you must also set a maximum size in the size field.
+   * @param capped
+   * @return CreateCollectionOptions
+   */
+  public CreateCollectionOptions setCapped(boolean capped) {
+    this.capped = capped;
+    return this;
+  }
+
+  public long getSizeInBytes() {
+    return this.sizeInBytes;
+  }
+
+  /**
+   * Optional. Specify a maximum size in bytes for a capped collection. Once a capped collection reaches its maximum size, MongoDB removes the older documents to make space for the new documents.
+   *           The size field is required for capped collections and ignored for other collections.
+   * @param sizeInBytes
+   * @return CreateCollectionOptions
+   */
+  public CreateCollectionOptions setSizeInBytes(long sizeInBytes) {
+    this.sizeInBytes = sizeInBytes;
+    return this;
+  }
+
+  @Nullable
+  public JsonObject getStorageEngineOptions() {
+    return this.storageEngineOptions;
+  }
+
+  /**
+   * Optional. Available for the WiredTiger storage engine only.
+   *
+   * Allows users to specify configuration to the storage engine on a per-collection basis when creating a collection.
+   * @param storageEngineOptions
+   * @return CreateCollectionOptions
+   */
+  public CreateCollectionOptions setStorageEngineOptions(@Nullable JsonObject storageEngineOptions) {
+    this.storageEngineOptions = storageEngineOptions;
+    return this;
+  }
+
+  public JsonObject getIndexOptionDefaults() {
+    return this.indexOptionDefaults;
+  }
+
+  /**
+   * Optional. Allows users to specify a default configuration for indexes when creating a collection.
+   * @param indexOptionDefaults
+   * @return CreateCollectionOptions
+   */
+  public CreateCollectionOptions setIndexOptionDefaults(JsonObject indexOptionDefaults) {
+    this.indexOptionDefaults = Assertions.notNull("indexOptionDefaults", indexOptionDefaults);
+    return this;
+  }
+
+  public ValidationOptions getValidationOptions() {
+    return this.validationOptions;
+  }
+
+  public CreateCollectionOptions setValidationOptions(ValidationOptions validationOptions) {
+    this.validationOptions = Assertions.notNull("validationOptions", validationOptions);
+    return this;
+  }
+
+  @Nullable
+  public CollationOptions getCollation() {
+    return this.collation;
+  }
+
+  /**
+   * Specifies the default collation for the collection.
+   *
+   * Collation allows users to specify language-specific rules for string comparison,
+   * such as rules for lettercase and accent marks.
+   * @param collation
+   * @return CreateCollectionOptions
+   */
+  public CreateCollectionOptions setCollation(@Nullable CollationOptions collation) {
+    this.collation = collation;
+    return this;
+  }
+
+  public String toString() {
+    return "CreateCollectionOptions{, maxDocuments=" + this.maxDocuments + ", capped=" + this.capped + ", sizeInBytes=" + this.sizeInBytes + ", storageEngineOptions=" + this.storageEngineOptions + ", indexOptionDefaults=" + this.indexOptionDefaults + ", validationOptions=" + this.validationOptions + ", collation=" + this.collation + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CreateCollectionOptions that = (CreateCollectionOptions) o;
+    return getMaxDocuments() == that.getMaxDocuments() && isCapped() == that.isCapped() && getSizeInBytes() == that.getSizeInBytes() && Objects.equals(getStorageEngineOptions(), that.getStorageEngineOptions()) && Objects.equals(getIndexOptionDefaults(), that.getIndexOptionDefaults()) && Objects.equals(getValidationOptions(), that.getValidationOptions()) && Objects.equals(getCollation(), that.getCollation());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getMaxDocuments(), isCapped(), getSizeInBytes(), getStorageEngineOptions(), getIndexOptionDefaults(), getValidationOptions(), getCollation());
+  }
+}

--- a/src/main/java/io/vertx/ext/mongo/DistinctOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/DistinctOptions.java
@@ -1,0 +1,48 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+@DataObject(generateConverter = true)
+public class DistinctOptions {
+  CollationOptions collation;
+
+  public DistinctOptions() {
+  }
+
+  public DistinctOptions(DistinctOptions distinctOptions) {
+    collation = distinctOptions.getCollation();
+  }
+
+  public DistinctOptions(JsonObject json) {
+    DistinctOptionsConverter.fromJson(json, this);
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    DistinctOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  /**
+   * @return Configured collationOptions
+   */
+  public CollationOptions getCollation() {
+    return collation;
+  }
+
+  /**
+   * Optional.
+   *
+   * Specifies the collation to use for the operation.
+   *
+   * Collation allows users to specify language-specific rules for string comparison, such as rules for letter-case and accent marks.
+   * @param collation
+   * @return reference to this, for fluency
+   */
+  public DistinctOptions setCollation(CollationOptions collation) {
+    this.collation = collation;
+    return this;
+  }
+
+}

--- a/src/main/java/io/vertx/ext/mongo/FindOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/FindOptions.java
@@ -3,6 +3,8 @@ package io.vertx.ext.mongo;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
+import java.util.Objects;
+
 /**
  * Options used to configure find operations.
  *
@@ -32,6 +34,7 @@ public class FindOptions {
   private int skip;
   private int batchSize;
   private String hint;
+  private CollationOptions collation;
 
   /**
    * Default constructor
@@ -42,13 +45,14 @@ public class FindOptions {
     this.limit = DEFAULT_LIMIT;
     this.skip = DEFAULT_SKIP;
     this.batchSize = DEFAULT_BATCH_SIZE;
-    this.hint = new String();
+    this.hint = "";
+    this.collation = null;
   }
 
   /**
    * Copy constructor
    *
-   * @param options  the one to copy
+   * @param options the one to copy
    */
   public FindOptions(FindOptions options) {
     this.fields = options.fields != null ? options.fields.copy() : new JsonObject();
@@ -57,22 +61,37 @@ public class FindOptions {
     this.skip = options.skip;
     this.batchSize = options.batchSize;
     this.hint = options.hint;
+    this.collation = options.getCollation();
   }
 
   /**
    * Constructor from JSON
    *
-   * @param options  the JSON
+   * @param options the JSON
    */
   public FindOptions(JsonObject options) {
     this();
     FindOptionsConverter.fromJson(options, this);
   }
 
+  public CollationOptions getCollation() {
+    return collation;
+  }
+
+  /**
+   * Set the collation
+   * @param collation
+   * @return reference to this, for fluency
+   */
+  public FindOptions setCollation(CollationOptions collation) {
+    this.collation = collation;
+    return this;
+  }
+
   /**
    * Convert to JSON
    *
-   * @return  the JSON
+   * @return the JSON
    */
   public JsonObject toJson() {
     JsonObject json = new JsonObject();
@@ -92,7 +111,7 @@ public class FindOptions {
   /**
    * Set the fields
    *
-   * @param fields  the fields
+   * @param fields the fields
    * @return reference to this, for fluency
    */
   public FindOptions setFields(JsonObject fields) {
@@ -103,7 +122,7 @@ public class FindOptions {
   /**
    * Get the sort document
    *
-   * @return  the sort document
+   * @return the sort document
    */
   public JsonObject getSort() {
     return sort;
@@ -112,7 +131,7 @@ public class FindOptions {
   /**
    * Set the sort document
    *
-   * @param sort  the sort document
+   * @param sort the sort document
    * @return reference to this, for fluency
    */
   public FindOptions setSort(JsonObject sort) {
@@ -122,7 +141,8 @@ public class FindOptions {
 
   /**
    * Get the limit - this determines the max number of rows to return
-   * @return  the limit
+   *
+   * @return the limit
    */
   public int getLimit() {
     return limit;
@@ -131,7 +151,7 @@ public class FindOptions {
   /**
    * Set the limit
    *
-   * @param limit  the limit
+   * @param limit the limit
    * @return reference to this, for fluency
    */
   public FindOptions setLimit(int limit) {
@@ -142,7 +162,7 @@ public class FindOptions {
   /**
    * Get the skip. This determines how many results to skip before returning results.
    *
-   * @return  the skip
+   * @return the skip
    */
   public int getSkip() {
     return skip;
@@ -151,7 +171,7 @@ public class FindOptions {
   /**
    * Set the skip
    *
-   * @param skip  the skip
+   * @param skip the skip
    * @return reference to this, for fluency
    */
   public FindOptions setSkip(int skip) {
@@ -180,7 +200,7 @@ public class FindOptions {
   /**
    * Get the hint. This determines the index to use.
    *
-   * @return  the hint
+   * @return the hint
    */
   public String getHint() {
     return hint;
@@ -189,7 +209,7 @@ public class FindOptions {
   /**
    * Set the hint
    *
-   * @param hint  the hint
+   * @param hint the hint
    * @return reference to this, for fluency
    */
   public FindOptions setHint(String hint) {
@@ -207,9 +227,9 @@ public class FindOptions {
     if (limit != that.limit) return false;
     if (skip != that.skip) return false;
     if (batchSize != that.batchSize) return false;
-    if (fields != null ? !fields.equals(that.fields) : that.fields != null) return false;
-    if (hint != null ? !hint.equals(that.hint) : that.hint != null) return false;
-    return sort != null ? sort.equals(that.sort) : that.sort == null;
+    if (!Objects.equals(fields, that.fields)) return false;
+    if (!Objects.equals(hint, that.hint)) return false;
+    return Objects.equals(sort, that.sort);
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/mongo/IndexOptionDefaults.java
+++ b/src/main/java/io/vertx/ext/mongo/IndexOptionDefaults.java
@@ -1,0 +1,68 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Objects;
+
+/**
+ * The default options for a collection to apply on the creation of indexes.
+ */
+@DataObject(generateConverter = true)
+public class IndexOptionDefaults {
+  private JsonObject storageEngine = new JsonObject();
+
+  public IndexOptionDefaults() {
+    storageEngine = new JsonObject();
+  }
+
+  public IndexOptionDefaults(JsonObject json) {
+    IndexOptionDefaultsConverter.fromJson(json, this);
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    IndexOptionDefaultsConverter.toJson(this, json);
+    return json;
+  }
+
+  /**
+   * Returns the mongo-java-driver specific object.
+   * @return com.mongodb.client.model.IndexOptionDefaults
+   */
+  public com.mongodb.client.model.IndexOptionDefaults toMongoDriverObject() {
+    return new com.mongodb.client.model.IndexOptionDefaults()
+      .storageEngine(org.bson.BsonDocument.parse(this.storageEngine.encode()));
+  }
+
+  /**
+   * Gets the default storage engine options document for indexes.
+   * @return storageEngine as JsonObject
+   */
+  public JsonObject getStorageEngine() {
+    return storageEngine;
+  }
+
+  /**
+   * Sets the default storage engine options document for indexes.
+   * @param storageEngine
+   * @return IndexOptionDefaults
+   */
+  public IndexOptionDefaults setStorageEngine(JsonObject storageEngine) {
+    this.storageEngine = storageEngine;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    IndexOptionDefaults that = (IndexOptionDefaults) o;
+    return Objects.equals(getStorageEngine(), that.getStorageEngine());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getStorageEngine());
+  }
+}

--- a/src/main/java/io/vertx/ext/mongo/IndexOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/IndexOptions.java
@@ -13,503 +13,534 @@ import java.util.concurrent.TimeUnit;
 @DataObject
 public class IndexOptions {
 
-    public static final boolean DEFAULT_BACKGROUD = false;
-    public static final boolean DEFAULT_UNIQUE = false;
-    public static final boolean DEFAULT_SPARSE = false;
+  public static final boolean DEFAULT_BACKGROUND = false;
+  public static final boolean DEFAULT_UNIQUE = false;
+  public static final boolean DEFAULT_SPARSE = false;
 
-    private boolean background;
-    private boolean unique;
-    private String name;
-    private boolean sparse;
-    private Long expireAfterSeconds;
-    private Integer version;
-    private JsonObject weights;
-    private String defaultLanguage;
-    private String languageOverride;
-    private Integer textVersion;
-    private Integer sphereVersion;
-    private Integer bits;
-    private Double min;
-    private Double max;
-    private Double bucketSize;
-    private JsonObject storageEngine;
-    private JsonObject partialFilterExpression;
+  private boolean background;
+  private boolean unique;
+  private String name;
+  private boolean sparse;
+  private Long expireAfterSeconds;
+  private Integer version;
+  private JsonObject weights;
+  private String defaultLanguage;
+  private String languageOverride;
+  private Integer textVersion;
+  private Integer sphereVersion;
+  private Integer bits;
+  private Double min;
+  private Double max;
+  private Double bucketSize;
+  private JsonObject storageEngine;
+  private JsonObject partialFilterExpression;
+  private CollationOptions collation;
 
-    /**
-     * Default constructor
-     */
-    public IndexOptions() {
-        background = DEFAULT_BACKGROUD;
-        unique = DEFAULT_UNIQUE;
-        sparse = DEFAULT_SPARSE;
+  /**
+   * Default constructor
+   */
+  public IndexOptions() {
+    background = DEFAULT_BACKGROUND;
+    unique = DEFAULT_UNIQUE;
+    sparse = DEFAULT_SPARSE;
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param options the one to copy
+   */
+  public IndexOptions(IndexOptions options) {
+    background = options.background;
+    unique = options.unique;
+    name = options.name;
+    sparse = options.sparse;
+    expireAfterSeconds = options.expireAfterSeconds;
+    version = options.version;
+    weights = options.weights;
+    defaultLanguage = options.defaultLanguage;
+    languageOverride = options.languageOverride;
+    textVersion = options.textVersion;
+    sphereVersion = options.sphereVersion;
+    bits = options.bits;
+    min = options.min;
+    max = options.max;
+    bucketSize = options.bucketSize;
+    storageEngine = options.storageEngine;
+    partialFilterExpression = options.partialFilterExpression;
+    collation = options.collation;
+  }
+
+  /**
+   * Constructor from JSON
+   *
+   * @param options the JSON
+   */
+  public IndexOptions(JsonObject options) {
+    background = options.getBoolean("background", DEFAULT_BACKGROUND);
+    unique = options.getBoolean("unique", DEFAULT_UNIQUE);
+    name = options.getString("name");
+    sparse = options.getBoolean("sparse", DEFAULT_SPARSE);
+    expireAfterSeconds = options.getLong("expireAfterSeconds");
+    version = options.getInteger("version");
+    weights = options.getJsonObject("weights");
+    defaultLanguage = options.getString("defaultLanguage");
+    languageOverride = options.getString("languageOverride");
+    textVersion = options.getInteger("textVersion");
+    sphereVersion = options.getInteger("sphereVersion");
+    bits = options.getInteger("bits");
+    min = options.getDouble("min");
+    max = options.getDouble("max");
+    bucketSize = options.getDouble("bucketSize");
+    storageEngine = options.getJsonObject("storageEngine");
+    partialFilterExpression = options.getJsonObject("partialFilterExpression");
+    collation = new CollationOptions(options.getJsonObject("collation"));
+  }
+
+  public CollationOptions getCollation() {
+    return collation;
+  }
+
+  /**
+   * Optional. Specifies the collation for the index.
+   * <p>
+   * Collation allows users to specify language-specific rules for string comparison, such as rules for lettercase and accent marks.
+   * <p>
+   * If you have specified a collation at the collection level, then:
+   * If you do not specify a collation when creating the index, MongoDB creates the index with the collection's default collation.
+   * If you do specify a collation when creating the index, MongoDB creates the index with the specified collation.
+   * When specifying collation, the locale field is mandatory; all other collation fields are optional.
+   * For descriptions of the fields, see <a href="https://docs.mongodb.com/manual/reference/collation/#std-label-collation-document-fields">Collation Document</a>.
+   *
+   * @param collation as CollationOption
+   * @return IndexOptions
+   * @see <a href="https://docs.mongodb.com/manual/reference/collation/#std-label-collation-document-fields">Collation Document</a>
+   */
+  public IndexOptions setCollation(CollationOptions collation) {
+    this.collation = collation;
+    return this;
+  }
+
+  /**
+   * Convert to JSON
+   *
+   * @return the JSON
+   */
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    json.put("background", background);
+    json.put("unique", unique);
+    json.put("sparse", sparse);
+    if (name != null) {
+      json.put("name", name);
     }
-
-    /**
-     * Copy constructor
-     *
-     * @param options  the one to copy
-     */
-    public IndexOptions(IndexOptions options) {
-        background = options.background;
-        unique = options.unique;
-        name = options.name;
-        sparse = options.sparse;
-        expireAfterSeconds = options.expireAfterSeconds;
-        version = options.version;
-        weights = options.weights;
-        defaultLanguage = options.defaultLanguage;
-        languageOverride = options.languageOverride;
-        textVersion = options.textVersion;
-        sphereVersion = options.sphereVersion;
-        bits = options.bits;
-        min = options.min;
-        max = options.max;
-        bucketSize = options.bucketSize;
-        storageEngine = options.storageEngine;
-        partialFilterExpression = options.partialFilterExpression;
+    if (expireAfterSeconds != null) {
+      json.put("expireAfterSeconds", expireAfterSeconds);
     }
-
-    /**
-     * Constructor from JSON
-     *
-     * @param options  the JSON
-     */
-    public IndexOptions(JsonObject options) {
-        background = options.getBoolean("background", DEFAULT_BACKGROUD);
-        unique = options.getBoolean("unique", DEFAULT_UNIQUE);
-        name = options.getString("name");
-        sparse = options.getBoolean("sparse", DEFAULT_SPARSE);
-        expireAfterSeconds = options.getLong("expireAfterSeconds");
-        version = options.getInteger("version");
-        weights = options.getJsonObject("weights");
-        defaultLanguage = options.getString("defaultLanguage");
-        languageOverride = options.getString("languageOverride");
-        textVersion = options.getInteger("textVersion");
-        sphereVersion = options.getInteger("sphereVersion");
-        bits = options.getInteger("bits");
-        min = options.getDouble("min");
-        max = options.getDouble("max");
-        bucketSize = options.getDouble("bucketSize");
-        storageEngine = options.getJsonObject("storageEngine");
-        partialFilterExpression = options.getJsonObject("partialFilterExpression");
+    if (version != null) {
+      json.put("version", version);
     }
-
-    /**
-     * Convert to JSON
-     * @return the JSON
-     */
-    public JsonObject toJson() {
-        JsonObject json = new JsonObject();
-        json.put("background", background);
-        json.put("unique", unique);
-        json.put("sparse", sparse);
-        if (name != null) {
-            json.put("name", name);
-        }
-        if (expireAfterSeconds != null) {
-            json.put("expireAfterSeconds", expireAfterSeconds);
-        }
-        if (version != null) {
-            json.put("version", version);
-        }
-        if (weights != null) {
-            json.put("weights", weights);
-        }
-        if (defaultLanguage != null) {
-            json.put("defaultLanguage", defaultLanguage);
-        }
-        if (languageOverride != null) {
-            json.put("languageOverride", languageOverride);
-        }
-        if (textVersion != null) {
-            json.put("textVersion", textVersion);
-        }
-        if (sphereVersion != null) {
-            json.put("sphereVersion", sphereVersion);
-        }
-        if (bits != null) {
-            json.put("bits", bits);
-        }
-        if (min != null) {
-            json.put("min", min);
-        }
-        if (max != null) {
-            json.put("max", max);
-        }
-        if (bucketSize != null) {
-            json.put("bucketSize", bucketSize);
-        }
-        if (storageEngine != null) {
-            json.put("storageEngine", storageEngine);
-        }
-        if (partialFilterExpression != null) {
-            json.put("partialFilterExpression", partialFilterExpression);
-        }
-        return json;
+    if (weights != null) {
+      json.put("weights", weights);
     }
-
-    /**
-     * Create the index in the background
-     *
-     * @return true if should create the index in the background
-     */
-    public boolean isBackground() {
-        return background;
+    if (defaultLanguage != null) {
+      json.put("defaultLanguage", defaultLanguage);
     }
-
-    /**
-     * Should the index should be created in the background
-     *
-     * @param background true if should create the index in the background
-     * @return reference to this, for fluency
-     */
-    public IndexOptions background(boolean background) {
-        this.background = background;
-        return this;
+    if (languageOverride != null) {
+      json.put("languageOverride", languageOverride);
     }
-
-    /**
-     * Gets if the index should be unique.
-     *
-     * @return true if the index should be unique
-     */
-    public boolean isUnique() {
-        return unique;
+    if (textVersion != null) {
+      json.put("textVersion", textVersion);
     }
-
-    /**
-     * Should the index should be unique.
-     *
-     * @param unique if the index should be unique
-     * @return reference to this, for fluency
-     */
-    public IndexOptions unique(boolean unique) {
-        this.unique = unique;
-        return this;
+    if (sphereVersion != null) {
+      json.put("sphereVersion", sphereVersion);
     }
-
-    /**
-     * Gets the name of the index.
-     *
-     * @return the name of the index
-     */
-    public String getName() {
-        return name;
+    if (bits != null) {
+      json.put("bits", bits);
     }
-
-    /**
-     * Sets the name of the index.
-     *
-     * @param name of the index
-     * @return reference to this, for fluency
-     */
-    public IndexOptions name(String name) {
-        this.name = name;
-        return this;
+    if (min != null) {
+      json.put("min", min);
     }
-
-    /**
-     * If true, the index only references documents with the specified field
-     *
-     * @return if the index should only reference documents with the specified field
-     */
-    public boolean isSparse() {
-        return sparse;
+    if (max != null) {
+      json.put("max", max);
     }
-
-    /**
-     * Should the index only references documents with the specified field
-     *
-     * @param sparse if true, the index only references documents with the specified field
-     * @return reference to this, for fluency
-     */
-    public IndexOptions sparse(boolean sparse) {
-        this.sparse = sparse;
-        return this;
+    if (bucketSize != null) {
+      json.put("bucketSize", bucketSize);
     }
-
-    /**
-     * Gets the time to live for documents in the collection
-     *
-     * @return the time to live for documents in the collection
-     * @param timeUnit the time unit
-     */
-    public Long getExpireAfter(TimeUnit timeUnit) {
-        if (expireAfterSeconds == null) {
-            return null;
-        }
-        return timeUnit.convert(expireAfterSeconds, TimeUnit.SECONDS);
+    if (storageEngine != null) {
+      json.put("storageEngine", storageEngine);
     }
-
-    /**
-     * Sets the time to live for documents in the collection
-     *
-     * @param expireAfter the time to live for documents in the collection
-     * @param timeUnit the time unit for expireAfter
-     * @return reference to this, for fluency
-     */
-    public IndexOptions expireAfter(Long expireAfter, TimeUnit timeUnit) {
-        if (expireAfter == null) {
-            this.expireAfterSeconds = null;
-        } else {
-            this.expireAfterSeconds = TimeUnit.SECONDS.convert(expireAfter, timeUnit);
-        }
-        return this;
+    if (partialFilterExpression != null) {
+      json.put("partialFilterExpression", partialFilterExpression);
     }
-
-    /**
-     * Gets the index version number.
-     *
-     * @return the index version number
-     */
-    public Integer getVersion() {
-        return this.version;
+    if (collation != null) {
+      json.put("collation", collation.toJson());
     }
+    return json;
+  }
 
-    /**
-     * Sets the index version number.
-     *
-     * @param version the index version number
-     * @return reference to this, for fluency
-     */
-    public IndexOptions version(Integer version) {
-        this.version = version;
-        return this;
-    }
+  /**
+   * Create the index in the background
+   *
+   * @return true if should create the index in the background
+   */
+  public boolean isBackground() {
+    return background;
+  }
 
-    /**
-     * Gets the weighting object for use with a text index
-     *
-     * <p>A document that represents field and weight pairs. The weight is an integer ranging from 1 to 99,999 and denotes the significance
-     * of the field relative to the other indexed fields in terms of the score.</p>
-     *
-     * @return the weighting object
-     */
-    public JsonObject getWeights() {
-        return weights;
-    }
+  /**
+   * Should the index be created in the background
+   *
+   * @param background true if should create the index in the background
+   * @return reference to this, for fluency
+   */
+  public IndexOptions background(boolean background) {
+    this.background = background;
+    return this;
+  }
 
-    /**
-     * Sets the weighting object for use with a text index.
-     *
-     * <p>An document that represents field and weight pairs. The weight is an integer ranging from 1 to 99,999 and denotes the significance
-     * of the field relative to the other indexed fields in terms of the score.</p>
-     *
-     * @param weights the weighting object
-     * @return reference to this, for fluency
-     */
-    public IndexOptions weights(JsonObject weights) {
-        this.weights = weights;
-        return this;
-    }
+  /**
+   * Gets if the index should be unique.
+   *
+   * @return true if the index should be unique
+   */
+  public boolean isUnique() {
+    return unique;
+  }
 
-    /**
-     * Gets the language for a text index.
-     *
-     * <p>The language that determines the list of stop words and the rules for the stemmer and tokenizer.</p>
-     *
-     * @return the language for a text index.
-     */
-    public String getDefaultLanguage() {
-        return defaultLanguage;
-    }
+  /**
+   * Should the index should be unique.
+   *
+   * @param unique if the index should be unique
+   * @return reference to this, for fluency
+   */
+  public IndexOptions unique(boolean unique) {
+    this.unique = unique;
+    return this;
+  }
 
-    /**
-     * Sets the language for the text index.
-     *
-     * <p>The language that determines the list of stop words and the rules for the stemmer and tokenizer.</p>
-     *
-     * @param defaultLanguage the language for the text index.
-     * @return reference to this, for fluency
-     */
-    public IndexOptions defaultLanguage(String defaultLanguage) {
-        this.defaultLanguage = defaultLanguage;
-        return this;
-    }
+  /**
+   * Gets the name of the index.
+   *
+   * @return the name of the index
+   */
+  public String getName() {
+    return name;
+  }
 
-    /**
-     * Gets the name of the field that contains the language string.
-     *
-     * <p>For text indexes, the name of the field, in the collection's documents, that contains the override language for the document.</p>
-     *
-     * @return the name of the field that contains the language string.
-     */
-    public String getLanguageOverride() {
-        return languageOverride;
-    }
+  /**
+   * Sets the name of the index.
+   *
+   * @param name of the index
+   * @return reference to this, for fluency
+   */
+  public IndexOptions name(String name) {
+    this.name = name;
+    return this;
+  }
 
-    /**
-     * Sets the name of the field that contains the language string.
-     *
-     * <p>For text indexes, the name of the field, in the collection's documents, that contains the override language for the document.</p>
-     *
-     * @param languageOverride the name of the field that contains the language string.
-     * @return reference to this, for fluency
-     */
-    public IndexOptions languageOverride(String languageOverride) {
-        this.languageOverride = languageOverride;
-        return this;
-    }
+  /**
+   * If true, the index only references documents with the specified field
+   *
+   * @return if the index should only reference documents with the specified field
+   */
+  public boolean isSparse() {
+    return sparse;
+  }
 
-    /**
-     * The text index version number.
-     *
-     * @return the text index version number.
-     */
-    public Integer getTextVersion() {
-        return textVersion;
-    }
+  /**
+   * Should the index only references documents with the specified field
+   *
+   * @param sparse if true, the index only references documents with the specified field
+   * @return reference to this, for fluency
+   */
+  public IndexOptions sparse(boolean sparse) {
+    this.sparse = sparse;
+    return this;
+  }
 
-    /**
-     * Set the text index version number.
-     *
-     * @param textVersion the text index version number.
-     * @return reference to this, for fluency
-     */
-    public IndexOptions textVersion(Integer textVersion) {
-        this.textVersion = textVersion;
-        return this;
+  /**
+   * Gets the time to live for documents in the collection
+   *
+   * @param timeUnit the time unit
+   * @return the time to live for documents in the collection
+   */
+  public Long getExpireAfter(TimeUnit timeUnit) {
+    if (expireAfterSeconds == null) {
+      return null;
     }
+    return timeUnit.convert(expireAfterSeconds, TimeUnit.SECONDS);
+  }
 
-    /**
-     * Gets the 2dsphere index version number.
-     *
-     * @return the 2dsphere index version number
-     */
-    public Integer getSphereVersion() {
-        return sphereVersion;
+  /**
+   * Sets the time to live for documents in the collection
+   *
+   * @param expireAfter the time to live for documents in the collection
+   * @param timeUnit    the time unit for expireAfter
+   * @return reference to this, for fluency
+   */
+  public IndexOptions expireAfter(Long expireAfter, TimeUnit timeUnit) {
+    if (expireAfter == null) {
+      this.expireAfterSeconds = null;
+    } else {
+      this.expireAfterSeconds = TimeUnit.SECONDS.convert(expireAfter, timeUnit);
     }
+    return this;
+  }
 
-    /**
-     * Sets the 2dsphere index version number.
-     *
-     * @param sphereVersion the 2dsphere index version number.
-     * @return reference to this, for fluency
-     */
-    public IndexOptions sphereVersion(Integer sphereVersion) {
-        this.sphereVersion = sphereVersion;
-        return this;
-    }
+  /**
+   * Gets the index version number.
+   *
+   * @return the index version number
+   */
+  public Integer getVersion() {
+    return this.version;
+  }
 
-    /**
-     * Gets the number of precision of the stored geohash value of the location data in 2d indexes.
-     *
-     * @return the number of precision of the stored geohash value
-     */
-    public Integer getBits() {
-        return bits;
-    }
+  /**
+   * Sets the index version number.
+   *
+   * @param version the index version number
+   * @return reference to this, for fluency
+   */
+  public IndexOptions version(Integer version) {
+    this.version = version;
+    return this;
+  }
 
-    /**
-     * Sets the number of precision of the stored geohash value of the location data in 2d indexes.
-     *
-     * @param bits the number of precision of the stored geohash value
-     * @return reference to this, for fluency
-     */
-    public IndexOptions bits(Integer bits) {
-        this.bits = bits;
-        return this;
-    }
+  /**
+   * Gets the weighting object for use with a text index
+   *
+   * <p>A document that represents field and weight pairs. The weight is an integer ranging from 1 to 99,999 and denotes the significance
+   * of the field relative to the other indexed fields in terms of the score.</p>
+   *
+   * @return the weighting object
+   */
+  public JsonObject getWeights() {
+    return weights;
+  }
 
-    /**
-     * Gets the lower inclusive boundary for the longitude and latitude values for 2d indexes..
-     *
-     * @return the lower inclusive boundary for the longitude and latitude values.
-     */
-    public Double getMin() {
-        return min;
-    }
+  /**
+   * Sets the weighting object for use with a text index.
+   *
+   * <p>An document that represents field and weight pairs. The weight is an integer ranging from 1 to 99,999 and denotes the significance
+   * of the field relative to the other indexed fields in terms of the score.</p>
+   *
+   * @param weights the weighting object
+   * @return reference to this, for fluency
+   */
+  public IndexOptions weights(JsonObject weights) {
+    this.weights = weights;
+    return this;
+  }
 
-    /**
-     * Sets the lower inclusive boundary for the longitude and latitude values for 2d indexes..
-     *
-     * @param min the lower inclusive boundary for the longitude and latitude values
-     * @return reference to this, for fluency
-     */
-    public IndexOptions min(Double min) {
-        this.min = min;
-        return this;
-    }
+  /**
+   * Gets the language for a text index.
+   *
+   * <p>The language that determines the list of stop words and the rules for the stemmer and tokenizer.</p>
+   *
+   * @return the language for a text index.
+   */
+  public String getDefaultLanguage() {
+    return defaultLanguage;
+  }
 
-    /**
-     * Gets the upper inclusive boundary for the longitude and latitude values for 2d indexes..
-     *
-     * @return the upper inclusive boundary for the longitude and latitude values.
-     */
-    public Double getMax() {
-        return max;
-    }
+  /**
+   * Sets the language for the text index.
+   *
+   * <p>The language that determines the list of stop words and the rules for the stemmer and tokenizer.</p>
+   *
+   * @param defaultLanguage the language for the text index.
+   * @return reference to this, for fluency
+   */
+  public IndexOptions defaultLanguage(String defaultLanguage) {
+    this.defaultLanguage = defaultLanguage;
+    return this;
+  }
 
-    /**
-     * Sets the upper inclusive boundary for the longitude and latitude values for 2d indexes..
-     *
-     * @param max the upper inclusive boundary for the longitude and latitude values
-     * @return reference to this, for fluency
-     */
-    public IndexOptions max(Double max) {
-        this.max = max;
-        return this;
-    }
+  /**
+   * Gets the name of the field that contains the language string.
+   *
+   * <p>For text indexes, the name of the field, in the collection's documents, that contains the override language for the document.</p>
+   *
+   * @return the name of the field that contains the language string.
+   */
+  public String getLanguageOverride() {
+    return languageOverride;
+  }
 
-    /**
-     * Gets the specified the number of units within which to group the location values for geoHaystack Indexes
-     *
-     * @return the specified the number of units within which to group the location values for geoHaystack Indexes
-     */
-    public Double getBucketSize() {
-        return bucketSize;
-    }
+  /**
+   * Sets the name of the field that contains the language string.
+   *
+   * <p>For text indexes, the name of the field, in the collection's documents, that contains the override language for the document.</p>
+   *
+   * @param languageOverride the name of the field that contains the language string.
+   * @return reference to this, for fluency
+   */
+  public IndexOptions languageOverride(String languageOverride) {
+    this.languageOverride = languageOverride;
+    return this;
+  }
 
-    /**
-     * Sets the specified the number of units within which to group the location values for geoHaystack Indexes
-     *
-     * @param bucketSize the specified the number of units within which to group the location values for geoHaystack Indexes
-     * @return reference to this, for fluency
-     */
-    public IndexOptions bucketSize(Double bucketSize) {
-        this.bucketSize = bucketSize;
-        return this;
-    }
+  /**
+   * The text index version number.
+   *
+   * @return the text index version number.
+   */
+  public Integer getTextVersion() {
+    return textVersion;
+  }
 
-    /**
-     * Gets the storage engine options document for this index.
-     *
-     * @return the storage engine options
-     */
-    public JsonObject getStorageEngine() {
-        return storageEngine;
-    }
+  /**
+   * Set the text index version number.
+   *
+   * @param textVersion the text index version number.
+   * @return reference to this, for fluency
+   */
+  public IndexOptions textVersion(Integer textVersion) {
+    this.textVersion = textVersion;
+    return this;
+  }
 
-    /**
-     * Sets the storage engine options document for this index.
-     *
-     * @param storageEngine the storage engine options
-     * @return reference to this, for fluency
-     */
-    public IndexOptions storageEngine(JsonObject storageEngine) {
-        this.storageEngine = storageEngine;
-        return this;
-    }
+  /**
+   * Gets the 2dsphere index version number.
+   *
+   * @return the 2dsphere index version number
+   */
+  public Integer getSphereVersion() {
+    return sphereVersion;
+  }
 
-    /**
-     * Get the filter expression for the documents to be included in the index or null if not set
-     *
-     * @return the filter expression for the documents to be included in the index or null if not set
-     */
-    public JsonObject getPartialFilterExpression() {
-        return partialFilterExpression;
-    }
+  /**
+   * Sets the 2dsphere index version number.
+   *
+   * @param sphereVersion the 2dsphere index version number.
+   * @return reference to this, for fluency
+   */
+  public IndexOptions sphereVersion(Integer sphereVersion) {
+    this.sphereVersion = sphereVersion;
+    return this;
+  }
 
-    /**
-     * Sets the filter expression for the documents to be included in the index
-     *
-     * @param partialFilterExpression the filter expression for the documents to be included in the index
-     * @return reference to this, for fluency
-     */
-    public IndexOptions partialFilterExpression(JsonObject partialFilterExpression) {
-        this.partialFilterExpression = partialFilterExpression;
-        return this;
-    }
+  /**
+   * Gets the number of precision of the stored geohash value of the location data in 2d indexes.
+   *
+   * @return the number of precision of the stored geohash value
+   */
+  public Integer getBits() {
+    return bits;
+  }
+
+  /**
+   * Sets the number of precision of the stored geohash value of the location data in 2d indexes.
+   *
+   * @param bits the number of precision of the stored geohash value
+   * @return reference to this, for fluency
+   */
+  public IndexOptions bits(Integer bits) {
+    this.bits = bits;
+    return this;
+  }
+
+  /**
+   * Gets the lower inclusive boundary for the longitude and latitude values for 2d indexes..
+   *
+   * @return the lower inclusive boundary for the longitude and latitude values.
+   */
+  public Double getMin() {
+    return min;
+  }
+
+  /**
+   * Sets the lower inclusive boundary for the longitude and latitude values for 2d indexes..
+   *
+   * @param min the lower inclusive boundary for the longitude and latitude values
+   * @return reference to this, for fluency
+   */
+  public IndexOptions min(Double min) {
+    this.min = min;
+    return this;
+  }
+
+  /**
+   * Gets the upper inclusive boundary for the longitude and latitude values for 2d indexes..
+   *
+   * @return the upper inclusive boundary for the longitude and latitude values.
+   */
+  public Double getMax() {
+    return max;
+  }
+
+  /**
+   * Sets the upper inclusive boundary for the longitude and latitude values for 2d indexes..
+   *
+   * @param max the upper inclusive boundary for the longitude and latitude values
+   * @return reference to this, for fluency
+   */
+  public IndexOptions max(Double max) {
+    this.max = max;
+    return this;
+  }
+
+  /**
+   * Gets the specified the number of units within which to group the location values for geoHaystack Indexes
+   *
+   * @return the specified the number of units within which to group the location values for geoHaystack Indexes
+   */
+  public Double getBucketSize() {
+    return bucketSize;
+  }
+
+  /**
+   * Sets the specified the number of units within which to group the location values for geoHaystack Indexes
+   *
+   * @param bucketSize the specified the number of units within which to group the location values for geoHaystack Indexes
+   * @return reference to this, for fluency
+   */
+  public IndexOptions bucketSize(Double bucketSize) {
+    this.bucketSize = bucketSize;
+    return this;
+  }
+
+  /**
+   * Gets the storage engine options document for this index.
+   *
+   * @return the storage engine options
+   */
+  public JsonObject getStorageEngine() {
+    return storageEngine;
+  }
+
+  /**
+   * Sets the storage engine options document for this index.
+   *
+   * @param storageEngine the storage engine options
+   * @return reference to this, for fluency
+   */
+  public IndexOptions storageEngine(JsonObject storageEngine) {
+    this.storageEngine = storageEngine;
+    return this;
+  }
+
+  /**
+   * Get the filter expression for the documents to be included in the index or null if not set
+   *
+   * @return the filter expression for the documents to be included in the index or null if not set
+   */
+  public JsonObject getPartialFilterExpression() {
+    return partialFilterExpression;
+  }
+
+  /**
+   * Sets the filter expression for the documents to be included in the index
+   *
+   * @param partialFilterExpression the filter expression for the documents to be included in the index
+   * @return reference to this, for fluency
+   */
+  public IndexOptions partialFilterExpression(JsonObject partialFilterExpression) {
+    this.partialFilterExpression = partialFilterExpression;
+    return this;
+  }
 
   @Override
   public boolean equals(Object o) {
@@ -522,19 +553,25 @@ public class IndexOptions {
     if (unique != options.unique) return false;
     if (name != null ? !name.equals(options.name) : options.name != null) return false;
     if (sparse != options.sparse) return false;
-    if (expireAfterSeconds != null ? !expireAfterSeconds.equals(options.expireAfterSeconds) : options.expireAfterSeconds!= null) return false;
+    if (expireAfterSeconds != null ? !expireAfterSeconds.equals(options.expireAfterSeconds) : options.expireAfterSeconds != null)
+      return false;
     if (version != null ? !version.equals(options.version) : options.version != null) return false;
     if (weights != null ? !weights.equals(options.weights) : options.weights != null) return false;
-    if (defaultLanguage != null ? !defaultLanguage.equals(options.defaultLanguage) : options.defaultLanguage != null) return false;
-    if (languageOverride != null ? !languageOverride.equals(options.languageOverride) : options.languageOverride != null) return false;
+    if (defaultLanguage != null ? !defaultLanguage.equals(options.defaultLanguage) : options.defaultLanguage != null)
+      return false;
+    if (languageOverride != null ? !languageOverride.equals(options.languageOverride) : options.languageOverride != null)
+      return false;
     if (textVersion != null ? !textVersion.equals(options.textVersion) : options.textVersion != null) return false;
-    if (sphereVersion != null ? !sphereVersion.equals(options.sphereVersion) : options.sphereVersion != null) return false;
+    if (sphereVersion != null ? !sphereVersion.equals(options.sphereVersion) : options.sphereVersion != null)
+      return false;
     if (bits != null ? !bits.equals(options.bits) : options.bits != null) return false;
     if (min != null ? !min.equals(options.min) : options.min != null) return false;
     if (max != null ? !max.equals(options.max) : options.max != null) return false;
     if (bucketSize != null ? !bucketSize.equals(options.bucketSize) : options.bucketSize != null) return false;
-    if (storageEngine != null ? !storageEngine.equals(options.storageEngine) : options.storageEngine != null) return false;
-    if (partialFilterExpression != null ? !partialFilterExpression.equals(options.partialFilterExpression) : options.partialFilterExpression != null) return false;
+    if (storageEngine != null ? !storageEngine.equals(options.storageEngine) : options.storageEngine != null)
+      return false;
+    if (partialFilterExpression != null ? !partialFilterExpression.equals(options.partialFilterExpression) : options.partialFilterExpression != null)
+      return false;
 
     return true;
   }

--- a/src/main/java/io/vertx/ext/mongo/MaxVariable.java
+++ b/src/main/java/io/vertx/ext/mongo/MaxVariable.java
@@ -1,0 +1,8 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+public enum MaxVariable {
+  punct, space;
+}

--- a/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -64,8 +64,9 @@ public interface MongoClient {
 
   /**
    * Like {@link #createShared(io.vertx.core.Vertx, JsonObject, String)} but with the default data source name
+   *
    * @param vertx  the Vert.x instance
-   * @param config  the configuration
+   * @param config the configuration
    * @return the client
    */
   static MongoClient createShared(Vertx vertx, JsonObject config) {
@@ -75,10 +76,11 @@ public interface MongoClient {
   /**
    * Constructor targeting the jvm, like standard constructor {@link #createShared(Vertx, JsonObject, String)}, but it accepts default mongoClientSettings
    * to configure mongo
-   * @param vertx the Vert.x instance
-   * @param config the configuration use only to provide objectId and database name
+   *
+   * @param vertx          the Vert.x instance
+   * @param config         the configuration use only to provide objectId and database name
    * @param dataSourceName the data source name
-   * @param settings the native java mongo settings
+   * @param settings       the native java mongo settings
    * @return the client
    */
   @GenIgnore
@@ -91,9 +93,9 @@ public interface MongoClient {
    * <p>
    * This operation might change <i>_id</i> field of <i>document</i> parameter
    *
-   * @param collection  the collection
-   * @param document  the document
-   * @param resultHandler  result handler will be provided with the id if document didn't already have one
+   * @param collection    the collection
+   * @param document      the document
+   * @param resultHandler result handler will be provided with the id if document didn't already have one
    */
   @Fluent
   MongoClient save(String collection, JsonObject document, Handler<AsyncResult<@Nullable String>> resultHandler);
@@ -108,10 +110,10 @@ public interface MongoClient {
    * <p>
    * This operation might change <i>_id</i> field of <i>document</i> parameter
    *
-   * @param collection  the collection
-   * @param document  the document
-   * @param writeOption  the write option to use
-   * @param resultHandler  result handler will be provided with the id if document didn't already have one
+   * @param collection    the collection
+   * @param document      the document
+   * @param writeOption   the write option to use
+   * @param resultHandler result handler will be provided with the id if document didn't already have one
    */
   @Fluent
   MongoClient saveWithOptions(String collection, JsonObject document, @Nullable WriteOption writeOption, Handler<AsyncResult<@Nullable String>> resultHandler);
@@ -126,9 +128,9 @@ public interface MongoClient {
    * <p>
    * This operation might change <i>_id</i> field of <i>document</i> parameter
    *
-   * @param collection  the collection
-   * @param document  the document
-   * @param resultHandler  result handler will be provided with the id if document didn't already have one
+   * @param collection    the collection
+   * @param document      the document
+   * @param resultHandler result handler will be provided with the id if document didn't already have one
    */
   @Fluent
   MongoClient insert(String collection, JsonObject document, Handler<AsyncResult<@Nullable String>> resultHandler);
@@ -143,10 +145,10 @@ public interface MongoClient {
    * <p>
    * This operation might change <i>_id</i> field of <i>document</i> parameter
    *
-   * @param collection  the collection
-   * @param document  the document
-   * @param writeOption  the write option to use
-   * @param resultHandler  result handler will be provided with the id if document didn't already have one
+   * @param collection    the collection
+   * @param document      the document
+   * @param writeOption   the write option to use
+   * @param resultHandler result handler will be provided with the id if document didn't already have one
    */
   @Fluent
   MongoClient insertWithOptions(String collection, JsonObject document, @Nullable WriteOption writeOption, Handler<AsyncResult<@Nullable String>> resultHandler);
@@ -159,9 +161,9 @@ public interface MongoClient {
   /**
    * Update matching documents in the specified collection and return the handler with {@code MongoClientUpdateResult} result
    *
-   * @param collection  the collection
-   * @param query  query used to match the documents
-   * @param update used to describe how the documents will be updated
+   * @param collection    the collection
+   * @param query         query used to match the documents
+   * @param update        used to describe how the documents will be updated
    * @param resultHandler will be called with a {@link MongoClientUpdateResult} when complete
    */
   @Fluent
@@ -176,9 +178,9 @@ public interface MongoClient {
   /**
    * Use an aggregation pipeline to update documents in the specified collection and return the handler with {@code MongoClientUpdateResult} result
    *
-   * @param collection  the collection
-   * @param query  query used to match the documents
-   * @param update used to describe how the documents will be updated
+   * @param collection    the collection
+   * @param query         query used to match the documents
+   * @param update        used to describe how the documents will be updated
    * @param resultHandler will be called with a {@link MongoClientUpdateResult} when complete
    */
   @Fluent
@@ -190,14 +192,13 @@ public interface MongoClient {
    */
   Future<@Nullable MongoClientUpdateResult> updateCollection(String collection, JsonObject query, JsonArray update);
 
-
   /**
    * Update matching documents in the specified collection, specifying options and return the handler with {@code MongoClientUpdateResult} result
    *
-   * @param collection  the collection
-   * @param query  query used to match the documents
-   * @param update used to describe how the documents will be updated
-   * @param options options to configure the update
+   * @param collection    the collection
+   * @param query         query used to match the documents
+   * @param update        used to describe how the documents will be updated
+   * @param options       options to configure the update
    * @param resultHandler will be called with a {@link MongoClientUpdateResult} when complete
    */
   @Fluent
@@ -212,10 +213,10 @@ public interface MongoClient {
   /**
    * Use an aggregation pipeline to update documents in the specified collection, specifying options and return the handler with {@code MongoClientUpdateResult} result
    *
-   * @param collection  the collection
-   * @param query  query used to match the documents
-   * @param update aggregation pipeline used to describe how documents will be updated
-   * @param options options to configure the update
+   * @param collection    the collection
+   * @param query         query used to match the documents
+   * @param update        aggregation pipeline used to describe how documents will be updated
+   * @param options       options to configure the update
    * @param resultHandler will be called with a {@link MongoClientUpdateResult} when complete
    */
   @Fluent
@@ -230,9 +231,9 @@ public interface MongoClient {
   /**
    * Replace matching documents in the specified collection and return the handler with {@code MongoClientUpdateResult} result
    *
-   * @param collection  the collection
-   * @param query  query used to match the documents
-   * @param replace  all matching documents will be replaced with this
+   * @param collection    the collection
+   * @param query         query used to match the documents
+   * @param replace       all matching documents will be replaced with this
    * @param resultHandler will be called with a {@link MongoClientUpdateResult} when complete
    */
   @Fluent
@@ -246,10 +247,10 @@ public interface MongoClient {
   /**
    * Replace matching documents in the specified collection, specifying options and return the handler with {@code MongoClientUpdateResult} result
    *
-   * @param collection  the collection
-   * @param query  query used to match the documents
-   * @param replace  all matching documents will be replaced with this
-   * @param options options to configure the replace
+   * @param collection    the collection
+   * @param query         query used to match the documents
+   * @param replace       all matching documents will be replaced with this
+   * @param options       options to configure the replace
    * @param resultHandler will be called with a {@link MongoClientUpdateResult} when complete
    */
   @Fluent
@@ -263,12 +264,9 @@ public interface MongoClient {
   /**
    * Execute a bulk operation. Can insert, update, replace, and/or delete multiple documents with one request.
    *
-   * @param collection
-   *          the collection
-   * @param operations
-   *          the operations to execute
-   * @param resultHandler
-   *          will be called with a {@link MongoClientBulkWriteResult} when complete
+   * @param collection    the collection
+   * @param operations    the operations to execute
+   * @param resultHandler will be called with a {@link MongoClientBulkWriteResult} when complete
    */
   @Fluent
   MongoClient bulkWrite(String collection, List<BulkOperation> operations,
@@ -283,14 +281,10 @@ public interface MongoClient {
    * Execute a bulk operation with the specified write options. Can insert, update, replace, and/or delete multiple
    * documents with one request.
    *
-   * @param collection
-   *          the collection
-   * @param operations
-   *          the operations to execute
-   * @param bulkWriteOptions
-   *          the write options
-   * @param resultHandler
-   *          will be called with a {@link MongoClientBulkWriteResult} when complete
+   * @param collection       the collection
+   * @param operations       the operations to execute
+   * @param bulkWriteOptions the write options
+   * @param resultHandler    will be called with a {@link MongoClientBulkWriteResult} when complete
    */
   @Fluent
   MongoClient bulkWriteWithOptions(String collection, List<BulkOperation> operations, BulkWriteOptions bulkWriteOptions,
@@ -304,9 +298,9 @@ public interface MongoClient {
   /**
    * Find matching documents in the specified collection
    *
-   * @param collection  the collection
-   * @param query  query used to match documents
-   * @param resultHandler  will be provided with list of documents
+   * @param collection    the collection
+   * @param query         query used to match documents
+   * @param resultHandler will be provided with list of documents
    */
   @Fluent
   MongoClient find(String collection, JsonObject query, Handler<AsyncResult<List<JsonObject>>> resultHandler);
@@ -320,8 +314,8 @@ public interface MongoClient {
    * Find matching documents in the specified collection.
    * This method use batchCursor for returning each found document.
    *
-   * @param collection  the collection
-   * @param query  query used to match documents
+   * @param collection the collection
+   * @param query      query used to match documents
    * @return a {@link ReadStream} emitting found documents
    */
   ReadStream<JsonObject> findBatch(String collection, JsonObject query);
@@ -329,10 +323,10 @@ public interface MongoClient {
   /**
    * Find matching documents in the specified collection, specifying options
    *
-   * @param collection  the collection
-   * @param query  query used to match documents
-   * @param options options to configure the find
-   * @param resultHandler  will be provided with list of documents
+   * @param collection    the collection
+   * @param query         query used to match documents
+   * @param options       options to configure the find
+   * @param resultHandler will be provided with list of documents
    */
   @Fluent
   MongoClient findWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<List<JsonObject>>> resultHandler);
@@ -346,9 +340,9 @@ public interface MongoClient {
    * Find matching documents in the specified collection, specifying options.
    * This method use batchCursor for returning each found document.
    *
-   * @param collection  the collection
-   * @param query  query used to match documents
-   * @param options options to configure the find
+   * @param collection the collection
+   * @param query      query used to match documents
+   * @param options    options to configure the find
    * @return a {@link ReadStream} emitting found documents
    */
   ReadStream<JsonObject> findBatchWithOptions(String collection, JsonObject query, FindOptions options);
@@ -358,9 +352,9 @@ public interface MongoClient {
    * <p>
    * This operation might change <i>_id</i> field of <i>query</i> parameter
    *
-   * @param collection  the collection
-   * @param query  the query used to match the document
-   * @param fields  the fields
+   * @param collection    the collection
+   * @param query         the query used to match the document
+   * @param fields        the fields
    * @param resultHandler will be provided with the document, if any
    */
   @Fluent
@@ -376,9 +370,9 @@ public interface MongoClient {
    * <p>
    * This operation might change <i>_id</i> field of <i>query</i> parameter
    *
-   * @param collection  the collection
-   * @param query  the query used to match the document
-   * @param update used to describe how the documents will be updated
+   * @param collection    the collection
+   * @param query         the query used to match the document
+   * @param update        used to describe how the documents will be updated
    * @param resultHandler will be provided with the document, if any
    */
   @Fluent
@@ -394,10 +388,10 @@ public interface MongoClient {
    * <p>
    * This operation might change <i>_id</i> field of <i>query</i> parameter
    *
-   * @param collection  the collection
-   * @param query  the query used to match the document
-   * @param update used to describe how the documents will be updated
-   * @param findOptions options to configure the find
+   * @param collection    the collection
+   * @param query         the query used to match the document
+   * @param update        used to describe how the documents will be updated
+   * @param findOptions   options to configure the find
    * @param updateOptions options to configure the update
    * @param resultHandler will be provided with the document, if any
    */
@@ -414,9 +408,9 @@ public interface MongoClient {
    * <p>
    * This operation might change <i>_id</i> field of <i>query</i> parameter
    *
-   * @param collection  the collection
-   * @param query  the query used to match the document
-   * @param replace  the replacement document
+   * @param collection    the collection
+   * @param query         the query used to match the document
+   * @param replace       the replacement document
    * @param resultHandler will be provided with the document, if any
    */
   @Fluent
@@ -432,10 +426,10 @@ public interface MongoClient {
    * <p>
    * This operation might change <i>_id</i> field of <i>query</i> parameter
    *
-   * @param collection  the collection
-   * @param query  the query used to match the document
-   * @param replace  the replacement document
-   * @param findOptions options to configure the find
+   * @param collection    the collection
+   * @param query         the query used to match the document
+   * @param replace       the replacement document
+   * @param findOptions   options to configure the find
    * @param updateOptions options to configure the update
    * @param resultHandler will be provided with the document, if any
    */
@@ -452,8 +446,8 @@ public interface MongoClient {
    * <p>
    * This operation might change <i>_id</i> field of <i>query</i> parameter
    *
-   * @param collection  the collection
-   * @param query  the query used to match the document
+   * @param collection    the collection
+   * @param query         the query used to match the document
    * @param resultHandler will be provided with the deleted document, if any
    */
   @Fluent
@@ -469,9 +463,9 @@ public interface MongoClient {
    * <p>
    * This operation might change <i>_id</i> field of <i>query</i> parameter
    *
-   * @param collection  the collection
-   * @param query  the query used to match the document
-   * @param findOptions options to configure the find
+   * @param collection    the collection
+   * @param query         the query used to match the document
+   * @param findOptions   options to configure the find
    * @param resultHandler will be provided with the deleted document, if any
    */
   @Fluent
@@ -485,8 +479,8 @@ public interface MongoClient {
   /**
    * Count matching documents in a collection.
    *
-   * @param collection  the collection
-   * @param query  query used to match documents
+   * @param collection    the collection
+   * @param query         query used to match documents
    * @param resultHandler will be provided with the number of matching documents
    */
   @Fluent
@@ -498,10 +492,26 @@ public interface MongoClient {
   Future<Long> count(String collection, JsonObject query);
 
   /**
+   * Count matching documents in a collection.
+   *
+   * @param collection    the collection
+   * @param query         query used to match documents
+   * @param countOptions
+   * @param resultHandler will be provided with the number of matching documents
+   */
+  @Fluent
+  MongoClient countWithOptions(String collection, JsonObject query, CountOptions countOptions, Handler<AsyncResult<Long>> resultHandler);
+
+  /**
+   * Like {@link #count(String, JsonObject, Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  Future<Long> countWithOptions(String collection, JsonObject query, CountOptions countOptions);
+
+  /**
    * Remove matching documents from a collection and return the handler with {@code MongoClientDeleteResult} result
    *
-   * @param collection  the collection
-   * @param query  query used to match documents
+   * @param collection    the collection
+   * @param query         query used to match documents
    * @param resultHandler will be called with a {@link MongoClientDeleteResult} when complete
    */
   @Fluent
@@ -515,9 +525,9 @@ public interface MongoClient {
   /**
    * Remove matching documents from a collection with the specified write option and return the handler with {@code MongoClientDeleteResult} result
    *
-   * @param collection  the collection
-   * @param query  query used to match documents
-   * @param writeOption  the write option to use
+   * @param collection    the collection
+   * @param query         query used to match documents
+   * @param writeOption   the write option to use
    * @param resultHandler will be called with a {@link MongoClientDeleteResult} when complete
    */
   @Fluent
@@ -531,8 +541,8 @@ public interface MongoClient {
   /**
    * Remove a single matching document from a collection and return the handler with {@code MongoClientDeleteResult} result
    *
-   * @param collection  the collection
-   * @param query  query used to match document
+   * @param collection    the collection
+   * @param query         query used to match document
    * @param resultHandler will be called with a {@link MongoClientDeleteResult} when complete
    */
   @Fluent
@@ -546,9 +556,9 @@ public interface MongoClient {
   /**
    * Remove a single matching document from a collection with the specified write option and return the handler with {@code MongoClientDeleteResult} result
    *
-   * @param collection  the collection
-   * @param query  query used to match document
-   * @param writeOption  the write option to use
+   * @param collection    the collection
+   * @param query         query used to match document
+   * @param writeOption   the write option to use
    * @param resultHandler will be called with a {@link MongoClientDeleteResult} when complete
    */
   @Fluent
@@ -562,11 +572,21 @@ public interface MongoClient {
   /**
    * Create a new collection
    *
-   * @param collectionName  the name of the collection
+   * @param collectionName the name of the collection
    * @param resultHandler  will be called when complete
    */
   @Fluent
   MongoClient createCollection(String collectionName, Handler<AsyncResult<Void>> resultHandler);
+
+  /**
+   * Create a new collection with options
+   *
+   * @param collectionName    the name of the collection
+   * @param collectionOptions options of the collection
+   * @param resultHandler     will be called when complete
+   */
+  @Fluent
+  MongoClient createCollectionWithOptions(String collectionName, CreateCollectionOptions collectionOptions, Handler<AsyncResult<Void>> resultHandler);
 
   /**
    * Like {@link #createCollection(String, Handler)} but returns a {@code Future} of the asynchronous result
@@ -574,9 +594,14 @@ public interface MongoClient {
   Future<Void> createCollection(String collectionName);
 
   /**
+   * Like {@link #createCollection(String, Handler)} but with options and returns a {@code Future} of the asynchronous result
+   */
+  Future<Void> createCollectionWithOptions(String collectionName, CreateCollectionOptions collectionOptions);
+
+  /**
    * Get a list of all collections in the database.
    *
-   * @param resultHandler  will be called with a list of collections.
+   * @param resultHandler will be called with a list of collections.
    */
   @Fluent
   MongoClient getCollections(Handler<AsyncResult<List<String>>> resultHandler);
@@ -589,7 +614,7 @@ public interface MongoClient {
   /**
    * Drop a collection
    *
-   * @param collection  the collection
+   * @param collection    the collection
    * @param resultHandler will be called when complete
    */
   @Fluent
@@ -603,10 +628,10 @@ public interface MongoClient {
   /**
    * Creates an index.
    *
-   * @param collection  the collection
-   * @param key  A document that contains the field and value pairs where the field is the index key and the value
-   *             describes the type of index for that field. For an ascending index on a field,
-   *             specify a value of 1; for descending index, specify a value of -1.
+   * @param collection    the collection
+   * @param key           A document that contains the field and value pairs where the field is the index key and the value
+   *                      describes the type of index for that field. For an ascending index on a field,
+   *                      specify a value of 1; for descending index, specify a value of -1.
    * @param resultHandler will be called when complete
    */
   @Fluent
@@ -620,11 +645,11 @@ public interface MongoClient {
   /**
    * Creates an index.
    *
-   * @param collection  the collection
-   * @param key  A document that contains the field and value pairs where the field is the index key and the value
-   *             describes the type of index for that field. For an ascending index on a field,
-   *             specify a value of 1; for descending index, specify a value of -1.
-   * @param options  the options for the index
+   * @param collection    the collection
+   * @param key           A document that contains the field and value pairs where the field is the index key and the value
+   *                      describes the type of index for that field. For an ascending index on a field,
+   *                      specify a value of 1; for descending index, specify a value of -1.
+   * @param options       the options for the index
    * @param resultHandler will be called when complete
    */
   @Fluent
@@ -637,10 +662,11 @@ public interface MongoClient {
 
   /**
    * creates an indexes
-   * @param collection the collection
-   * @param indexes A model that contains pairs of document and indexOptions, document contains the field and value pairs
-   *                where the field is the index key and the value describes the type of index for that field.
-   *                For an ascending index on a field, specify a value of 1; for descending index, specify a value of -1.
+   *
+   * @param collection    the collection
+   * @param indexes       A model that contains pairs of document and indexOptions, document contains the field and value pairs
+   *                      where the field is the index key and the value describes the type of index for that field.
+   *                      For an ascending index on a field, specify a value of 1; for descending index, specify a value of -1.
    * @param resultHandler will be called when complete
    */
   @Fluent
@@ -654,7 +680,7 @@ public interface MongoClient {
   /**
    * Get all the indexes in this collection.
    *
-   * @param collection  the collection
+   * @param collection    the collection
    * @param resultHandler will be called when complete
    */
   @Fluent
@@ -668,8 +694,8 @@ public interface MongoClient {
   /**
    * Drops the index given its name.
    *
-   * @param collection  the collection
-   * @param indexName the name of the index to remove
+   * @param collection    the collection
+   * @param indexName     the name of the index to remove
    * @param resultHandler will be called when complete
    */
   @Fluent
@@ -683,9 +709,9 @@ public interface MongoClient {
   /**
    * Run an arbitrary MongoDB command.
    *
-   * @param commandName  the name of the command
-   * @param command  the command
-   * @param resultHandler  will be called with the result.
+   * @param commandName   the name of the command
+   * @param command       the command
+   * @param resultHandler will be called with the result.
    */
   @Fluent
   MongoClient runCommand(String commandName, JsonObject command, Handler<AsyncResult<@Nullable JsonObject>> resultHandler);
@@ -699,12 +725,24 @@ public interface MongoClient {
    * Gets the distinct values of the specified field name.
    * Return a JsonArray containing distinct values (eg: [ 1 , 89 ])
    *
-   * @param collection  the collection
-   * @param fieldName  the field name
-   * @param resultHandler  will be provided with array of values.
+   * @param collection    the collection
+   * @param fieldName     the field name
+   * @param resultHandler will be provided with array of values.
    */
   @Fluent
   MongoClient distinct(String collection, String fieldName, String resultClassname, Handler<AsyncResult<JsonArray>> resultHandler);
+
+  /**
+   * Gets the distinct values of the specified field name.
+   * Return a JsonArray containing distinct values (eg: [ 1 , 89 ])
+   *
+   * @param collection      the collection
+   * @param fieldName       the field name
+   * @param resultHandler   will be provided with array of values.
+   * @param distinctOptions options (e.g. collation)
+   */
+  @Fluent
+  MongoClient distinct(String collection, String fieldName, String resultClassname, Handler<AsyncResult<JsonArray>> resultHandler, DistinctOptions distinctOptions);
 
   /**
    * Like {@link #distinct(String, String, String, Handler)} but returns a {@code Future} of the asynchronous result
@@ -712,16 +750,34 @@ public interface MongoClient {
   Future<JsonArray> distinct(String collection, String fieldName, String resultClassname);
 
   /**
+   * Like {@link #distinct(String, String, String, Handler, DistinctOptions)} but returns a {@code Future} of the asynchronous result
+   */
+  Future<JsonArray> distinct(String collection, String fieldName, String resultClassname, DistinctOptions distinctOptions);
+
+  /**
    * Gets the distinct values of the specified field name filtered by specified query.
    * Return a JsonArray containing distinct values (eg: [ 1 , 89 ])
    *
-   * @param collection  the collection
-   * @param fieldName  the field name
-   * @param query the query
-   * @param resultHandler  will be provided with array of values.
+   * @param collection    the collection
+   * @param fieldName     the field name
+   * @param query         the query
+   * @param resultHandler will be provided with array of values.
    */
   @Fluent
   MongoClient distinctWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonArray>> resultHandler);
+
+  /**
+   * Gets the distinct values of the specified field name filtered by specified query.
+   * Return a JsonArray containing distinct values (eg: [ 1 , 89 ])
+   *
+   * @param collection      the collection
+   * @param fieldName       the field name
+   * @param query           the query
+   * @param resultHandler   will be provided with array of values.
+   * @param distinctOptions options (e.g. collation)
+   */
+  @Fluent
+  MongoClient distinctWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonArray>> resultHandler, DistinctOptions distinctOptions);
 
   /**
    * Like {@link #distinctWithQuery(String, String, String, JsonObject, Handler)} but returns a {@code Future} of the asynchronous result
@@ -729,27 +785,57 @@ public interface MongoClient {
   Future<JsonArray> distinctWithQuery(String collection, String fieldName, String resultClassname, JsonObject query);
 
   /**
+   * Like {@link #distinctWithQuery(String, String, String, JsonObject, Handler, DistinctOptions)} but returns a {@code Future} of the asynchronous result
+   */
+  Future<JsonArray> distinctWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, DistinctOptions distinctOptions);
+
+  /**
    * Gets the distinct values of the specified field name.
    * This method use batchCursor for returning each found value.
    * Each value is a json fragment with fieldName key (eg: {"num": 1}).
    *
-   * @param collection  the collection
+   * @param collection the collection
    * @param fieldName  the field name
    * @return a {@link ReadStream} emitting json fragments
    */
   ReadStream<JsonObject> distinctBatch(String collection, String fieldName, String resultClassname);
 
   /**
+   * Gets the distinct values of the specified field name.
+   * This method use batchCursor for returning each found value.
+   * Each value is a json fragment with fieldName key (eg: {"num": 1}).
+   *
+   * @param collection      the collection
+   * @param fieldName       the field name
+   * @param distinctOptions options (e.g. collation)
+   * @return a {@link ReadStream} emitting json fragments
+   */
+  ReadStream<JsonObject> distinctBatch(String collection, String fieldName, String resultClassname, DistinctOptions distinctOptions);
+
+  /**
    * Gets the distinct values of the specified field name filtered by specified query.
    * This method use batchCursor for returning each found value.
    * Each value is a json fragment with fieldName key (eg: {"num": 1}).
    *
-   * @param collection  the collection
+   * @param collection the collection
    * @param fieldName  the field name
-   * @param query the query
+   * @param query      the query
    * @return a {@link ReadStream} emitting json fragments
    */
   ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query);
+
+  /**
+   * Gets the distinct values of the specified field name filtered by specified query.
+   * This method use batchCursor for returning each found value.
+   * Each value is a json fragment with fieldName key (eg: {"num": 1}).
+   *
+   * @param collection      the collection
+   * @param fieldName       the field name
+   * @param query           the query
+   * @param distinctOptions options (e.g. collation)
+   * @return a {@link ReadStream} emitting json fragments
+   */
+  ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, DistinctOptions distinctOptions);
 
   /**
    * Gets the distinct values of the specified field name filtered by specified query.
@@ -764,6 +850,19 @@ public interface MongoClient {
    */
   ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, int batchSize);
 
+  /**
+   * Gets the distinct values of the specified field name filtered by specified query.
+   * This method use batchCursor for returning each found value.
+   * Each value is a json fragment with fieldName key (eg: {"num": 1}).
+   *
+   * @param collection      the collection
+   * @param fieldName       the field name
+   * @param query           the query
+   * @param batchSize       the number of documents to load in a batch
+   * @param distinctOptions options (e.g. collation)
+   * @return a {@link ReadStream} emitting json fragments
+   */
+  ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, int batchSize, DistinctOptions distinctOptions);
 
   /**
    * Run aggregate MongoDB command with default {@link AggregateOptions}.
@@ -784,10 +883,11 @@ public interface MongoClient {
 
   /**
    * Watch the collection change.
-   * @param collection the collection
-   * @param pipeline   watching pipeline to be executed
+   *
+   * @param collection     the collection
+   * @param pipeline       watching pipeline to be executed
    * @param withUpdatedDoc whether to get updated fullDocument for "update" operation
-   * @param batchSize  the number of documents to load in a batch
+   * @param batchSize      the number of documents to load in a batch
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   ReadStream<ChangeStreamDocument<JsonObject>> watch(String collection, JsonArray pipeline, boolean withUpdatedDoc, int batchSize);
@@ -795,7 +895,7 @@ public interface MongoClient {
   /**
    * Creates a {@link MongoGridFsClient} used to interact with Mongo GridFS.
    *
-   * @param resultHandler  the {@link MongoGridFsClient} to interact with the bucket named bucketName
+   * @param resultHandler the {@link MongoGridFsClient} to interact with the bucket named bucketName
    */
   @Fluent
   MongoClient createDefaultGridFsBucketService(Handler<AsyncResult<MongoGridFsClient>> resultHandler);
@@ -808,8 +908,8 @@ public interface MongoClient {
   /**
    * Creates a {@link MongoGridFsClient} used to interact with Mongo GridFS.
    *
-   * @param bucketName  the name of the GridFS bucket
-   * @param resultHandler  the {@link MongoGridFsClient} to interact with the bucket named bucketName
+   * @param bucketName    the name of the GridFS bucket
+   * @param resultHandler the {@link MongoGridFsClient} to interact with the bucket named bucketName
    */
   @Fluent
   MongoClient createGridFsBucketService(String bucketName, Handler<AsyncResult<MongoGridFsClient>> resultHandler);

--- a/src/main/java/io/vertx/ext/mongo/UpdateOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/UpdateOptions.java
@@ -32,6 +32,7 @@ public class UpdateOptions {
   private boolean multi;
   private boolean returnNewDocument; // uniquely valid on findOneAnd* methods
   private JsonArray arrayFilters;
+  private CollationOptions collation;
 
   /**
    * Default constructor
@@ -44,7 +45,8 @@ public class UpdateOptions {
 
   /**
    * Constructor specify upsert
-   * @param upsert  the value of upsert
+   *
+   * @param upsert the value of upsert
    */
   public UpdateOptions(boolean upsert) {
     this.upsert = upsert;
@@ -54,7 +56,8 @@ public class UpdateOptions {
 
   /**
    * Constructor specify upsert and multi
-   * @param upsert  the value of upsert
+   *
+   * @param upsert the value of upsert
    * @param multi  the value of multi
    */
   public UpdateOptions(boolean upsert, boolean multi) {
@@ -64,7 +67,8 @@ public class UpdateOptions {
 
   /**
    * Copy constructor
-   * @param other  the one to copy
+   *
+   * @param other the one to copy
    */
   public UpdateOptions(UpdateOptions other) {
     this.writeOption = other.writeOption;
@@ -72,12 +76,13 @@ public class UpdateOptions {
     this.multi = other.multi;
     this.returnNewDocument = other.returnNewDocument;
     this.arrayFilters = other.arrayFilters;
+    this.collation = other.collation;
   }
 
   /**
    * Constructor from JSON
    *
-   * @param json  the json
+   * @param json the json
    */
   public UpdateOptions(JsonObject json) {
     String wo = json.getString("writeOption");
@@ -88,6 +93,22 @@ public class UpdateOptions {
     multi = json.getBoolean("multi", DEFAULT_MULTI);
     returnNewDocument = json.getBoolean("return_new_document", DEFAULT_RETURN_NEW_DOCUMENT);
     arrayFilters = json.getJsonArray("arrayFilters", null);
+    if (json.getJsonObject("collation") != null) {
+      collation = new CollationOptions(json.getJsonObject("collation"));
+    }
+  }
+  
+  public CollationOptions getCollation() {
+    return collation;
+  }
+
+  /**
+   * Collation options
+   *
+   * @param collation
+   */
+  public void setCollation(CollationOptions collation) {
+    this.collation = collation;
   }
 
   /**
@@ -101,7 +122,8 @@ public class UpdateOptions {
 
   /**
    * Set the write option
-   * @param writeOption  the write option
+   *
+   * @param writeOption the write option
    * @return reference to this, for fluency
    */
   public UpdateOptions setWriteOption(WriteOption writeOption) {
@@ -121,7 +143,7 @@ public class UpdateOptions {
   /**
    * Set whether upsert is enabled
    *
-   * @param upsert  true if enabled
+   * @param upsert true if enabled
    * @return reference to this, for fluency
    */
   public UpdateOptions setUpsert(boolean upsert) {
@@ -141,8 +163,7 @@ public class UpdateOptions {
   /**
    * Set whether new document property is enabled. Valid only on findOneAnd* methods.
    *
-   * @param returnNewDocument  true if enabled
-   *
+   * @param returnNewDocument true if enabled
    * @return reference to this, for fluency
    */
   public UpdateOptions setReturningNewDocument(boolean returnNewDocument) {
@@ -162,7 +183,7 @@ public class UpdateOptions {
   /**
    * Set whether multi is enabled
    *
-   * @param multi  true if enabled
+   * @param multi true if enabled
    * @return reference to this, for fluency
    */
   public UpdateOptions setMulti(boolean multi) {
@@ -181,7 +202,8 @@ public class UpdateOptions {
 
   /**
    * Set the arrayFilters option
-   * @param arrayFilters  the arrayFilters option
+   *
+   * @param arrayFilters the arrayFilters option
    * @return reference to this, for fluency
    */
   public UpdateOptions setArrayFilters(JsonArray arrayFilters) {
@@ -222,6 +244,7 @@ public class UpdateOptions {
     if (writeOption != options.writeOption) return false;
     if (returnNewDocument != options.returnNewDocument) return false;
     if (arrayFilters != options.arrayFilters) return false;
+    if (collation != options.collation) return false;
 
     return true;
   }
@@ -233,6 +256,7 @@ public class UpdateOptions {
     result = 31 * result + (multi ? 1 : 0);
     result = 31 * result + (returnNewDocument ? 1 : 0);
     result = 31 * result + (arrayFilters != null ? arrayFilters.hashCode() : 0);
+    result = 31 * result + (collation != null ? collation.hashCode() : 0);
     return result;
   }
 }

--- a/src/main/java/io/vertx/ext/mongo/ValidationOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/ValidationOptions.java
@@ -1,0 +1,113 @@
+package io.vertx.ext.mongo;
+
+import com.mongodb.client.model.ValidationAction;
+import com.mongodb.client.model.ValidationLevel;
+import com.mongodb.lang.Nullable;
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Objects;
+
+@DataObject(generateConverter = true)
+public final class ValidationOptions {
+  private JsonObject validator = new JsonObject();
+  private ValidationLevel validationLevel;
+  private ValidationAction validationAction;
+
+  public ValidationOptions() {
+    validator = new JsonObject();
+    validationLevel = ValidationLevel.STRICT;
+    validationAction = ValidationAction.ERROR;
+  }
+
+  public ValidationOptions(ValidationOptions validationOptions) {
+    validator = validationOptions.getValidator();
+    validationLevel = validationOptions.getValidationLevel();
+    validationAction = validationOptions.getValidationAction();
+  }
+
+  public ValidationOptions(JsonObject json) {
+    ValidationOptionsConverter.fromJson(json, this);
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    ValidationOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  /**
+   * Returns the mongo-java-driver specific object.
+   * @return com.mongodb.client.model.ValidationOptions
+   */
+  public com.mongodb.client.model.ValidationOptions toMongoDriverObject() {
+    return new com.mongodb.client.model.ValidationOptions()
+      .validator(org.bson.BsonDocument.parse(validator.encode()))
+      .validationAction(validationAction)
+      .validationLevel(validationLevel);
+  }
+
+  @Nullable
+  public JsonObject getValidator() {
+    return this.validator;
+  }
+
+  /**
+   * Optional. Allows users to specify validation rules or expressions for the collection.
+   * For more information, see <a href="https://docs.mongodb.com/v4.4/core/schema-validation/">Schema Validation</a>.
+   * @param validator
+   * @return ValidationOptions
+   */
+  public ValidationOptions setValidator(@Nullable JsonObject validator) {
+    this.validator = validator;
+    return this;
+  }
+
+  @Nullable
+  public ValidationLevel getValidationLevel() {
+    return this.validationLevel;
+  }
+
+  /**
+   * Optional. Determines how strictly MongoDB applies the validation rules to existing documents during an update.
+   * @param validationLevel
+   * @return ValidationOptions
+   */
+  public ValidationOptions setValidationLevel(@Nullable ValidationLevel validationLevel) {
+    this.validationLevel = validationLevel;
+    return this;
+  }
+
+  @Nullable
+  public ValidationAction getValidationAction() {
+    return this.validationAction;
+  }
+
+  /**
+   * Optional. Determines whether to error on invalid documents or
+   *           just warn about the violations but allow invalid documents to be inserted.
+   * @param validationAction
+   * @return ValidationOptions
+   */
+  public ValidationOptions setValidationAction(@Nullable ValidationAction validationAction) {
+    this.validationAction = validationAction;
+    return this;
+  }
+
+  public String toString() {
+    return "ValidationOptions{validator=" + this.validator + ", validationLevel=" + this.validationLevel + ", validationAction=" + this.validationAction + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ValidationOptions that = (ValidationOptions) o;
+    return Objects.equals(getValidator(), that.getValidator()) && getValidationLevel() == that.getValidationLevel() && getValidationAction() == that.getValidationAction();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getValidator(), getValidationLevel(), getValidationAction());
+  }
+}

--- a/src/test/java/io/vertx/ext/mongo/AggregateOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/AggregateOptionsTest.java
@@ -4,7 +4,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.TestUtils;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
@@ -44,20 +44,24 @@ public class AggregateOptionsTest {
     AggregateOptions options = new AggregateOptions(new JsonObject());
     AggregateOptions def = new AggregateOptions();
     assertEquals(def.getMaxTime(), options.getMaxTime());
+    assertNull(options.getCollationOptions());
   }
 
   @Test
   public void testCopyOptions() {
-    AggregateOptions options = new AggregateOptions();
+    CollationOptions collationOptions = new CollationOptions();
+    AggregateOptions options = new AggregateOptions().setCollationOptions(collationOptions);
     options.setMaxTime(TestUtils.randomLong());
 
     AggregateOptions copy = new AggregateOptions(options);
     assertEquals(options.getMaxTime(), copy.getMaxTime());
+    assertEquals(options.getCollationOptions(), copy.getCollationOptions());
   }
 
   @Test
   public void testToJson() {
-    AggregateOptions options = new AggregateOptions();
+    CollationOptions collationOptions = new CollationOptions();
+    AggregateOptions options = new AggregateOptions().setCollationOptions(collationOptions);
     long maxTime = TestUtils.randomPositiveLong();
     options.setMaxTime(maxTime);
 

--- a/src/test/java/io/vertx/ext/mongo/CollationOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/CollationOptionsTest.java
@@ -1,0 +1,111 @@
+package io.vertx.ext.mongo;
+
+import org.junit.Test;
+
+import java.util.Locale;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class CollationOptionsTest {
+
+  private static final String DEFAULT_LOCALE = Locale.getDefault().toString();
+
+  private static void assertNotEqual(BiConsumer<CollationOptions, CollationOptions> f) {
+    CollationOptions a = new CollationOptions();
+    CollationOptions b = new CollationOptions();
+    f.accept(a, b);
+    assertNotEquals(a, b);
+  }
+
+  private static void assertNotEqual(int expected, Consumer<CollationOptions> f) {
+    CollationOptions o = new CollationOptions();
+    f.accept(o);
+    assertNotEquals(expected, o.hashCode());
+  }
+
+  @Test
+  public void testEquals() {
+    assertEquals(new CollationOptions(), new CollationOptions());
+
+    assertNotEqual((a, b) -> {
+      a.alternate(Alternate.NON_IGNORABLE);
+      b.alternate(Alternate.SHIFTED);
+    });
+    assertNotEqual((a, b) -> {
+      a.setBackwards(true);
+      b.setBackwards(false);
+    });
+    assertNotEqual((a, b) -> {
+      a.setCaseFirst(CaseFirst.off);
+      b.setCaseFirst(CaseFirst.lower);
+    });
+    assertNotEqual((a, b) -> {
+      a.setCaseFirst(CaseFirst.off);
+      b.setCaseFirst(CaseFirst.upper);
+    });
+    assertNotEqual((a, b) -> {
+      a.setCaseFirst(CaseFirst.lower);
+      b.setCaseFirst(CaseFirst.upper);
+    });
+    assertNotEqual((a, b) -> {
+      a.setLocale("en_US");
+      b.setLocale("de_AT");
+    });
+    assertNotEqual((a, b) -> {
+      a.setCaseLevel(true);
+      b.setCaseLevel(false);
+    });
+    assertNotEqual((a, b) -> {
+      a.setMaxVariable(MaxVariable.punct);
+      b.setMaxVariable(MaxVariable.space);
+    });
+    assertNotEqual((a, b) -> {
+      a.setNormalization(true);
+      b.setNormalization(false);
+    });
+    assertNotEqual((a, b) -> {
+      a.setNumericOrdering(true);
+      b.setNumericOrdering(false);
+    });
+    assertNotEqual((a, b) -> {
+      a.setStrength(1);
+      b.setStrength(2);
+    });
+
+    assertNotEquals(new CollationOptions(), null);
+  }
+
+  @Test
+  public void testHashCode() {
+    CollationOptions a = new CollationOptions();
+    int hash = a.hashCode();
+
+    assertEquals(hash, new CollationOptions().hashCode());
+
+    assertNotEqual(hash, o -> o.setStrength(1));
+    assertNotEqual(hash, o -> o.setNormalization(true));
+    assertNotEqual(hash, o -> o.setNumericOrdering(true));
+    assertNotEqual(hash, o -> o.setMaxVariable(MaxVariable.space));
+    assertNotEqual(hash, o -> o.setLocale("de_AT"));
+    assertNotEqual(hash, o -> o.setCaseLevel(true));
+    assertNotEqual(hash, o -> o.setCaseFirst(CaseFirst.upper));
+    assertNotEqual(hash, o -> o.setCaseFirst(CaseFirst.lower));
+    assertNotEqual(hash, o -> o.alternate(Alternate.SHIFTED));
+    assertNotEqual(hash, o -> o.setBackwards(true));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidStrengthLevelLessThan1() {
+    CollationOptions collationOptions = new CollationOptions();
+    collationOptions.setStrength(0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidStrengthLevelGreaterThan5() {
+    CollationOptions collationOptions = new CollationOptions();
+    collationOptions.setStrength(6);
+  }
+}

--- a/src/test/java/io/vertx/ext/mongo/CountOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/CountOptionsTest.java
@@ -1,0 +1,78 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class CountOptionsTest {
+
+  private static void assertNotEqual(BiConsumer<CountOptions, CountOptions> f) {
+    CountOptions a = new CountOptions();
+    CountOptions b = new CountOptions();
+    f.accept(a, b);
+    assertNotEquals(a, b);
+  }
+
+  private static void assertNotEqual(int expected, Consumer<CountOptions> f) {
+    CountOptions o = new CountOptions();
+    f.accept(o);
+    assertNotEquals(expected, o.hashCode());
+  }
+
+  @Test
+  public void testEquals() {
+    assertEquals(new CountOptions(), new CountOptions());
+
+    assertNotEqual((a, b) -> {
+      a.setCollation(new CollationOptions().setLocale("de_AT"));
+      b.setCollation(new CollationOptions().setLocale("de_DE"));
+    });
+    assertNotEqual((a, b) -> {
+      a.setHint(new JsonObject("{ \"$natural\" : 1 }"));
+      b.setHint(new JsonObject("{ \"$natural\" : -1 }"));
+    });
+    assertNotEqual((a, b) -> {
+      a.setHintString("x");
+      b.setHintString("y");
+    });
+    assertNotEqual((a, b) -> {
+      a.setLimit(10);
+      b.setLimit(20);
+    });
+    assertNotEqual((a, b) -> {
+      a.setSkip(1);
+      b.setSkip(2);
+    });
+    assertNotEqual((a, b) -> {
+      a.setMaxTime(10, TimeUnit.SECONDS);
+      a.setMaxTime(10, TimeUnit.MINUTES);
+    });
+    assertNotEqual((a, b) -> {
+      a.setMaxTime(10, TimeUnit.SECONDS);
+      a.setMaxTime(20, TimeUnit.SECONDS);
+    });
+
+    assertNotEquals(new CountOptions(), null);
+  }
+
+  @Test
+  public void testHashCode() {
+    CountOptions a = new CountOptions();
+    int hash = a.hashCode();
+
+    assertEquals(hash, new CountOptions().hashCode());
+
+    assertNotEqual(hash, o -> o.setCollation(new CollationOptions()));
+    assertNotEqual(hash, o -> o.setHint(new JsonObject("{ \"$natural\" : 1 }")));
+    assertNotEqual(hash, o -> o.setHintString("x"));
+    assertNotEqual(hash, o -> o.setLimit(10));
+    assertNotEqual(hash, o -> o.setSkip(2));
+    assertNotEqual(hash, o -> o.setMaxTime(10, TimeUnit.SECONDS));
+  }
+}

--- a/src/test/java/io/vertx/ext/mongo/CreateCollectionOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/CreateCollectionOptionsTest.java
@@ -1,0 +1,81 @@
+package io.vertx.ext.mongo;
+
+import com.mongodb.client.model.ValidationAction;
+import com.mongodb.client.model.ValidationLevel;
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class CreateCollectionOptionsTest {
+
+
+  private static void assertNotEqual(BiConsumer<CreateCollectionOptions, CreateCollectionOptions> f) {
+    CreateCollectionOptions a = new CreateCollectionOptions();
+    CreateCollectionOptions b = new CreateCollectionOptions();
+    f.accept(a, b);
+    assertNotEquals(a, b);
+  }
+
+  private static void assertNotEqual(int expected, Consumer<CreateCollectionOptions> f) {
+    CreateCollectionOptions o = new CreateCollectionOptions();
+    f.accept(o);
+    assertNotEquals(expected, o.hashCode());
+  }
+
+  @Test
+  public void testEquals() {
+    assertEquals(new CreateCollectionOptions(), new CreateCollectionOptions());
+
+    assertNotEqual((a, b) -> {
+      a.setCapped(true);
+      b.setCapped(false);
+    });
+    assertNotEqual((a, b) -> {
+      a.setCollation(new CollationOptions().setLocale("de_AT"));
+      b.setCollation(new CollationOptions().setLocale("en_US"));
+    });
+    assertNotEqual((a, b) -> {
+      a.setIndexOptionDefaults(new JsonObject().put("some", "option"));
+      b.setIndexOptionDefaults(new JsonObject());
+    });
+    assertNotEqual((a, b) -> {
+      a.setValidationOptions(new ValidationOptions().setValidationAction(ValidationAction.WARN));
+      b.setValidationOptions(new ValidationOptions().setValidationAction(ValidationAction.ERROR));
+    });
+    assertNotEqual((a, b) -> {
+      a.setMaxDocuments(12345);
+      b.setMaxDocuments(10);
+    });
+    assertNotEqual((a, b) -> {
+      a.setSizeInBytes(1024);
+      b.setSizeInBytes(2048);
+    });
+    assertNotEqual((a, b) -> {
+      a.setStorageEngineOptions(new JsonObject().put("some", "option"));
+      b.setStorageEngineOptions(new JsonObject());
+    });
+
+    assertNotEquals(new CreateCollectionOptions(), null);
+  }
+
+  @Test
+  public void testHashCode() {
+    CreateCollectionOptions a = new CreateCollectionOptions();
+    int hash = a.hashCode();
+
+    assertEquals(hash, new CreateCollectionOptions().hashCode());
+
+    assertNotEqual(hash, o -> o.setMaxDocuments(12345));
+    assertNotEqual(hash, o -> o.setSizeInBytes(4096));
+    assertNotEqual(hash, o -> o.setCapped(true));
+    assertNotEqual(hash, o -> o.setValidationOptions(new ValidationOptions().setValidationLevel(ValidationLevel.MODERATE)));
+    assertNotEqual(hash, o -> o.setIndexOptionDefaults(new JsonObject().put("some", "option")));
+    assertNotEqual(hash, o -> o.setCollation(new CollationOptions().setLocale("de_AT").setStrength(5)));
+    assertNotEqual(hash, o -> o.setStorageEngineOptions(new JsonObject().put("some", "option")));
+  }
+}

--- a/src/test/java/io/vertx/ext/mongo/FindOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/FindOptionsTest.java
@@ -4,12 +4,23 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.TestUtils;
 import org.junit.Test;
 
+import java.util.Locale;
+
 import static org.junit.Assert.*;
 
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
 public class FindOptionsTest {
+  private static JsonObject randomJsonObject() {
+    JsonObject json = new JsonObject();
+    json.put("string", TestUtils.randomAlphaString(10));
+    json.put("int", TestUtils.randomInt());
+    json.put("boolean", TestUtils.randomBoolean());
+
+    return json;
+  }
+
   @Test
   public void testOptions() {
     FindOptions options = new FindOptions();
@@ -29,6 +40,10 @@ public class FindOptionsTest {
     int skip = TestUtils.randomInt();
     assertEquals(options, options.setSkip(skip));
     assertEquals(skip, options.getSkip());
+
+    CollationOptions collationOptions = new CollationOptions();
+    assertEquals(options, options.setCollation(collationOptions));
+    assertEquals(collationOptions, options.getCollation());
   }
 
   @Test
@@ -40,6 +55,7 @@ public class FindOptionsTest {
     assertTrue(options.getSort().isEmpty());
     assertEquals(FindOptions.DEFAULT_LIMIT, options.getLimit());
     assertEquals(FindOptions.DEFAULT_SKIP, options.getSkip());
+    assertNull(options.getCollation());
   }
 
   @Test
@@ -58,11 +74,24 @@ public class FindOptionsTest {
     int skip = TestUtils.randomInt();
     json.put("skip", skip);
 
+    JsonObject collationOptions = new JsonObject()
+      .put("locale", Locale.getDefault().toString())
+      .put("caseLevel", true)
+      .put("caseFirst", "lower")
+      .put("alternate", "non-ignorable") // this
+      .put("strength", 1)
+      .put("numericOrdering", true)
+      .put("maxVariable", "punct")
+      .put("backwards", false)
+      .put("normalization", true);
+    json.put("collation", collationOptions);
+
     FindOptions options = new FindOptions(json);
     assertEquals(fields, options.getFields());
     assertEquals(sort, options.getSort());
     assertEquals(limit, options.getLimit());
     assertEquals(skip, options.getSkip());
+    assertEquals(collationOptions, options.getCollation().toJson());
   }
 
   @Test
@@ -73,6 +102,7 @@ public class FindOptionsTest {
     assertEquals(def.getSort(), options.getSort());
     assertEquals(def.getLimit(), options.getLimit());
     assertEquals(def.getSkip(), options.getSkip());
+    assertEquals(def.getCollation(), options.getCollation());
   }
 
   @Test
@@ -82,25 +112,19 @@ public class FindOptionsTest {
     JsonObject sort = randomJsonObject();
     int limit = TestUtils.randomInt();
     int skip = TestUtils.randomInt();
+    CollationOptions collationOptions = new CollationOptions().setStrength(1);
     options.setFields(fields);
     options.setSort(sort);
     options.setLimit(limit);
     options.setSkip(skip);
+    options.setCollation(collationOptions);
 
     FindOptions copy = new FindOptions(options);
     assertEquals(options.getFields(), copy.getFields());
     assertEquals(options.getSort(), copy.getSort());
     assertEquals(options.getLimit(), copy.getLimit());
     assertEquals(options.getSkip(), copy.getSkip());
-  }
-
-  private static JsonObject randomJsonObject() {
-    JsonObject json = new JsonObject();
-    json.put("string", TestUtils.randomAlphaString(10));
-    json.put("int", TestUtils.randomInt());
-    json.put("boolean", TestUtils.randomBoolean());
-
-    return json;
+    assertEquals(options.getCollation(), copy.getCollation());
   }
 
   @Test
@@ -110,10 +134,12 @@ public class FindOptionsTest {
     JsonObject sort = randomJsonObject();
     int limit = TestUtils.randomPositiveInt();
     int skip = TestUtils.randomPositiveInt();
+    CollationOptions collationOptions = new CollationOptions().setStrength(1);
     options.setFields(fields);
     options.setSort(sort);
     options.setLimit(limit);
     options.setSkip(skip);
+    options.setCollation(collationOptions);
 
     assertEquals(options, new FindOptions(options.toJson()));
   }

--- a/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
@@ -1,27 +1,5 @@
 package io.vertx.ext.mongo;
 
-import static io.vertx.ext.mongo.WriteOption.ACKNOWLEDGED;
-import static io.vertx.ext.mongo.WriteOption.UNACKNOWLEDGED;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
-import org.bson.types.ObjectId;
-import org.junit.Test;
-
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
@@ -30,6 +8,18 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.impl.codec.json.JsonObjectCodec;
 import io.vertx.test.core.TestUtils;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+
+import java.io.*;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static io.vertx.ext.mongo.WriteOption.ACKNOWLEDGED;
+import static io.vertx.ext.mongo.WriteOption.UNACKNOWLEDGED;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -105,7 +95,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
         mongoClient.listIndexes(collection, onSuccess(res3 -> {
           long cnt = res3.stream()
             .filter(o -> ((JsonObject) o).getJsonObject("key").containsKey("field") ||
-              ((JsonObject) o).getJsonObject("key").containsKey("field1") )
+              ((JsonObject) o).getJsonObject("key").containsKey("field1"))
             .count();
           assertEquals(2, cnt);
           testComplete();
@@ -123,9 +113,33 @@ public abstract class MongoClientTestBase extends MongoTestBase {
       mongoClient.createIndex(collection, key, onSuccess(res2 -> {
         mongoClient.listIndexes(collection, onSuccess(res3 -> {
           long cnt = res3.stream()
-                  .filter(o -> ((JsonObject) o).getJsonObject("key").containsKey("field"))
-                  .count();
-          assertEquals(cnt, 1);
+            .filter(o -> ((JsonObject) o).getJsonObject("key").containsKey("field"))
+            .count();
+          assertEquals(1, cnt);
+          testComplete();
+        }));
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  public void testCreateIndexWithCollation() {
+    String collection = randomCollection();
+    mongoClient.createCollection(collection, onSuccess(res -> {
+      JsonObject key = new JsonObject().put("field", 1);
+      IndexOptions options = new IndexOptions()
+        .setCollation(new CollationOptions());
+      System.out.println(options.toJson().toString());
+      mongoClient.createIndexWithOptions(collection, key, options, onSuccess(res2 -> {
+        mongoClient.listIndexes(collection, onSuccess(res3 -> {
+          System.out.println(res3.encodePrettily());
+          long keyCount = res3.stream()
+            .filter(o -> ((JsonObject) o).getJsonObject("key").containsKey("field"))
+            .count();
+          assertEquals(1, keyCount);
+          long collationCount = res3.stream().filter(o -> ((JsonObject) o).containsKey("collation")).count();
+          assertEquals(1, collationCount);
           testComplete();
         }));
       }));
@@ -142,8 +156,8 @@ public abstract class MongoClientTestBase extends MongoTestBase {
         mongoClient.dropIndex(collection, "field_1", onSuccess(res3 -> {
           mongoClient.listIndexes(collection, onSuccess(res4 -> {
             long cnt = res4.stream()
-                    .filter(o -> ((JsonObject) o).getJsonObject("key").containsKey("field"))
-                    .count();
+              .filter(o -> ((JsonObject) o).getJsonObject("key").containsKey("field"))
+              .count();
             assertEquals(cnt, 0);
             testComplete();
           }));
@@ -155,7 +169,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
 
   @Test
   public void testRunCommand() throws Exception {
-    JsonObject command  = new JsonObject().put("isMaster", 1);
+    JsonObject command = new JsonObject().put("isMaster", 1);
     mongoClient.runCommand("isMaster", command, onSuccess(reply -> {
       assertTrue(reply.getBoolean("ismaster"));
       testComplete();
@@ -182,7 +196,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
 
   @Test
   public void testRunInvalidCommand() throws Exception {
-    JsonObject command  = new JsonObject().put("iuhioqwdqhwd", 1);
+    JsonObject command = new JsonObject().put("iuhioqwdqhwd", 1);
     mongoClient.runCommand("iuhioqwdqhwd", command, onFailure(ex -> {
       testComplete();
     }));
@@ -208,12 +222,12 @@ public abstract class MongoClientTestBase extends MongoTestBase {
 
   public void assertDocumentWithIdIsPresent(String collection, Object id) {
     mongoClient.find(collection,
-            new JsonObject()
-                    .put("_id", id),
-            onSuccess(result -> {
-              assertEquals(1, result.size());
-              testComplete();
-            }));
+      new JsonObject()
+        .put("_id", id),
+      onSuccess(result -> {
+        assertEquals(1, result.size());
+        testComplete();
+      }));
   }
 
   @Test
@@ -327,7 +341,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     String collection = randomCollection();
     mongoClient.createCollection(collection, onSuccess(res -> {
       JsonObject doc = createDoc();
-      JsonObject genID  = new JsonObject().put("id", TestUtils.randomAlphaString(100));
+      JsonObject genID = new JsonObject().put("id", TestUtils.randomAlphaString(100));
       doc.put("_id", genID);
       mongoClient.saveWithOptions(collection, doc, ACKNOWLEDGED, onSuccess(id -> {
         assertNull(id);
@@ -594,15 +608,15 @@ public abstract class MongoClientTestBase extends MongoTestBase {
       mongoClient.insert(collection, doc, onSuccess(id -> {
         assertNotNull(id);
         mongoClient.findOneAndUpdateWithOptions(collection,
-                new JsonObject().put("num", 123),
-                new JsonObject().put("$inc", new JsonObject().put("num", 7)),
-                new FindOptions().setFields(new JsonObject().put("num", 1)),
-                new UpdateOptions().setReturningNewDocument(true),
-                onSuccess(obj -> {
-                  assertEquals(130, (long) obj.getLong("num", -1L));
-                  assertFalse(obj.containsKey("foo"));
-                  testComplete();
-                }));
+          new JsonObject().put("num", 123),
+          new JsonObject().put("$inc", new JsonObject().put("num", 7)),
+          new FindOptions().setFields(new JsonObject().put("num", 1)),
+          new UpdateOptions().setReturningNewDocument(true),
+          onSuccess(obj -> {
+            assertEquals(130, (long) obj.getLong("num", -1L));
+            assertFalse(obj.containsKey("foo"));
+            testComplete();
+          }));
       }));
     }));
     await();
@@ -634,15 +648,15 @@ public abstract class MongoClientTestBase extends MongoTestBase {
         assertNotNull(id);
         doc.remove("_id");
         mongoClient.findOneAndReplaceWithOptions(collection,
-                new JsonObject().put("num", 123),
-                doc.put("num", 130),
-                new FindOptions().setFields(new JsonObject().put("num", 1)),
-                new UpdateOptions().setReturningNewDocument(true),
-                onSuccess(obj -> {
-                  assertEquals(130, (long) obj.getLong("num", -1L));
-                  assertFalse(obj.containsKey("foo"));
-                  testComplete();
-                }));
+          new JsonObject().put("num", 123),
+          doc.put("num", 130),
+          new FindOptions().setFields(new JsonObject().put("num", 1)),
+          new UpdateOptions().setReturningNewDocument(true),
+          onSuccess(obj -> {
+            assertEquals(130, (long) obj.getLong("num", -1L));
+            assertFalse(obj.containsKey("foo"));
+            testComplete();
+          }));
       }));
     }));
     await();
@@ -670,6 +684,27 @@ public abstract class MongoClientTestBase extends MongoTestBase {
   }
 
   @Test
+  public void testFindOneWithOptionsAndCollation() throws Exception {
+    String collection = randomCollection();
+    mongoClient.createCollection(collection, onSuccess(res -> {
+      JsonObject doc1 = createDoc();
+      JsonObject doc2 = createDoc().put("foo", "bär");
+      mongoClient.insert(collection, doc1, onSuccess(id1 -> {
+        assertNotNull(id1);
+        mongoClient.insert(collection, doc2, onSuccess(id2 -> {
+          assertNotNull(id2);
+          mongoClient.countWithOptions(collection, new JsonObject().put("foo", "bar"), new CountOptions().setCollation(new CollationOptions().setLocale("de_AT").setStrength(3)), onSuccess(count -> {
+            assertNotNull(count);
+            assertEquals(1, count.intValue());
+            testComplete();
+          }));
+        }));
+      }));
+    }));
+    await();
+  }
+
+  @Test
   public void testFindOneAndDeleteWithOptions() throws Exception {
     String collection = randomCollection();
     mongoClient.createCollection(collection, onSuccess(res -> {
@@ -677,18 +712,18 @@ public abstract class MongoClientTestBase extends MongoTestBase {
       mongoClient.insert(collection, doc, onSuccess(id -> {
         assertNotNull(id);
         mongoClient.findOneAndDeleteWithOptions(collection,
-                new JsonObject().put("num", 123),
-                new FindOptions().setFields(new JsonObject().put("num", 1)),
-                onSuccess(obj -> {
-                  assertEquals(123, (long) obj.getLong("num", -1L));
-                  assertFalse(obj.containsKey("foo"));
+          new JsonObject().put("num", 123),
+          new FindOptions().setFields(new JsonObject().put("num", 1)),
+          onSuccess(obj -> {
+            assertEquals(123, (long) obj.getLong("num", -1L));
+            assertFalse(obj.containsKey("foo"));
 
-                  mongoClient.count(collection, new JsonObject(), onSuccess(count -> {
-                    assertNotNull(count);
-                    assertEquals(0, count.intValue());
-                    testComplete();
-                  }));
-                }));
+            mongoClient.count(collection, new JsonObject(), onSuccess(count -> {
+              assertNotNull(count);
+              assertEquals(0, count.intValue());
+              testComplete();
+            }));
+          }));
       }));
     }));
     await();
@@ -966,7 +1001,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
         new UpdateOptions().setWriteOption(UNACKNOWLEDGED), onSuccess(v -> {
           assertNull(v);
           testComplete();
-      }));
+        }));
     }));
 
     await();
@@ -1027,7 +1062,8 @@ public abstract class MongoClientTestBase extends MongoTestBase {
       JsonObject replacement = createDoc();
       replacement.put("replacement", true);
       mongoClient.replaceDocumentsWithOptions(collection, new JsonObject().put("_id", upsertTestId), replacement, new UpdateOptions(true), onSuccess(v -> {
-        mongoClient.find(collection, new JsonObject(), onSuccess(list -> {assertEquals(upsertTestId, v.getDocUpsertedId().getString(MongoClientUpdateResult.ID_FIELD));
+        mongoClient.find(collection, new JsonObject(), onSuccess(list -> {
+          assertEquals(upsertTestId, v.getDocUpsertedId().getString(MongoClientUpdateResult.ID_FIELD));
           assertEquals(0, v.getDocMatched());
           assertEquals(0, v.getDocModified());
 
@@ -1103,12 +1139,13 @@ public abstract class MongoClientTestBase extends MongoTestBase {
 
     await();
   }
+
   //TODO: Technical debt. Later may have to re-factor so that the tests that extend this does not cause different execution path because of the conditional tests.
   @Test
   public void testUpdate() throws Exception {
     String collection = randomCollection();
     mongoClient.insert(collection, createDoc(), onSuccess(id -> {
-      if(useObjectId) {
+      if (useObjectId) {
         JsonObject docIdToBeUpdatedObjectId = new JsonObject().put(JsonObjectCodec.OID_FIELD, id);
         updateDataBasedOnId(collection, docIdToBeUpdatedObjectId);
       } else {
@@ -1130,12 +1167,11 @@ public abstract class MongoClientTestBase extends MongoTestBase {
   }
 
 
-
   @Test
   public void testUpdateWithMongoClientUpdateResult() throws Exception {
     String collection = randomCollection();
     mongoClient.insert(collection, createDoc(), onSuccess(id -> {
-      if(useObjectId) {
+      if (useObjectId) {
         JsonObject docIdToBeUpdatedObjectId = new JsonObject().put(JsonObjectCodec.OID_FIELD, id);
         updateDataBasedOnIdWithMongoClientUpdateResult(collection, docIdToBeUpdatedObjectId);
       } else {
@@ -1216,12 +1252,12 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     String upsertedId = TestUtils.randomAlphaString(20);
     mongoClient.insert(collection, createDoc(), onSuccess(id -> {
       mongoClient.updateCollectionWithOptions(collection, new JsonObject().put("_id", upsertedId), new JsonObject().put("$set", new JsonObject().put("foo", "fooed")),
-        new UpdateOptions().setUpsert(true),onSuccess(res -> {
+        new UpdateOptions().setUpsert(true), onSuccess(res -> {
           assertEquals(0, res.getDocModified());
           assertEquals(0, res.getDocMatched());
-          assertEquals(upsertedId,res.getDocUpsertedId().getString(MongoClientUpdateResult.ID_FIELD));
+          assertEquals(upsertedId, res.getDocUpsertedId().getString(MongoClientUpdateResult.ID_FIELD));
           testComplete();
-      }));
+        }));
     }));
     await();
   }
@@ -1230,7 +1266,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
   public void testMongoClientUpdateResultAcknowledge() throws Exception {
     String collection = randomCollection();
     mongoClient.insert(collection, createDoc(), onSuccess(id -> {
-      if(useObjectId) {
+      if (useObjectId) {
         JsonObject docIdToBeUpdatedObjectId = new JsonObject().put(JsonObjectCodec.OID_FIELD, id);
         updateWithOptionWithMongoClientUpdateResultBasedOnIdAcknowledged(collection, docIdToBeUpdatedObjectId);
       } else {
@@ -1243,7 +1279,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
 
   private <T> void updateWithOptionWithMongoClientUpdateResultBasedOnIdAcknowledged(String collection, T id) {
     mongoClient.updateCollectionWithOptions(collection, new JsonObject().put("_id", id), new JsonObject().put("$set", new JsonObject().put("foo", "fooed")),
-      new UpdateOptions().setWriteOption(ACKNOWLEDGED),onSuccess(res -> {
+      new UpdateOptions().setWriteOption(ACKNOWLEDGED), onSuccess(res -> {
         assertEquals(1, res.getDocModified());
         assertEquals(1, res.getDocMatched());
         assertNull(res.getDocUpsertedId());
@@ -1257,7 +1293,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     String upsertedId = TestUtils.randomAlphaString(20);
     mongoClient.insert(collection, createDoc(), onSuccess(id -> {
       mongoClient.updateCollectionWithOptions(collection, new JsonObject().put("_id", upsertedId), new JsonObject().put("$set", new JsonObject().put("foo", "fooed")),
-        new UpdateOptions().setWriteOption(UNACKNOWLEDGED),onSuccess(res -> {
+        new UpdateOptions().setWriteOption(UNACKNOWLEDGED), onSuccess(res -> {
           assertNull(res);
           testComplete();
         }));
@@ -1282,7 +1318,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
   }
 
   private void doTestUpdateWithMongoClientUpdateResult(int numDocs, JsonObject query, JsonObject update, UpdateOptions options,
-                            Consumer<List<JsonObject>> resultConsumer) throws Exception {
+                                                       Consumer<List<JsonObject>> resultConsumer) throws Exception {
     String collection = randomCollection();
     mongoClient.createCollection(collection, onSuccess(res -> {
       insertDocs(mongoClient, collection, numDocs, onSuccess(res2 -> {
@@ -1531,14 +1567,14 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     JsonObject doc1 = new JsonObject().put("foo", "bar");
     JsonObject doc2 = new JsonObject().put("foo", "foobar");
     mongoClient.bulkWrite(collection,
-        Arrays.asList(BulkOperation.createInsert(doc1), BulkOperation.createInsert(doc2)),
-        onSuccess(bulkResult -> {
-          assertEquals(2, bulkResult.getInsertedCount());
-          assertEquals(0, bulkResult.getModifiedCount());
-          assertEquals(0, bulkResult.getDeletedCount());
-          assertEquals(0, bulkResult.getMatchedCount());
-          testComplete();
-        }));
+      Arrays.asList(BulkOperation.createInsert(doc1), BulkOperation.createInsert(doc2)),
+      onSuccess(bulkResult -> {
+        assertEquals(2, bulkResult.getInsertedCount());
+        assertEquals(0, bulkResult.getModifiedCount());
+        assertEquals(0, bulkResult.getDeletedCount());
+        assertEquals(0, bulkResult.getMatchedCount());
+        testComplete();
+      }));
     await();
   }
 
@@ -1554,18 +1590,18 @@ public abstract class MongoClientTestBase extends MongoTestBase {
       else
         filter.put("_id", id);
       mongoClient.bulkWrite(collection, Arrays.asList(BulkOperation.createUpdate(filter, update)),
-          onSuccess(bulkResult -> {
-            assertEquals(1, bulkResult.getModifiedCount());
-            assertEquals(0, bulkResult.getDeletedCount());
-            assertEquals(0, bulkResult.getInsertedCount());
-            assertEquals(1, bulkResult.getMatchedCount());
-            mongoClient.find(collection, new JsonObject(), onSuccess(docs -> {
-              assertEquals(1, docs.size());
-              JsonObject foundDoc = docs.get(0);
-              assertEquals("foobar", foundDoc.getString("foo"));
-              testComplete();
-            }));
+        onSuccess(bulkResult -> {
+          assertEquals(1, bulkResult.getModifiedCount());
+          assertEquals(0, bulkResult.getDeletedCount());
+          assertEquals(0, bulkResult.getInsertedCount());
+          assertEquals(1, bulkResult.getMatchedCount());
+          mongoClient.find(collection, new JsonObject(), onSuccess(docs -> {
+            assertEquals(1, docs.size());
+            JsonObject foundDoc = docs.get(0);
+            assertEquals("foobar", foundDoc.getString("foo"));
+            testComplete();
           }));
+        }));
     }));
     await();
   }
@@ -1620,7 +1656,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     String collection = randomCollection();
     JsonObject doc = new JsonObject().put("$set", new JsonObject().put("foo", "bar"));
     BulkOperation bulkUpdate = BulkOperation.createUpdate(new JsonObject().put("foo", "bur"), doc)
-        .setUpsert(true);
+      .setUpsert(true);
     mongoClient.bulkWrite(collection, Arrays.asList(bulkUpdate), onSuccess(bulkResult -> {
       // even though one document was created, the MongoDB client returns 0 for all counts
       assertEquals(0, bulkResult.getInsertedCount());
@@ -1642,7 +1678,7 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     String collection = randomCollection();
     JsonObject doc = new JsonObject().put("$set", new JsonObject().put("foo", "bar"));
     BulkOperation bulkUpdate = BulkOperation.createUpdate(new JsonObject().put("foo", "bur"), doc)
-        .setUpsert(false);
+      .setUpsert(false);
     mongoClient.bulkWrite(collection, Arrays.asList(bulkUpdate), onSuccess(bulkResult -> {
       assertEquals(0, bulkResult.getInsertedCount());
       assertEquals(0, bulkResult.getModifiedCount());
@@ -1792,9 +1828,9 @@ public abstract class MongoClientTestBase extends MongoTestBase {
     insertDocs(mongoClient, collection, 5, onSuccess(v -> {
       BulkOperation bulkInsert = BulkOperation.createInsert(new JsonObject().put("foo", "insert"));
       BulkOperation bulkUpdate = BulkOperation.createUpdate(new JsonObject().put("foo", "bar1"),
-          new JsonObject().put("$set", new JsonObject().put("foo", "update")));
+        new JsonObject().put("$set", new JsonObject().put("foo", "update")));
       BulkOperation bulkReplace = BulkOperation.createReplace(new JsonObject().put("foo", "bar2"),
-          new JsonObject().put("foo", "replace"));
+        new JsonObject().put("foo", "replace"));
       BulkOperation bulkDelete = BulkOperation.createDelete(new JsonObject().put("foo", "bar3"));
       Handler<AsyncResult<MongoClientBulkWriteResult>> successHandler = onSuccess(bulkResult -> {
         if (bulkWriteOptions != null && bulkWriteOptions.getWriteOption() == UNACKNOWLEDGED) {
@@ -1820,10 +1856,10 @@ public abstract class MongoClientTestBase extends MongoTestBase {
       });
       if (bulkWriteOptions == null)
         mongoClient.bulkWrite(collection, Arrays.asList(bulkInsert, bulkUpdate, bulkReplace, bulkDelete),
-            successHandler);
+          successHandler);
       else
         mongoClient.bulkWriteWithOptions(collection, Arrays.asList(bulkInsert, bulkUpdate, bulkReplace, bulkDelete),
-            bulkWriteOptions, successHandler);
+          bulkWriteOptions, successHandler);
     }));
     await();
   }


### PR DESCRIPTION
Motivation:

Providing collation options for an index is available since mongo 3.4.
I thought vertx-mongoclient could use this feature as well, since the driver supports it.
