### PR TITLE
update mongo driver version to support periods in field name.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <stack.version>4.2.1-SNAPSHOT</stack.version>
-    <mongodb.driver.reactivestreams.version>4.1.2</mongodb.driver.reactivestreams.version>
+    <mongodb.driver.reactivestreams.version>4.4.0</mongodb.driver.reactivestreams.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 


### PR DESCRIPTION
Motivation:

mongo > 3.6, field names with Periods (.) and Dollar Signs ($), more info: https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
want to update mongo driver version to support periods in field name. 
