### PR TITLE
CollationOptions improvements and clean up

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/BulkOperation.java
+++ b/src/main/java/io/vertx/ext/mongo/BulkOperation.java
@@ -31,8 +31,9 @@ public class BulkOperation {
     return collation;
   }
 
-  public void setCollation(CollationOptions collation) {
+  public BulkOperation setCollation(CollationOptions collation) {
     this.collation = collation;
+    return this;
   }
 
   private CollationOptions collation;

--- a/src/main/java/io/vertx/ext/mongo/CollationOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/CollationOptions.java
@@ -96,7 +96,7 @@ public class CollationOptions {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     CollationOptions that = (CollationOptions) o;
-    return isCaseLevel() == that.isCaseLevel() && getStrength() == that.getStrength() && isNumericOrdering() == that.isNumericOrdering() && isBackwards() == that.isBackwards() && isNormalization() == that.isNormalization() && Objects.equals(getLocale(), that.getLocale()) && getCaseFirst() == that.getCaseFirst() && getAlternate() == that.getAlternate() && getMaxVariable() == that.getMaxVariable();
+    return isCaseLevel() == that.isCaseLevel() && getStrength() == that.getStrength() && isNumericOrdering() == that.isNumericOrdering() && isBackwards() == that.isBackwards() && isNormalization() == that.isNormalization() && Objects.equals(getLocale(), that.getLocale()) && getCaseFirst() == that.getCaseFirst() && Objects.equals(getAlternate(), that.getAlternate()) && getMaxVariable() == that.getMaxVariable();
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/mongo/GridFsDownloadOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/GridFsDownloadOptions.java
@@ -57,8 +57,9 @@ public class GridFsDownloadOptions {
     return revision;
   }
 
-  public void setRevision(Integer revision) {
+  public GridFsDownloadOptions setRevision(Integer revision) {
     this.revision = revision;
+    return this;
   }
 
 }

--- a/src/main/java/io/vertx/ext/mongo/GridFsUploadOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/GridFsUploadOptions.java
@@ -55,16 +55,18 @@ public class GridFsUploadOptions {
     return metadata;
   }
 
-  public void setMetadata(JsonObject metadata) {
+  public GridFsUploadOptions setMetadata(JsonObject metadata) {
     this.metadata = metadata;
+    return this;
   }
 
   public Integer getChunkSizeBytes() {
     return chunkSizeBytes;
   }
 
-  public void setChunkSizeBytes(Integer chunkSizeBytes) {
+  public GridFsUploadOptions setChunkSizeBytes(Integer chunkSizeBytes) {
     this.chunkSizeBytes = chunkSizeBytes;
+    return this;
   }
 
 }

--- a/src/main/java/io/vertx/ext/mongo/IndexOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/IndexOptions.java
@@ -94,7 +94,7 @@ public class IndexOptions {
     bucketSize = options.getDouble("bucketSize");
     storageEngine = options.getJsonObject("storageEngine");
     partialFilterExpression = options.getJsonObject("partialFilterExpression");
-    collation = new CollationOptions(options.getJsonObject("collation"));
+    collation = new CollationOptions(options.getJsonObject("collation", new JsonObject()));
   }
 
   public CollationOptions getCollation() {

--- a/src/main/java/io/vertx/ext/mongo/UpdateOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/UpdateOptions.java
@@ -97,7 +97,7 @@ public class UpdateOptions {
       collation = new CollationOptions(json.getJsonObject("collation"));
     }
   }
-  
+
   public CollationOptions getCollation() {
     return collation;
   }
@@ -107,8 +107,9 @@ public class UpdateOptions {
    *
    * @param collation
    */
-  public void setCollation(CollationOptions collation) {
+  public UpdateOptions setCollation(CollationOptions collation) {
     this.collation = collation;
+    return this;
   }
 
   /**

--- a/src/test/java/io/vertx/ext/mongo/CollationOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/CollationOptionsTest.java
@@ -2,7 +2,6 @@ package io.vertx.ext.mongo;
 
 import org.junit.Test;
 
-import java.util.Locale;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -10,8 +9,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 public class CollationOptionsTest {
-
-  private static final String DEFAULT_LOCALE = Locale.getDefault().toString();
 
   private static void assertNotEqual(BiConsumer<CollationOptions, CollationOptions> f) {
     CollationOptions a = new CollationOptions();


### PR DESCRIPTION
Motivation:

While using the newly itnroduced collation options in 4.2.3, I realized that some setters in data object classes are non-compliant to the builder-pattern, which is widely used in the project and also nice to use imho.
It's merely syntactical sugar, still, I thought I'd provide a fix for it.

Also add an empty json object fallback on non-provided collation options within IndexOptions

Seemingly, I made a mistake while integrating requested changes of my last PR (#266) in the equals method of `CollationOptions`. Should be fixed with this commit (`alternate` is not compared properly)