### PR TITLE
Add hint support to Bulk operations 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,10 +7,6 @@ An asynchronous client for interacting with a MongoDB database
 Please see the main documentation on the web-site for a full description:
 
 * https://vertx.io/docs/vertx-mongo-client/java/[Java documentation]
-* https://vertx.io/docs/vertx-mongo-client/js/[JavaScript documentation]
-* https://vertx.io/docs/vertx-mongo-client/kotlin/[Kotlin documentation]
-* https://vertx.io/docs/vertx-mongo-client/groovy/[Groovy documentation]
-* https://vertx.io/docs/vertx-mongo-client/ruby/[Ruby documentation]
 
 The following docker CLI can be used for running mongo tests:
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,13 +77,6 @@
       <version>1.0.3</version>
     </dependency>
     <dependency>
-      <!-- declare this dependency to force flapdoodle to use this one. It is the version used by vert.x -->
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.21</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
@@ -91,7 +84,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mongodb</artifactId>
-      <version>1.15.2</version>
+      <version>1.17.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/generated/io/vertx/ext/mongo/FindOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/mongo/FindOptionsConverter.java
@@ -36,8 +36,13 @@ public class FindOptionsConverter {
           }
           break;
         case "hint":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setHint(((JsonObject)member.getValue()).copy());
+          }
+          break;
+        case "hintString":
           if (member.getValue() instanceof String) {
-            obj.setHint((String)member.getValue());
+            obj.setHintString((String)member.getValue());
           }
           break;
         case "limit":
@@ -73,6 +78,9 @@ public class FindOptionsConverter {
     }
     if (obj.getHint() != null) {
       json.put("hint", obj.getHint());
+    }
+    if (obj.getHintString() != null) {
+      json.put("hintString", obj.getHintString());
     }
     json.put("limit", obj.getLimit());
     json.put("skip", obj.getSkip());

--- a/src/main/java/io/vertx/ext/mongo/BulkOperation.java
+++ b/src/main/java/io/vertx/ext/mongo/BulkOperation.java
@@ -321,8 +321,8 @@ public class BulkOperation {
       ", document=" + document +
       ", upsert=" + upsert +
       ", multi=" + multi +
-      ", hint='" + hint + '\''+
-      ", hintString=" + hintString +
+      ", hint=" + hint +
+      ", hintString='" + hintString + '\''+
       ", collation=" + collation +
       '}';
   }

--- a/src/main/java/io/vertx/ext/mongo/BulkOperation.java
+++ b/src/main/java/io/vertx/ext/mongo/BulkOperation.java
@@ -28,6 +28,8 @@ public class BulkOperation {
   private JsonObject document;
   private boolean upsert;
   private boolean multi;
+  private JsonObject hint;
+  private String hintString;
   private CollationOptions collation;
 
   /**
@@ -41,6 +43,8 @@ public class BulkOperation {
     this.document = null;
     this.upsert = DEFAULT_UPSERT;
     this.multi = DEFAULT_MULTI;
+    this.hint = null;
+    this.hintString = null;
     this.collation = null;
   }
 
@@ -56,6 +60,8 @@ public class BulkOperation {
     document = json.getJsonObject("document");
     upsert = json.getBoolean("upsert");
     multi = json.getBoolean("multi");
+    hint = json.getJsonObject("hint");
+    hintString = json.getString("hintString");
     collation = json.getJsonObject("collation") != null ? new CollationOptions(json.getJsonObject("collation")) : null;
   }
 
@@ -148,6 +154,8 @@ public class BulkOperation {
     json.put("document", document);
     json.put("upsert", upsert);
     json.put("multi", multi);
+    json.put("hint", hint);
+    json.put("hintString", hintString);
     json.put("collation", collation != null ? collation.toJson() : null);
     return json;
   }
@@ -252,17 +260,57 @@ public class BulkOperation {
     return this;
   }
 
+  /**
+   * Returns the operation hint
+   *
+   * @return the operation hint
+   */
+  public JsonObject getHint() {
+    return hint;
+  }
+
+  /**
+   * Sets the operation hint
+   *
+   * @param hint the operation hint
+   * @return this for fluency
+   */
+  public BulkOperation setHint(JsonObject hint) {
+    this.hint = hint;
+    return this;
+  }
+
+  /**
+   * Returns the operation hint string
+   *
+   * @return the operation hint string
+   */
+  public String getHintString() {
+    return hintString;
+  }
+
+  /**
+   * Sets the operation hint string
+   *
+   * @param hintString the operation hint string
+   * @return this for fluency
+   */
+  public BulkOperation setHintString(String hintString) {
+    this.hintString = hintString;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     BulkOperation operation = (BulkOperation) o;
-    return upsert == operation.upsert && multi == operation.multi && type == operation.type && Objects.equals(filter, operation.filter) && Objects.equals(document, operation.document) && Objects.equals(collation, operation.collation);
+    return upsert == operation.upsert && multi == operation.multi && type == operation.type && Objects.equals(filter, operation.filter) && Objects.equals(document, operation.document) && Objects.equals(hint, operation.hint) && Objects.equals(hintString, operation.hintString) && Objects.equals(collation, operation.collation);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, filter, document, upsert, multi, collation);
+    return Objects.hash(type, filter, document, upsert, multi, hint, hintString, collation);
   }
 
   @Override
@@ -273,6 +321,8 @@ public class BulkOperation {
       ", document=" + document +
       ", upsert=" + upsert +
       ", multi=" + multi +
+      ", hint='" + hint + '\''+
+      ", hintString=" + hintString +
       ", collation=" + collation +
       '}';
   }

--- a/src/main/java/io/vertx/ext/mongo/FindOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/FindOptions.java
@@ -227,7 +227,7 @@ public class FindOptions {
   }
 
   /**
-   * Set the hint
+   * Set the hint string
    *
    * @param hintString the hint string
    * @return reference to this, for fluency

--- a/src/main/java/io/vertx/ext/mongo/FindOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/FindOptions.java
@@ -33,7 +33,8 @@ public class FindOptions {
   private int limit;
   private int skip;
   private int batchSize;
-  private String hint;
+  private JsonObject hint;
+  private String hintString;
   private CollationOptions collation;
 
   /**
@@ -59,6 +60,7 @@ public class FindOptions {
     this.skip = options.skip;
     this.batchSize = options.batchSize;
     this.hint = options.hint;
+    this.hintString = options.hintString;
     this.collation = options.getCollation();
   }
 
@@ -200,7 +202,7 @@ public class FindOptions {
    *
    * @return the hint
    */
-  public String getHint() {
+  public JsonObject getHint() {
     return hint;
   }
 
@@ -210,8 +212,28 @@ public class FindOptions {
    * @param hint the hint
    * @return reference to this, for fluency
    */
-  public FindOptions setHint(String hint) {
+  public FindOptions setHint(JsonObject hint) {
     this.hint = hint;
+    return this;
+  }
+
+  /**
+   * Get the hint string. This determines the index to use.
+   *
+   * @return the hint string
+   */
+  public String getHintString() {
+    return hintString;
+  }
+
+  /**
+   * Set the hint
+   *
+   * @param hintString the hint string
+   * @return reference to this, for fluency
+   */
+  public FindOptions setHintString(String hintString) {
+    this.hintString = hintString;
     return this;
   }
 
@@ -220,12 +242,12 @@ public class FindOptions {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     FindOptions that = (FindOptions) o;
-    return limit == that.limit && skip == that.skip && batchSize == that.batchSize && Objects.equals(fields, that.fields) && Objects.equals(sort, that.sort) && Objects.equals(hint, that.hint) && Objects.equals(collation, that.collation);
+    return limit == that.limit && skip == that.skip && batchSize == that.batchSize && Objects.equals(fields, that.fields) && Objects.equals(sort, that.sort) && Objects.equals(hint, that.hint) && Objects.equals(hintString, that.hintString) && Objects.equals(collation, that.collation);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(fields, sort, limit, skip, batchSize, hint, collation);
+    return Objects.hash(fields, sort, limit, skip, batchSize, hint, hintString, collation);
   }
 
   @Override
@@ -236,7 +258,8 @@ public class FindOptions {
       ", limit=" + limit +
       ", skip=" + skip +
       ", batchSize=" + batchSize +
-      ", hint='" + hint + '\'' +
+      ", hint=" + hint +
+      ", hintString='" + hintString + '\'' +
       ", collation=" + collation +
       '}';
   }

--- a/src/main/java/io/vertx/ext/mongo/UpdateOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/UpdateOptions.java
@@ -312,8 +312,8 @@ public class UpdateOptions {
       ", multi=" + multi +
       ", returnNewDocument=" + returnNewDocument +
       ", arrayFilters=" + arrayFilters +
-      ", hint='" + hint + '\''+
-      ", hintString=" + hintString +
+      ", hint=" + hint +
+      ", hintString='" + hintString + '\''+
       ", collation=" + collation +
       '}';
   }

--- a/src/main/java/io/vertx/ext/mongo/UpdateOptions.java
+++ b/src/main/java/io/vertx/ext/mongo/UpdateOptions.java
@@ -34,6 +34,8 @@ public class UpdateOptions {
   private boolean multi;
   private boolean returnNewDocument; // uniquely valid on findOneAnd* methods
   private JsonArray arrayFilters;
+  private JsonObject hint;
+  private String hintString;
   private CollationOptions collation;
 
   /**
@@ -79,6 +81,8 @@ public class UpdateOptions {
     this.multi = other.multi;
     this.returnNewDocument = other.returnNewDocument;
     this.arrayFilters = other.arrayFilters;
+    this.hint = other.hint;
+    this.hintString = other.hintString;
     this.collation = other.collation;
   }
 
@@ -96,6 +100,8 @@ public class UpdateOptions {
     multi = json.getBoolean("multi", DEFAULT_MULTI);
     returnNewDocument = json.getBoolean("return_new_document", DEFAULT_RETURN_NEW_DOCUMENT);
     arrayFilters = json.getJsonArray("arrayFilters", null);
+    hint = json.getJsonObject("hint", null);
+    hintString = json.getString("hintString", null);
     if (json.getJsonObject("collation") != null) {
       collation = new CollationOptions(json.getJsonObject("collation"));
     }
@@ -215,6 +221,46 @@ public class UpdateOptions {
     return this;
   }
 
+  /**
+   * Get the hint.
+   *
+   * @return the hint
+   */
+  public JsonObject getHint() {
+    return hint;
+  }
+
+  /**
+   * Set the hint.
+   *
+   * @param hint the hint
+   * @return reference to this, for fluency
+   */
+  public UpdateOptions setHint(JsonObject hint) {
+    this.hint = hint;
+    return this;
+  }
+
+  /**
+   * Get the hint string.
+   *
+   * @return the hint string
+   */
+  public String getHintString() {
+    return hintString;
+  }
+
+  /**
+   * Set the hint string.
+   *
+   * @param hintString the hint string
+   * @return reference to this, for fluency
+   */
+  public UpdateOptions setHintString(String hintString) {
+    this.hintString = hintString;
+    return this;
+  }
+
   public JsonObject toJson() {
     JsonObject json = new JsonObject();
     if (writeOption != null) {
@@ -232,6 +278,12 @@ public class UpdateOptions {
     if (arrayFilters != null && !arrayFilters.isEmpty()) {
       json.put("arrayFilters", arrayFilters);
     }
+    if (hint != null) {
+      json.put("hint", hint);
+    }
+    if (hintString != null) {
+      json.put("hintString", hintString);
+    }
     if (collation != null) {
       json.put("collation", collation.toJson());
     }
@@ -244,12 +296,12 @@ public class UpdateOptions {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     UpdateOptions that = (UpdateOptions) o;
-    return upsert == that.upsert && multi == that.multi && returnNewDocument == that.returnNewDocument && writeOption == that.writeOption && Objects.equals(arrayFilters, that.arrayFilters) && Objects.equals(collation, that.collation);
+    return upsert == that.upsert && multi == that.multi && returnNewDocument == that.returnNewDocument && writeOption == that.writeOption && Objects.equals(arrayFilters, that.arrayFilters) && Objects.equals(hint, that.hint) && Objects.equals(hintString, that.hintString) && Objects.equals(collation, that.collation);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(writeOption, upsert, multi, returnNewDocument, arrayFilters, collation);
+    return Objects.hash(writeOption, upsert, multi, returnNewDocument, arrayFilters, hint, hintString, collation);
   }
 
   @Override
@@ -260,6 +312,8 @@ public class UpdateOptions {
       ", multi=" + multi +
       ", returnNewDocument=" + returnNewDocument +
       ", arrayFilters=" + arrayFilters +
+      ", hint='" + hint + '\''+
+      ", hintString=" + hintString +
       ", collation=" + collation +
       '}';
   }

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -267,6 +267,12 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
       options.getArrayFilters().getList().forEach(entry -> bArrayFilters.add(wrap(JsonObject.mapFrom(entry))));
       updateOptions.arrayFilters(bArrayFilters);
     }
+    if (options.getHint() != null) {
+      updateOptions.hint(wrap(options.getHint()));
+    }
+    if (options.getHintString() != null && !options.getHintString().isEmpty()) {
+      updateOptions.hintString(options.getHintString());
+    }
     if (options.getCollation() != null) {
       updateOptions.collation(options.getCollation().toMongoDriverObject());
     }
@@ -309,6 +315,12 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
       final List<Bson> bArrayFilters = new ArrayList<>(options.getArrayFilters().size());
       options.getArrayFilters().getList().forEach(entry -> bArrayFilters.add(wrap(JsonObject.mapFrom(entry))));
       updateOptions.arrayFilters(bArrayFilters);
+    }
+    if (options.getHint() != null) {
+      updateOptions.hint(wrap(options.getHint()));
+    }
+    if (options.getHintString() != null && !options.getHintString().isEmpty()) {
+      updateOptions.hintString(options.getHintString());
     }
     if (options.getCollation() != null) {
       updateOptions.collation(options.getCollation().toMongoDriverObject());
@@ -367,6 +379,12 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     MongoCollection<JsonObject> coll = getCollection(collection, options.getWriteOption());
     Bson bquery = wrap(encodeKeyWhenUseObjectId(query));
     com.mongodb.client.model.ReplaceOptions replaceOptions = new com.mongodb.client.model.ReplaceOptions().upsert(options.isUpsert());
+    if (options.getHint() != null) {
+      replaceOptions.hint(wrap(options.getHint()));
+    }
+    if (options.getHintString() != null && !options.getHintString().isEmpty()) {
+      replaceOptions.hintString(options.getHintString());
+    }
     if (options.getCollation() != null) {
       replaceOptions.collation(options.getCollation().toMongoDriverObject());
     }
@@ -480,6 +498,15 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
       updateOptions.getArrayFilters().getList().forEach(entry -> bArrayFilters.add(wrap(JsonObject.mapFrom(entry))));
       foauOptions.arrayFilters(bArrayFilters);
     }
+    if (findOptions.getHint() != null && !findOptions.getHint().isEmpty()) {
+      foauOptions.hintString(findOptions.getHint());
+    }
+    if (updateOptions.getHint() != null) {
+      foauOptions.hint(wrap(updateOptions.getHint()));
+    }
+    if (updateOptions.getHintString() != null && !updateOptions.getHintString().isEmpty()) {
+      foauOptions.hintString(updateOptions.getHintString());
+    }
     if(findOptions.getCollation() != null) {
       foauOptions.collation(findOptions.getCollation().toMongoDriverObject());
     }
@@ -527,6 +554,16 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     foarOptions.projection(wrap(findOptions.getFields()));
     foarOptions.upsert(updateOptions.isUpsert());
     foarOptions.returnDocument(updateOptions.isReturningNewDocument() ? ReturnDocument.AFTER : ReturnDocument.BEFORE);
+    if (findOptions.getHint() != null && !findOptions.getHint().isEmpty()) {
+      foarOptions.hintString(findOptions.getHint());
+    }
+    if (updateOptions.getHint() != null) {
+      foarOptions.hint(wrap(updateOptions.getHint()));
+    }
+    if (updateOptions.getHintString() != null) {
+      foarOptions.hintString(updateOptions.getHintString());
+    }
+
     if(findOptions.getCollation() != null) {
       foarOptions.collation(findOptions.getCollation().toMongoDriverObject());
     }
@@ -568,6 +605,10 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     FindOneAndDeleteOptions foadOptions = new FindOneAndDeleteOptions();
     foadOptions.sort(wrap(findOptions.getSort()));
     foadOptions.projection(wrap(findOptions.getFields()));
+
+    if(findOptions.getHint() != null && !findOptions.getHint().isEmpty()) {
+      foadOptions.hintString(findOptions.getHint());
+    }
 
     if(findOptions.getCollation() != null) {
       foadOptions.collation(findOptions.getCollation().toMongoDriverObject());
@@ -714,6 +755,12 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
         case DELETE:
           Bson bsonFilter = toBson(encodeKeyWhenUseObjectId(bulkOperation.getFilter()));
           DeleteOptions deleteOptions = new DeleteOptions();
+          if (bulkOperation.getHint() != null) {
+            deleteOptions.hint(toBson(bulkOperation.getHint()));
+          }
+          if (bulkOperation.getHintString() != null && !bulkOperation.getHintString().isEmpty()) {
+            deleteOptions.hintString(bulkOperation.getHintString());
+          }
           if (bulkOperation.getCollation() != null) {
             deleteOptions.collation(bulkOperation.getCollation().toMongoDriverObject());
           }
@@ -731,6 +778,12 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
           if (bulkOperation.getCollation() != null) {
             replaceOptions.collation(bulkOperation.getCollation().toMongoDriverObject());
           }
+          if (bulkOperation.getHint() != null) {
+            replaceOptions.hint(toBson(bulkOperation.getHint()));
+          }
+          if (bulkOperation.getHintString() != null && !bulkOperation.getHintString().isEmpty()) {
+            replaceOptions.hintString(bulkOperation.getHintString());
+          }
           result.add(new ReplaceOneModel<>(toBson(encodeKeyWhenUseObjectId(bulkOperation.getFilter())), bulkOperation.getDocument(),
             replaceOptions.upsert(bulkOperation.isUpsert())));
           break;
@@ -741,6 +794,12 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
             .upsert(bulkOperation.isUpsert());
           if (bulkOperation.getCollation() != null) {
             updateOptions.collation(bulkOperation.getCollation().toMongoDriverObject());
+          }
+          if (bulkOperation.getHint() != null) {
+            updateOptions.hint(toBson(bulkOperation.getHint()));
+          }
+          if (bulkOperation.getHintString() != null && !bulkOperation.getHintString().isEmpty()) {
+            updateOptions.hintString(bulkOperation.getHintString());
           }
           if (bulkOperation.isMulti()) {
             result.add(new UpdateManyModel<>(filter, document, updateOptions));

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -498,8 +498,11 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
       updateOptions.getArrayFilters().getList().forEach(entry -> bArrayFilters.add(wrap(JsonObject.mapFrom(entry))));
       foauOptions.arrayFilters(bArrayFilters);
     }
-    if (findOptions.getHint() != null && !findOptions.getHint().isEmpty()) {
-      foauOptions.hintString(findOptions.getHint());
+    if (findOptions.getHint() != null) {
+      foauOptions.hint(wrap(findOptions.getHint()));
+    }
+    if (findOptions.getHintString() != null && !findOptions.getHintString().isEmpty()) {
+      foauOptions.hintString(findOptions.getHintString());
     }
     if (updateOptions.getHint() != null) {
       foauOptions.hint(wrap(updateOptions.getHint()));
@@ -554,8 +557,11 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     foarOptions.projection(wrap(findOptions.getFields()));
     foarOptions.upsert(updateOptions.isUpsert());
     foarOptions.returnDocument(updateOptions.isReturningNewDocument() ? ReturnDocument.AFTER : ReturnDocument.BEFORE);
-    if (findOptions.getHint() != null && !findOptions.getHint().isEmpty()) {
-      foarOptions.hintString(findOptions.getHint());
+    if (findOptions.getHint() != null) {
+      foarOptions.hint(wrap(findOptions.getHint()));
+    }
+    if (findOptions.getHintString() != null && !findOptions.getHintString().isEmpty()) {
+      foarOptions.hintString(findOptions.getHintString());
     }
     if (updateOptions.getHint() != null) {
       foarOptions.hint(wrap(updateOptions.getHint()));
@@ -606,8 +612,11 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     foadOptions.sort(wrap(findOptions.getSort()));
     foadOptions.projection(wrap(findOptions.getFields()));
 
-    if(findOptions.getHint() != null && !findOptions.getHint().isEmpty()) {
-      foadOptions.hintString(findOptions.getHint());
+    if (findOptions.getHint() != null) {
+      foadOptions.hint(wrap(findOptions.getHint()));
+    }
+    if (findOptions.getHintString() != null && !findOptions.getHintString().isEmpty()) {
+      foadOptions.hintString(findOptions.getHintString());
     }
 
     if(findOptions.getCollation() != null) {
@@ -1223,8 +1232,11 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     if (options.getFields() != null) {
       find.projection(wrap(options.getFields()));
     }
-    if (options.getHint() != null && !options.getHint().isEmpty()) {
-      find.hintString(options.getHint());
+    if (options.getHint() != null) {
+      find.hint(wrap(options.getHint()));
+    }
+    if (options.getHintString() != null && !options.getHintString().isEmpty()) {
+      find.hintString(options.getHintString());
     }
     if(options.getCollation() != null) {
       find.collation(options.getCollation().toMongoDriverObject());

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -560,7 +560,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     if (updateOptions.getHint() != null) {
       foarOptions.hint(wrap(updateOptions.getHint()));
     }
-    if (updateOptions.getHintString() != null) {
+    if (updateOptions.getHintString() != null && !updateOptions.getHintString().isEmpty()) {
       foarOptions.hintString(updateOptions.getHintString());
     }
 

--- a/src/test/java/io/vertx/ext/mongo/BulkOperationTest.java
+++ b/src/test/java/io/vertx/ext/mongo/BulkOperationTest.java
@@ -49,6 +49,18 @@ public class BulkOperationTest {
     b.setCollation(new CollationOptions());
     assertEquals(a,b);
 
+    a.setHint(new JsonObject().put("foo", "bar"));
+    b.setHint(new JsonObject().put("bar", "foo"));
+    assertNotEquals(a, b);
+    b.setHint(new JsonObject().put("foo", "bar"));
+    assertEquals(a, b);
+
+    a.setHintString("foo");
+    b.setHintString("bar");
+    assertNotEquals(a, b);
+    b.setHintString("foo");
+    assertEquals(a, b);
+
     assertNotEquals(a, null);
   }
 
@@ -85,6 +97,16 @@ public class BulkOperationTest {
     a.setCollation(new CollationOptions());
     assertNotEquals(hash, a.hashCode());
     a.setCollation(null);
+    assertEquals(hash, a.hashCode());
+
+    a.setHint(new JsonObject().put("foo", "bar"));
+    assertNotEquals(hash, a.hashCode());
+    a.setHint(null);
+    assertEquals(hash, a.hashCode());
+
+    a.setHintString("foo");
+    assertNotEquals(hash, a.hashCode());
+    a.setHintString(null);
     assertEquals(hash, a.hashCode());
 
     assertNotEquals(a, null);

--- a/src/test/java/io/vertx/ext/mongo/UpdateOptionsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/UpdateOptionsTest.java
@@ -31,6 +31,14 @@ public class UpdateOptionsTest {
     JsonArray arrayFilters = new JsonArray().add(new JsonObject().put(TestUtils.randomAlphaString(5), TestUtils.randomAlphaString(5)));
     assertEquals(options, options.setArrayFilters(arrayFilters));
     assertEquals(arrayFilters, options.getArrayFilters());
+
+    JsonObject hint = new JsonObject().put(TestUtils.randomAlphaString(5), TestUtils.randomInt());
+    assertEquals(options, options.setHint(hint));
+    assertEquals(hint, options.getHint());
+
+    String hintString = TestUtils.randomAlphaString(12);
+    assertEquals(options, options.setHintString(hintString));
+    assertEquals(hintString, options.getHintString());
   }
 
   @Test
@@ -40,6 +48,8 @@ public class UpdateOptionsTest {
     assertFalse(options.isMulti());
     assertFalse(options.isUpsert());
     assertNull(options.getArrayFilters());
+    assertNull(options.getHint());
+    assertNull(options.getHintString());
   }
 
   @Test
@@ -58,11 +68,19 @@ public class UpdateOptionsTest {
     JsonArray arrayFilters = new JsonArray().add(new JsonObject().put(TestUtils.randomAlphaString(5), TestUtils.randomAlphaString(5)));
     json.put("arrayFilters", arrayFilters);
 
+    JsonObject hint = new JsonObject().put(TestUtils.randomAlphaString(5), TestUtils.randomInt());
+    json.put("hint", hint);
+
+    String hintString = TestUtils.randomAlphaString(12);
+    json.put("hintString", hintString);
+
     UpdateOptions options = new UpdateOptions(json);
     assertEquals(writeOption, options.getWriteOption());
     assertEquals(multi, options.isMulti());
     assertEquals(upsert, options.isUpsert());
     assertEquals(arrayFilters, options.getArrayFilters());
+    assertEquals(hint, options.getHint());
+    assertEquals(hintString, options.getHintString());
   }
 
   @Test
@@ -73,6 +91,8 @@ public class UpdateOptionsTest {
     assertEquals(def.isMulti(), options.isMulti());
     assertEquals(def.isUpsert(), options.isUpsert());
     assertEquals(def.getArrayFilters(), options.getArrayFilters());
+    assertEquals(def.getHint(), options.getHint());
+    assertEquals(def.getHintString(), options.getHintString());
   }
 
   @Test
@@ -82,17 +102,23 @@ public class UpdateOptionsTest {
     boolean multi = TestUtils.randomBoolean();
     boolean upsert = TestUtils.randomBoolean();
     JsonArray arrayFilters = new JsonArray().add(new JsonObject().put(TestUtils.randomAlphaString(5), TestUtils.randomAlphaString(5)));
+    JsonObject hint = new JsonObject().put(TestUtils.randomAlphaString(5), TestUtils.randomInt());
+    String hintString = TestUtils.randomAlphaString(12);
 
     options.setWriteOption(writeOption);
     options.setMulti(multi);
     options.setUpsert(upsert);
     options.setArrayFilters(arrayFilters);
+    options.setHint(hint);
+    options.setHintString(hintString);
 
     UpdateOptions copy = new UpdateOptions(options);
     assertEquals(options.getWriteOption(), copy.getWriteOption());
     assertEquals(options.isMulti(), copy.isMulti());
     assertEquals(options.isUpsert(), copy.isUpsert());
     assertEquals(options.getArrayFilters(), copy.getArrayFilters());
+    assertEquals(options.getHint(), copy.getHint());
+    assertEquals(options.getHintString(), copy.getHintString());
   }
 
   @Test
@@ -102,11 +128,15 @@ public class UpdateOptionsTest {
     boolean multi = TestUtils.randomBoolean();
     boolean upsert = TestUtils.randomBoolean();
     JsonArray arrayFilters = new JsonArray().add(new JsonObject().put(TestUtils.randomAlphaString(5), TestUtils.randomAlphaString(5)));
+    JsonObject hint = new JsonObject().put(TestUtils.randomAlphaString(5), TestUtils.randomInt());
+    String hintString = TestUtils.randomAlphaString(12);
 
     options.setWriteOption(writeOption);
     options.setMulti(multi);
     options.setUpsert(upsert);
     options.setArrayFilters(arrayFilters);
+    options.setHint(hint);
+    options.setHintString(hintString);
 
     assertEquals(options, new UpdateOptions(options.toJson()));
   }


### PR DESCRIPTION
I encountered an inefficient collection index selection in a bulk update operation in MongoDB by default. The only way to change the index selection is to specify a `hint` in UpdateOptions.

The changes provided by this PR:
- Add hint support for all bulk operations and other methods with `UpdateOptions`.
- Remove broken links to documentation in `README.adoc`
- Remove `slf4j-api` dependency due to comment.
- Update `testcontainers` version to latest (1.15.2 is incompatible with a M1 chip)