### PR TITLE
Fix #280: Avoid NullPointerException in BulkOperation Constructor

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/BulkOperation.java
+++ b/src/main/java/io/vertx/ext/mongo/BulkOperation.java
@@ -58,8 +58,8 @@ public class BulkOperation {
     type = typeValue != null ? BulkOperationType.valueOf(typeValue.toUpperCase()): null;
     filter = json.getJsonObject("filter");
     document = json.getJsonObject("document");
-    upsert = json.containsKey("upsert") ? json.getBoolean("upsert") : DEFAULT_UPSERT;
-    multi = json.containsKey("multi") ? json.getBoolean("multi") : DEFAULT_MULTI;
+    upsert = json.getBoolean("upsert", DEFAULT_UPSERT);
+    multi = json.getBoolean("multi", DEFAULT_MULTI);
     hint = json.getJsonObject("hint");
     hintString = json.getString("hintString");
     collation = json.getJsonObject("collation") != null ? new CollationOptions(json.getJsonObject("collation")) : null;

--- a/src/main/java/io/vertx/ext/mongo/BulkOperation.java
+++ b/src/main/java/io/vertx/ext/mongo/BulkOperation.java
@@ -58,8 +58,8 @@ public class BulkOperation {
     type = typeValue != null ? BulkOperationType.valueOf(typeValue.toUpperCase()): null;
     filter = json.getJsonObject("filter");
     document = json.getJsonObject("document");
-    upsert = json.containsKey("upsert") : json.getBoolean("upsert") : DEFAULT_UPSERT;
-    multi = json.containsKey("multi") : json.getBoolean("multi") : DEFAULT_MULTI;
+    upsert = json.containsKey("upsert") ? json.getBoolean("upsert") : DEFAULT_UPSERT;
+    multi = json.containsKey("multi") ? json.getBoolean("multi") : DEFAULT_MULTI;
     hint = json.getJsonObject("hint");
     hintString = json.getString("hintString");
     collation = json.getJsonObject("collation") != null ? new CollationOptions(json.getJsonObject("collation")) : null;

--- a/src/main/java/io/vertx/ext/mongo/BulkOperation.java
+++ b/src/main/java/io/vertx/ext/mongo/BulkOperation.java
@@ -58,8 +58,8 @@ public class BulkOperation {
     type = typeValue != null ? BulkOperationType.valueOf(typeValue.toUpperCase()): null;
     filter = json.getJsonObject("filter");
     document = json.getJsonObject("document");
-    upsert = json.getBoolean("upsert");
-    multi = json.getBoolean("multi");
+    upsert = json.containsKey("upsert") : json.getBoolean("upsert") : DEFAULT_UPSERT;
+    multi = json.containsKey("multi") : json.getBoolean("multi") : DEFAULT_MULTI;
     hint = json.getJsonObject("hint");
     hintString = json.getString("hintString");
     collation = json.getJsonObject("collation") != null ? new CollationOptions(json.getJsonObject("collation")) : null;


### PR DESCRIPTION
Motivation:

This allows caller to send an empty JsonObject and later set only the needed fields and leave others at default.
Fix #280 
