### PR TITLE
Add inserted ids in bulk write response

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/MongoClientBulkWriteResult.java
+++ b/src/main/java/io/vertx/ext/mongo/MongoClientBulkWriteResult.java
@@ -42,6 +42,11 @@ public class MongoClientBulkWriteResult {
   public static final String UPSERTS = "upserts";
 
   /**
+   * Constant to be used when storing and retrieving Json for insert information.
+   */
+  public static final String INSERTS = "inserts";
+
+  /**
    * Constant to be used when storing and retrieving Json for ID of upsert information.
    */
   public static final String ID = "_id";
@@ -76,6 +81,7 @@ public class MongoClientBulkWriteResult {
   private long deletedCount;
   private long modifiedCount;
   private List<JsonObject> upserts;
+  private List<JsonObject> inserts;
 
   /**
    * Default constructor
@@ -89,7 +95,7 @@ public class MongoClientBulkWriteResult {
 
   /**
    * Constructor to specify the result of the bulk write operation.
-   * 
+   *
    * @param insertedCount
    *          the number of inserted documents
    * @param matchedCount
@@ -100,19 +106,22 @@ public class MongoClientBulkWriteResult {
    *          the number of modified documents
    * @param upserts
    *          the list of upserted items
+   * @param inserts
+   *          the list of inserted items
    */
   public MongoClientBulkWriteResult(long insertedCount, long matchedCount, long deletedCount, long modifiedCount,
-      List<JsonObject> upserts) {
+      List<JsonObject> upserts, List<JsonObject> inserts) {
     this.insertedCount = insertedCount;
     this.matchedCount = matchedCount;
     this.deletedCount = deletedCount;
     this.modifiedCount = modifiedCount;
     this.upserts = upserts;
+    this.inserts = inserts;
   }
 
   /**
    * Copy constructor
-   * 
+   *
    * @param other
    */
   public MongoClientBulkWriteResult(MongoClientBulkWriteResult other) {
@@ -124,11 +133,15 @@ public class MongoClientBulkWriteResult {
       this.upserts = other.upserts.stream().map(JsonObject::copy).collect(Collectors.toList());
     } else
       this.upserts = null;
+    if (other.inserts != null) {
+      this.inserts = other.inserts.stream().map(JsonObject::copy).collect(Collectors.toList());
+    } else
+      this.inserts = null;
   }
 
   /**
    * Constructor from JSON
-   * 
+   *
    * @param mongoClientBulkWriteResultJson
    */
   public MongoClientBulkWriteResult(JsonObject mongoClientBulkWriteResultJson) {
@@ -140,11 +153,15 @@ public class MongoClientBulkWriteResult {
     if (upsertArray != null)
       this.upserts = upsertArray.stream().filter(object -> object instanceof JsonObject)
           .map(object -> (JsonObject) object).collect(Collectors.toList());
+    JsonArray insertArray = mongoClientBulkWriteResultJson.getJsonArray(INSERTS);
+    if (insertArray != null)
+      this.inserts = insertArray.stream().filter(object -> object instanceof JsonObject)
+        .map(object -> (JsonObject) object).collect(Collectors.toList());
   }
 
   /**
    * Convert to JSON
-   * 
+   *
    * @return the JSON
    */
   public JsonObject toJson() {
@@ -165,12 +182,15 @@ public class MongoClientBulkWriteResult {
     if (upserts != null) {
       mongoClientBulkWriteResultJson.put(UPSERTS, new JsonArray(upserts));
     }
+    if (inserts != null) {
+      mongoClientBulkWriteResultJson.put(INSERTS, new JsonArray(inserts));
+    }
     return mongoClientBulkWriteResultJson;
   }
 
   /**
    * Returns the number of inserted documents
-   * 
+   *
    * @return the inserted documents
    */
   public long getInsertedCount() {
@@ -179,7 +199,7 @@ public class MongoClientBulkWriteResult {
 
   /**
    * Returns the number of matched documents
-   * 
+   *
    * @return the matched documents
    */
   public long getMatchedCount() {
@@ -188,7 +208,7 @@ public class MongoClientBulkWriteResult {
 
   /**
    * Returns the number of deleted documents
-   * 
+   *
    * @return the deleted documents
    */
   public long getDeletedCount() {
@@ -197,7 +217,7 @@ public class MongoClientBulkWriteResult {
 
   /**
    * Returns the number of modified documents
-   * 
+   *
    * @return the modified documents
    */
   public long getModifiedCount() {
@@ -207,12 +227,25 @@ public class MongoClientBulkWriteResult {
   /**
    * An unmodifiable list of upsert data. Each entry has the index of the request that lead to the upsert, and the
    * generated ID of the upsert.
-   * 
+   *
    * @return an unmodifiable list of upsert info
    */
   public List<JsonObject> getUpserts() {
     if (upserts != null)
       return Collections.unmodifiableList(upserts);
+    else
+      return null;
+  }
+
+  /**
+   * An unmodifiable list of inserts data. Each entry has the index of the request that lead to the insert, and the
+   * generated ID of the insert.
+   *
+   * @return an unmodifiable list of insert info
+   */
+  public List<JsonObject> getInserts() {
+    if (inserts != null)
+      return Collections.unmodifiableList(inserts);
     else
       return null;
   }
@@ -226,6 +259,7 @@ public class MongoClientBulkWriteResult {
     result = prime * result + (int) (matchedCount ^ (matchedCount >>> 32));
     result = prime * result + (int) (modifiedCount ^ (modifiedCount >>> 32));
     result = prime * result + ((upserts == null) ? 0 : upserts.hashCode());
+    result = prime * result + ((inserts == null) ? 0 : inserts.hashCode());
     return result;
   }
 
@@ -250,6 +284,11 @@ public class MongoClientBulkWriteResult {
       if (other.upserts != null)
         return false;
     } else if (!upserts.equals(other.upserts))
+      return false;
+    if (inserts == null) {
+      if (other.inserts != null)
+        return false;
+    } else if (!inserts.equals(other.inserts))
       return false;
     return true;
   }

--- a/src/test/java/io/vertx/ext/mongo/MongoClientBulkWriteResultTest.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientBulkWriteResultTest.java
@@ -25,8 +25,8 @@ public class MongoClientBulkWriteResultTest {
     long randomModified = TestUtils.randomLong();
     long randomInserted = TestUtils.randomLong();
     long randomDeleted = TestUtils.randomLong();
-    List<JsonObject> upserts = randomUpsertIds();
-    List<JsonObject> inserts = randomInsertIds();
+    List<JsonObject> upserts = randomBulkWriteResultIds();
+    List<JsonObject> inserts = randomBulkWriteResultIds();
 
     MongoClientBulkWriteResult mongoClientBulkWriteResult = new MongoClientBulkWriteResult(randomInserted,
         randomMatched, randomDeleted, randomModified, upserts, inserts);
@@ -53,7 +53,7 @@ public class MongoClientBulkWriteResultTest {
   @Test
   public void testCopyMongoClientBulkWriteResult() {
     MongoClientBulkWriteResult mongoClientBulkWriteResultOrigin = new MongoClientBulkWriteResult(TestUtils.randomLong(),
-        TestUtils.randomLong(), TestUtils.randomLong(), TestUtils.randomLong(), randomUpsertIds(), randomInsertIds());
+        TestUtils.randomLong(), TestUtils.randomLong(), TestUtils.randomLong(), randomBulkWriteResultIds(), randomBulkWriteResultIds());
 
     MongoClientBulkWriteResult mongoClientBulkWriteResultCopy = new MongoClientBulkWriteResult(
         mongoClientBulkWriteResultOrigin);
@@ -131,8 +131,8 @@ public class MongoClientBulkWriteResultTest {
     long randomModified = TestUtils.randomLong();
     long randomInserted = TestUtils.randomLong();
     long randomDeleted = TestUtils.randomLong();
-    List<JsonObject> upserts = randomUpsertIds();
-    List<JsonObject> inserts = randomInsertIds();
+    List<JsonObject> upserts = randomBulkWriteResultIds();
+    List<JsonObject> inserts = randomBulkWriteResultIds();
 
     MongoClientBulkWriteResult mongoClientBulkWriteResult1 = new MongoClientBulkWriteResult(randomInserted,
         randomMatched, randomDeleted, randomModified, upserts, inserts);
@@ -145,9 +145,9 @@ public class MongoClientBulkWriteResultTest {
 
   private void logicallyUnequal() {
     MongoClientBulkWriteResult mongoClientBulkWriteResult1 = new MongoClientBulkWriteResult(123, 456, 789, 135,
-        randomUpsertIds(), randomInsertIds());
+      randomBulkWriteResultIds(), randomBulkWriteResultIds());
     MongoClientBulkWriteResult mongoClientBulkWriteResult2 = new MongoClientBulkWriteResult(456, 789, 135, 123,
-        randomUpsertIds(), randomInsertIds());
+      randomBulkWriteResultIds(), randomBulkWriteResultIds());
 
     assertFalse(mongoClientBulkWriteResult1.equals(mongoClientBulkWriteResult2));
     assertFalse(mongoClientBulkWriteResult2.equals(mongoClientBulkWriteResult1));
@@ -160,26 +160,17 @@ public class MongoClientBulkWriteResultTest {
     mongoClientBulkWriteResultJson.put(MongoClientBulkWriteResult.INSERTED_COUNT, TestUtils.randomLong());
     mongoClientBulkWriteResultJson.put(MongoClientBulkWriteResult.MATCHED_COUNT, TestUtils.randomLong());
     mongoClientBulkWriteResultJson.put(MongoClientBulkWriteResult.MODIFIED_COUNT, TestUtils.randomLong());
-    mongoClientBulkWriteResultJson.put(MongoClientBulkWriteResult.UPSERTS, randomUpsertIds());
-    mongoClientBulkWriteResultJson.put(MongoClientBulkWriteResult.INSERTS, randomInsertIds());
+    mongoClientBulkWriteResultJson.put(MongoClientBulkWriteResult.UPSERTS, randomBulkWriteResultIds());
+    mongoClientBulkWriteResultJson.put(MongoClientBulkWriteResult.INSERTS, randomBulkWriteResultIds());
 
     return mongoClientBulkWriteResultJson;
   }
 
-  private List<JsonObject> randomUpsertIds() {
-    return Arrays.asList(randomUpsertId(), randomUpsertId());
+  private List<JsonObject> randomBulkWriteResultIds() {
+    return Arrays.asList(randomBulkWriteResultId(), randomBulkWriteResultId());
   }
 
-  private List<JsonObject> randomInsertIds() {
-    return Arrays.asList(randomInsertId(), randomInsertId());
-  }
-
-  private JsonObject randomUpsertId() {
-    return new JsonObject().put(MongoClientBulkWriteResult.ID, TestUtils.randomAlphaString(23))
-        .put(MongoClientBulkWriteResult.INDEX, TestUtils.randomInt());
-  }
-
-  private JsonObject randomInsertId() {
+  private JsonObject randomBulkWriteResultId() {
     return new JsonObject().put(MongoClientBulkWriteResult.ID, TestUtils.randomAlphaString(23))
       .put(MongoClientBulkWriteResult.INDEX, TestUtils.randomInt());
   }

--- a/src/test/java/io/vertx/ext/mongo/MongoClientBulkWriteResultTest.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientBulkWriteResultTest.java
@@ -26,15 +26,17 @@ public class MongoClientBulkWriteResultTest {
     long randomInserted = TestUtils.randomLong();
     long randomDeleted = TestUtils.randomLong();
     List<JsonObject> upserts = randomUpsertIds();
+    List<JsonObject> inserts = randomInsertIds();
 
     MongoClientBulkWriteResult mongoClientBulkWriteResult = new MongoClientBulkWriteResult(randomInserted,
-        randomMatched, randomDeleted, randomModified, upserts);
+        randomMatched, randomDeleted, randomModified, upserts, inserts);
 
     assertEquals(randomMatched, mongoClientBulkWriteResult.getMatchedCount());
     assertEquals(randomModified, mongoClientBulkWriteResult.getModifiedCount());
     assertEquals(randomInserted, mongoClientBulkWriteResult.getInsertedCount());
     assertEquals(randomDeleted, mongoClientBulkWriteResult.getDeletedCount());
     assertEquals(upserts, mongoClientBulkWriteResult.getUpserts());
+    assertEquals(inserts, mongoClientBulkWriteResult.getInserts());
   }
 
   @Test
@@ -51,7 +53,7 @@ public class MongoClientBulkWriteResultTest {
   @Test
   public void testCopyMongoClientBulkWriteResult() {
     MongoClientBulkWriteResult mongoClientBulkWriteResultOrigin = new MongoClientBulkWriteResult(TestUtils.randomLong(),
-        TestUtils.randomLong(), TestUtils.randomLong(), TestUtils.randomLong(), randomUpsertIds());
+        TestUtils.randomLong(), TestUtils.randomLong(), TestUtils.randomLong(), randomUpsertIds(), randomInsertIds());
 
     MongoClientBulkWriteResult mongoClientBulkWriteResultCopy = new MongoClientBulkWriteResult(
         mongoClientBulkWriteResultOrigin);
@@ -63,6 +65,7 @@ public class MongoClientBulkWriteResultTest {
         mongoClientBulkWriteResultOrigin.getInsertedCount());
     assertEquals(mongoClientBulkWriteResultCopy.getDeletedCount(), mongoClientBulkWriteResultOrigin.getDeletedCount());
     assertEquals(mongoClientBulkWriteResultCopy.getUpserts(), mongoClientBulkWriteResultOrigin.getUpserts());
+    assertEquals(mongoClientBulkWriteResultCopy.getInserts(), mongoClientBulkWriteResultOrigin.getInserts());
   }
 
   @Test
@@ -82,6 +85,7 @@ public class MongoClientBulkWriteResultTest {
     assertEquals(MongoClientBulkWriteResult.DEFAULT_INSERTED_COUNT, mongoClientBulkWriteResult.getInsertedCount());
     assertEquals(MongoClientBulkWriteResult.DEFAULT_DELETED_COUNT, mongoClientBulkWriteResult.getDeletedCount());
     assertNull(mongoClientBulkWriteResult.getUpserts());
+    assertNull(mongoClientBulkWriteResult.getInserts());
   }
 
   private void properJson() {
@@ -100,6 +104,9 @@ public class MongoClientBulkWriteResultTest {
 
     JsonArray upserts = mongoClientBulkWriteResultJson.getJsonArray(MongoClientBulkWriteResult.UPSERTS, null);
     assertEquals(upserts != null ? upserts.getList() : null, mongoClientBulkWriteResult.getUpserts());
+
+    JsonArray inserts = mongoClientBulkWriteResultJson.getJsonArray(MongoClientBulkWriteResult.INSERTS, null);
+    assertEquals(inserts != null ? inserts.getList() : null, mongoClientBulkWriteResult.getInserts());
 
   }
 
@@ -125,11 +132,12 @@ public class MongoClientBulkWriteResultTest {
     long randomInserted = TestUtils.randomLong();
     long randomDeleted = TestUtils.randomLong();
     List<JsonObject> upserts = randomUpsertIds();
+    List<JsonObject> inserts = randomInsertIds();
 
     MongoClientBulkWriteResult mongoClientBulkWriteResult1 = new MongoClientBulkWriteResult(randomInserted,
-        randomMatched, randomDeleted, randomModified, upserts);
+        randomMatched, randomDeleted, randomModified, upserts, inserts);
     MongoClientBulkWriteResult mongoClientBulkWriteResult2 = new MongoClientBulkWriteResult(randomInserted,
-        randomMatched, randomDeleted, randomModified, upserts);
+        randomMatched, randomDeleted, randomModified, upserts, inserts);
 
     assertTrue(mongoClientBulkWriteResult1.equals(mongoClientBulkWriteResult2));
     assertTrue(mongoClientBulkWriteResult2.equals(mongoClientBulkWriteResult1));
@@ -137,9 +145,9 @@ public class MongoClientBulkWriteResultTest {
 
   private void logicallyUnequal() {
     MongoClientBulkWriteResult mongoClientBulkWriteResult1 = new MongoClientBulkWriteResult(123, 456, 789, 135,
-        randomUpsertIds());
+        randomUpsertIds(), randomInsertIds());
     MongoClientBulkWriteResult mongoClientBulkWriteResult2 = new MongoClientBulkWriteResult(456, 789, 135, 123,
-        randomUpsertIds());
+        randomUpsertIds(), randomInsertIds());
 
     assertFalse(mongoClientBulkWriteResult1.equals(mongoClientBulkWriteResult2));
     assertFalse(mongoClientBulkWriteResult2.equals(mongoClientBulkWriteResult1));
@@ -153,6 +161,7 @@ public class MongoClientBulkWriteResultTest {
     mongoClientBulkWriteResultJson.put(MongoClientBulkWriteResult.MATCHED_COUNT, TestUtils.randomLong());
     mongoClientBulkWriteResultJson.put(MongoClientBulkWriteResult.MODIFIED_COUNT, TestUtils.randomLong());
     mongoClientBulkWriteResultJson.put(MongoClientBulkWriteResult.UPSERTS, randomUpsertIds());
+    mongoClientBulkWriteResultJson.put(MongoClientBulkWriteResult.INSERTS, randomInsertIds());
 
     return mongoClientBulkWriteResultJson;
   }
@@ -161,8 +170,17 @@ public class MongoClientBulkWriteResultTest {
     return Arrays.asList(randomUpsertId(), randomUpsertId());
   }
 
+  private List<JsonObject> randomInsertIds() {
+    return Arrays.asList(randomInsertId(), randomInsertId());
+  }
+
   private JsonObject randomUpsertId() {
     return new JsonObject().put(MongoClientBulkWriteResult.ID, TestUtils.randomAlphaString(23))
         .put(MongoClientBulkWriteResult.INDEX, TestUtils.randomInt());
+  }
+
+  private JsonObject randomInsertId() {
+    return new JsonObject().put(MongoClientBulkWriteResult.ID, TestUtils.randomAlphaString(23))
+      .put(MongoClientBulkWriteResult.INDEX, TestUtils.randomInt());
   }
 }

--- a/src/test/java/io/vertx/ext/mongo/impl/UtilsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/UtilsTest.java
@@ -16,17 +16,16 @@ import static org.junit.Assert.assertNull;
 /**
  * @author <a href="mailto:nikolakofistariji@gmail.com">Nikola Kosanovic</a>
  */
-public class UtilsTest
-{
+public class UtilsTest {
   @Test
-  public void noAcknowledgedTest() {
+  public void testUnacknowledgedBulkWriteResultTest() {
     BulkWriteResult writeResult = stubBulkWriteResult(false);
     MongoClientBulkWriteResult result = Utils.toMongoClientBulkWriteResult(writeResult);
     assertNull(result);
   }
 
   @Test
-  public void mapperTest() {
+  public void BulkWriteResultMapperTest() {
     BulkWriteResult writeResult = stubBulkWriteResult(true);
     MongoClientBulkWriteResult result = Utils.toMongoClientBulkWriteResult(writeResult);
     assertEquals(result.getDeletedCount(), writeResult.getDeletedCount());
@@ -46,8 +45,7 @@ public class UtilsTest
     String randomInsertId = TestUtils.randomAlphaString(32);
     String randomUpsertId = TestUtils.randomAlphaString(32);
 
-    return new BulkWriteResult()
-    {
+    return new BulkWriteResult() {
       @Override
       public boolean wasAcknowledged() {
         return wasAcknowledged;

--- a/src/test/java/io/vertx/ext/mongo/impl/UtilsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/UtilsTest.java
@@ -1,0 +1,2 @@
+package io.vertx.ext.mongo.impl;public class UtilsTest {
+}

--- a/src/test/java/io/vertx/ext/mongo/impl/UtilsTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/UtilsTest.java
@@ -1,2 +1,87 @@
-package io.vertx.ext.mongo.impl;public class UtilsTest {
+package io.vertx.ext.mongo.impl;
+
+import com.mongodb.bulk.BulkWriteInsert;
+import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.bulk.BulkWriteUpsert;
+import io.vertx.ext.mongo.MongoClientBulkWriteResult;
+import io.vertx.test.core.TestUtils;
+import org.bson.BsonString;
+import org.junit.Test;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author <a href="mailto:nikolakofistariji@gmail.com">Nikola Kosanovic</a>
+ */
+public class UtilsTest
+{
+  @Test
+  public void noAcknowledgedTest() {
+    BulkWriteResult writeResult = stubBulkWriteResult(false);
+    MongoClientBulkWriteResult result = Utils.toMongoClientBulkWriteResult(writeResult);
+    assertNull(result);
+  }
+
+  @Test
+  public void mapperTest() {
+    BulkWriteResult writeResult = stubBulkWriteResult(true);
+    MongoClientBulkWriteResult result = Utils.toMongoClientBulkWriteResult(writeResult);
+    assertEquals(result.getDeletedCount(), writeResult.getDeletedCount());
+    assertEquals(result.getInsertedCount(), writeResult.getInsertedCount());
+    assertEquals(result.getMatchedCount(), writeResult.getMatchedCount());
+    assertEquals(result.getModifiedCount(), writeResult.getModifiedCount());
+
+    assertEquals(result.getUpserts().get(0).getInteger(MongoClientBulkWriteResult.INDEX), Integer.valueOf(writeResult.getUpserts().get(0).getIndex()));
+    assertEquals(result.getUpserts().get(0).getString(MongoClientBulkWriteResult.ID), writeResult.getUpserts().get(0).getId().asString().getValue());
+
+    assertEquals(result.getInserts().get(0).getInteger(MongoClientBulkWriteResult.INDEX), Integer.valueOf(writeResult.getInserts().get(0).getIndex()));
+    assertEquals(result.getInserts().get(0).getString(MongoClientBulkWriteResult.ID), writeResult.getInserts().get(0).getId().asString().getValue());
+  }
+
+  BulkWriteResult stubBulkWriteResult(boolean wasAcknowledged) {
+    int counter = TestUtils.randomInt();
+    String randomInsertId = TestUtils.randomAlphaString(32);
+    String randomUpsertId = TestUtils.randomAlphaString(32);
+
+    return new BulkWriteResult()
+    {
+      @Override
+      public boolean wasAcknowledged() {
+        return wasAcknowledged;
+      }
+
+      @Override
+      public int getInsertedCount() {
+        return counter;
+      }
+
+      @Override
+      public int getMatchedCount() {
+        return counter;
+      }
+
+      @Override
+      public int getDeletedCount() {
+        return counter;
+      }
+
+      @Override
+      public int getModifiedCount() {
+        return counter;
+      }
+
+      @Override
+      public List<BulkWriteInsert> getInserts() {
+        return Collections.singletonList(new BulkWriteInsert(0, new BsonString(randomInsertId)));
+      }
+
+      @Override
+      public List<BulkWriteUpsert> getUpserts() {
+        return Collections.singletonList(new BulkWriteUpsert(0, new BsonString(randomUpsertId)));
+      }
+    };
+  }
 }


### PR DESCRIPTION
This pull request is created as fix for https://github.com/vert-x3/vertx-mongo-client/issues/284
