### PR TITLE
Fix #296 Compressors config didn't work

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -743,7 +743,11 @@ For more information on the format of the connection string please consult the d
   "trustAll" : false,                  // boolean
   "keyPath" : "key.pem",               // string
   "certPath" : "cert.pem",             // string
-  "caPath" : "ca.pem"                  // string
+  "caPath" : "ca.pem",                 // string
+
+  // Network compression Settings
+  "compressors"           : ["zstd", "snappy", "zlib"],  // string array
+  "zlibCompressionLevel"  : 6                            // int
 }
 ----
 
@@ -780,6 +784,8 @@ For more information on the format of the connection string please consult the d
 `keyPath`:: Set a path to a file that contains the client key that will be used to authenticate against the server when making SSL connections to mongo.
 `certPath`:: Set a path to a file that contains the certificate that will be used to authenticate against the server when making SSL connections to mongo.
 `caPath`:: Set a path to a file that contains a certificate that will be used as a source of trust when making SSL connections to mongo.
+`compressors`:: Sets the compression algorithm for network transmission. Valid values range from [`snappy`, `zlib`, `zstd`], the default value is `null` (meaning no compression). *NOTE* - When using the `snappy` or `zstd` compression algorithm, you must add explicit dependencies in your `pom.xml`.
+`zlibCompressionLevel`:: Sets the compression level for zlib. Valid values are between -1 and 9, the default value is -1 if zlib is enabled.
 
 
 NOTE: Most of the default values listed above use the default values of the MongoDB Java Driver.

--- a/src/test/java/io/vertx/ext/mongo/CompressorsConnectivityTest.java
+++ b/src/test/java/io/vertx/ext/mongo/CompressorsConnectivityTest.java
@@ -1,0 +1,50 @@
+package io.vertx.ext.mongo;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+import static io.vertx.ext.mongo.WriteOption.ACKNOWLEDGED;
+
+public class CompressorsConnectivityTest extends MongoTestBase {
+
+  private MongoClient mongoClient;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    JsonObject config = getConfig();
+    mongoClient = MongoClient.create(vertx, config);
+    CountDownLatch latch = new CountDownLatch(1);
+    dropCollections(mongoClient, latch);
+    awaitLatch(latch);
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    mongoClient.close();
+    super.tearDown();
+  }
+
+  @Test
+  public void testQueryWithZLibCompressOptions() {
+    JsonObject config = getConfig()
+      .put("compressors", new JsonArray().add("zlib"))
+      .put("zlibCompressionLevel", 6);
+
+    MongoClient mongoClient = MongoClient.create(vertx, config);
+    String collection = randomCollection();
+    mongoClient.createCollection(collection, onSuccess(res -> {
+      JsonObject doc = new JsonObject().put("compressor", "zlib");
+      mongoClient.insertWithOptions(collection, doc, ACKNOWLEDGED, onSuccess(id -> {
+        mongoClient.find(collection, new JsonObject(), onSuccess(r -> {
+          assertEquals("zlib", r.get(0).getString("compressor"));
+          testComplete();
+        }));
+      }));
+    }));
+    await();
+  }
+}

--- a/src/test/java/io/vertx/ext/mongo/impl/config/CompressorsSettingsParserTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/config/CompressorsSettingsParserTest.java
@@ -1,0 +1,59 @@
+package io.vertx.ext.mongo.impl.config;
+
+import com.mongodb.MongoCompressor;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class CompressorsSettingsParserTest {
+
+  private Vertx vertx;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void tearDown() {
+    vertx.close();
+  }
+
+  @Test
+  public void testCompressorsConnectionString() {
+    String connectionString = "mongodb://localhost:27017/?compressors=zstd,zlib&zlibCompressionLevel=1";
+    JsonObject config = new JsonObject()
+      .put("connection_string", connectionString);
+
+    MongoClientOptionsParser parser = new MongoClientOptionsParser(vertx, config);
+    List<MongoCompressor> compressorList = parser.settings().getCompressorList();
+    assertEquals("zstd", compressorList.get(0).getName());
+    assertEquals("zlib", compressorList.get(1).getName());
+    assertEquals(1, (int) compressorList.get(1).getPropertyNonNull(MongoCompressor.LEVEL, 0));
+    assertEquals(2, compressorList.size());
+  }
+
+  @Test
+  public void testCompressorsConfig() {
+    String connectionString = "mongodb://localhost:27017/?compressors=zstd,zlib&zlibCompressionLevel=1";
+    JsonObject config = new JsonObject()
+      .put("connection_string", connectionString)
+      .put("compressors", new JsonArray().add("snappy").add("zstd").add("zlib"))
+      .put("zlibCompressionLevel", 6);
+
+    MongoClientOptionsParser parser = new MongoClientOptionsParser(vertx, config);
+    List<MongoCompressor> compressorList = parser.settings().getCompressorList();
+    assertEquals("snappy", compressorList.get(0).getName());
+    assertEquals("zstd", compressorList.get(1).getName());
+    assertEquals("zlib", compressorList.get(2).getName());
+    assertEquals(6, (int) compressorList.get(2).getPropertyNonNull(MongoCompressor.LEVEL, 0));
+    assertEquals(3, compressorList.size());
+  }
+}

--- a/src/test/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParserTest.java
+++ b/src/test/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParserTest.java
@@ -1,14 +1,10 @@
 package io.vertx.ext.mongo.impl.config;
 
-import com.mongodb.MongoCompressor;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,36 +37,5 @@ public class MongoClientOptionsParserTest {
 
     MongoClientOptionsParser parser = new MongoClientOptionsParser(vertx, config);
     assertEquals("my_db", parser.database());
-  }
-
-  @Test
-  public void testCompressorsConnectionString() {
-    String connectionString = "mongodb://localhost:27017/?compressors=zstd,zlib&zlibCompressionLevel=1";
-    JsonObject config = new JsonObject()
-      .put("connection_string", connectionString);
-
-    MongoClientOptionsParser parser = new MongoClientOptionsParser(vertx, config);
-    List<MongoCompressor> compressorList = parser.settings().getCompressorList();
-    assertEquals("zstd", compressorList.get(0).getName());
-    assertEquals("zlib", compressorList.get(1).getName());
-    assertEquals(1, (int) compressorList.get(1).getPropertyNonNull(MongoCompressor.LEVEL, 0));
-    assertEquals(2, compressorList.size());
-  }
-
-  @Test
-  public void testCompressorsConfig() {
-    String connectionString = "mongodb://localhost:27017/?compressors=zstd,zlib&zlibCompressionLevel=1";
-    JsonObject config = new JsonObject()
-      .put("connection_string", connectionString)
-      .put("compressors", new JsonArray().add("snappy").add("zstd").add("zlib"))
-      .put("zlibCompressionLevel", 6);
-
-    MongoClientOptionsParser parser = new MongoClientOptionsParser(vertx, config);
-    List<MongoCompressor> compressorList = parser.settings().getCompressorList();
-    assertEquals("snappy", compressorList.get(0).getName());
-    assertEquals("zstd", compressorList.get(1).getName());
-    assertEquals("zlib", compressorList.get(2).getName());
-    assertEquals(6, (int) compressorList.get(2).getPropertyNonNull(MongoCompressor.LEVEL, 0));
-    assertEquals(3, compressorList.size());
   }
 }


### PR DESCRIPTION
Motivation:

Fix #296: Compressors config didn't work

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
