### PR TITLE
Add feature to drop index with keys json used to create it

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -482,6 +482,15 @@ public interface MongoClient {
   Future<Void> dropIndex(String collection, String indexName);
 
   /**
+   * Drops the index given the keys used to create it.
+   *
+   * @param collection the collection
+   * @param key        the key(s) of the index to remove
+   * @return a future notified when complete
+   */
+  Future<Void> dropIndex(String collection, JsonObject key);
+
+  /**
    * Run an arbitrary MongoDB command.
    *
    * @param commandName   the name of the command

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -707,6 +707,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
   @Override
   public Future<JsonArray> listIndexes(String collection) {
     requireNonNull(collection, COLLECTION_CANNOT_BE_NULL);
+
     MongoCollection<JsonObject> coll = getCollection(collection);
     Promise<List<JsonObject>> promise = vertx.promise();
     coll.listIndexes(JsonObject.class).subscribe(new BufferingSubscriber<>(promise));
@@ -717,6 +718,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
   public Future<Void> dropIndex(String collection, String indexName) {
     requireNonNull(collection, COLLECTION_CANNOT_BE_NULL);
     requireNonNull(indexName, "indexName cannot be null");
+
     MongoCollection<JsonObject> coll = getCollection(collection);
     Promise<Void> promise = vertx.promise();
     coll.dropIndex(indexName).subscribe(new CompletionSubscriber<>(promise));
@@ -724,9 +726,21 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
   }
 
   @Override
+  public Future<Void> dropIndex(String collection, JsonObject key) {
+    requireNonNull(collection, COLLECTION_CANNOT_BE_NULL);
+    requireNonNull(key, FIELD_NAME_CANNOT_BE_NULL);
+
+    MongoCollection<JsonObject> coll = getCollection(collection);
+    Promise<Void> promise = vertx.promise();
+    coll.dropIndex(wrap(key)).subscribe(new CompletionSubscriber<>(promise));
+    return promise.future();
+  }
+
+  @Override
   public Future<@Nullable JsonObject> runCommand(String commandName, JsonObject command) {
     requireNonNull(commandName, "commandName cannot be null");
     requireNonNull(command, "command cannot be null");
+
     // The command name must be the first entry in the bson, so to ensure this we must recreate and add the command
     // name as first (JsonObject is internally ordered)
     JsonObject json = new JsonObject();

--- a/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientTestBase.java
@@ -176,6 +176,26 @@ public abstract class MongoClientTestBase extends MongoTestBase {
   }
 
   @Test
+  public void testCreateAndDropIndexWithJsonObject() {
+    String collection = randomCollection();
+    mongoClient.createCollection(collection).onComplete(onSuccess(res -> {
+      JsonObject key = JsonObject.of("field", 1);
+      mongoClient.createIndex(collection, key).onComplete(onSuccess(res2 -> {
+        mongoClient.dropIndex(collection, key).onComplete(onSuccess(res3 -> {
+          mongoClient.listIndexes(collection).onComplete(onSuccess(res4 -> {
+            long cnt = res4.stream()
+                .filter(o -> ((JsonObject) o).getJsonObject("key").containsKey("field"))
+                .count();
+            assertEquals(cnt, 0);
+            testComplete();
+          }));
+        }));
+      }));
+    }));
+    await();
+  }
+
+  @Test
   public void testRunCommand() throws Exception {
     JsonObject command = new JsonObject().put("isMaster", 1);
     mongoClient.runCommand("isMaster", command).onComplete(onSuccess(reply -> {


### PR DESCRIPTION
Motivation:

Add ability to drop index with keys json used to create it, no need to get keys from it.

Please check java driver document https://mongodb.github.io/mongo-java-driver/4.10/apidocs/mongodb-driver-reactivestreams/com/mongodb/reactivestreams/client/MongoCollection.html#dropIndex(org.bson.conversions.Bson) and mongodb document https://www.mongodb.com/docs/manual/reference/method/db.collection.dropIndex/

