### PR TITLE
Add support for read preference with run command.

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -1,6 +1,7 @@
 package io.vertx.ext.mongo;
 
 import com.mongodb.MongoClientSettings;
+import com.mongodb.ReadPreference;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Nullable;
@@ -491,13 +492,23 @@ public interface MongoClient {
   Future<Void> dropIndex(String collection, JsonObject key);
 
   /**
-   * Run an arbitrary MongoDB command.
+   * Run an arbitrary MongoDB command with read preference on primary.
    *
    * @param commandName   the name of the command
    * @param command       the command
    * @return a future notified with the result.
    */
   Future<@Nullable JsonObject> runCommand(String commandName, JsonObject command);
+
+  /**
+   * Run an arbitrary MongoDB command.
+   *
+   * @param commandName      the name of the command
+   * @param command          the command
+   * @param readPreference   the read preference
+   * @return a future notified with the result.
+   */
+  Future<@Nullable JsonObject> runCommand(String commandName, JsonObject command, ReadPreference readPreference);
 
   /**
    * Gets the distinct values of the specified field name.

--- a/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -508,6 +508,7 @@ public interface MongoClient {
    * @param readPreference   the read preference
    * @return a future notified with the result.
    */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Future<@Nullable JsonObject> runCommand(String commandName, JsonObject command, ReadPreference readPreference);
 
   /**

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.mongo.impl;
 
 import com.mongodb.MongoClientSettings;
+import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.model.*;
@@ -738,8 +739,13 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
 
   @Override
   public Future<@Nullable JsonObject> runCommand(String commandName, JsonObject command) {
+    return runCommand(commandName, command, ReadPreference.primary());
+  }
+
+  public Future<@Nullable JsonObject> runCommand(String commandName, JsonObject command, ReadPreference readPreference) {
     requireNonNull(commandName, "commandName cannot be null");
     requireNonNull(command, "command cannot be null");
+    requireNonNull(readPreference, "readPreference cannot be null");
 
     // The command name must be the first entry in the bson, so to ensure this we must recreate and add the command
     // name as first (JsonObject is internally ordered)
@@ -756,7 +762,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     });
 
     Promise<JsonObject> promise = vertx.promise();
-    holder.db.runCommand(wrap(json), JsonObject.class).subscribe(new SingleResultSubscriber<>(promise));
+    holder.db.runCommand(wrap(json), readPreference, JsonObject.class).subscribe(new SingleResultSubscriber<>(promise));
     return promise.future();
   }
 

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -742,6 +742,8 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     return runCommand(commandName, command, ReadPreference.primary());
   }
 
+  @Override
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   public Future<@Nullable JsonObject> runCommand(String commandName, JsonObject command, ReadPreference readPreference) {
     requireNonNull(commandName, "commandName cannot be null");
     requireNonNull(command, "command cannot be null");


### PR DESCRIPTION
Motivation:

Adding support for read preference on run command. Some hard operations like aggregate in some scenarios is needed to run against others nodes on Mongo cluster.

