### PR TITLE
Deep handle mongo ID_FIELD when useObjectId

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -209,7 +209,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(options, OPTIONS_CANNOT_BE_NULL);
 
     MongoCollection<JsonObject> coll = getCollection(collection, options.getWriteOption());
-    Bson bquery = wrap(encodeKeyWhenUseObjectId(query));
+    Bson bquery = wrap(deepEncodeKeyWhenUseObjectId(query));
     Bson bupdate = wrap(encodeKeyWhenUseObjectId(generateIdIfNeeded(query, update, options)));
 
     com.mongodb.client.model.UpdateOptions updateOptions = new com.mongodb.client.model.UpdateOptions().upsert(options.isUpsert());
@@ -248,7 +248,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(options, OPTIONS_CANNOT_BE_NULL);
 
     MongoCollection<JsonObject> coll = getCollection(collection, options.getWriteOption());
-    Bson bquery = wrap(encodeKeyWhenUseObjectId(query));
+    Bson bquery = wrap(deepEncodeKeyWhenUseObjectId(query));
     List<Bson> bpipeline = new ArrayList<>(pipeline.size());
     for (int i=0 ; i<pipeline.size() ; i++) {
       bpipeline.add(wrap(pipeline.getJsonObject(i)));
@@ -307,7 +307,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(options, OPTIONS_CANNOT_BE_NULL);
 
     MongoCollection<JsonObject> coll = getCollection(collection, options.getWriteOption());
-    Bson bquery = wrap(encodeKeyWhenUseObjectId(query));
+    Bson bquery = wrap(deepEncodeKeyWhenUseObjectId(query));
     com.mongodb.client.model.ReplaceOptions replaceOptions = new com.mongodb.client.model.ReplaceOptions().upsert(options.isUpsert());
     if (options.getHint() != null) {
       replaceOptions.hint(wrap(options.getHint()));
@@ -334,7 +334,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(query, QUERY_CANNOT_BE_NULL);
 
     Promise<List<JsonObject>> promise = vertx.promise();
-    doFind(collection, encodeKeyWhenUseObjectId(query), options)
+    doFind(collection, deepEncodeKeyWhenUseObjectId(query), options)
       .subscribe(new MappingAndBufferingSubscriber<>(this::decodeKeyWhenUseObjectId, promise));
     return promise.future();
   }
@@ -357,7 +357,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(collection, COLLECTION_CANNOT_BE_NULL);
     requireNonNull(query, QUERY_CANNOT_BE_NULL);
 
-    JsonObject encodedQuery = encodeKeyWhenUseObjectId(query);
+    JsonObject encodedQuery = deepEncodeKeyWhenUseObjectId(query);
 
     Bson bquery = wrap(encodedQuery);
     Bson bfields = wrap(fields);
@@ -379,7 +379,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(findOptions, FIND_OPTIONS_CANNOT_BE_NULL);
     requireNonNull(updateOptions, "update options cannot be null");
 
-    JsonObject encodedQuery = encodeKeyWhenUseObjectId(query);
+    JsonObject encodedQuery = deepEncodeKeyWhenUseObjectId(query);
 
     Bson bquery = wrap(encodedQuery);
     Bson bupdate = wrap(update);
@@ -430,7 +430,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(findOptions, FIND_OPTIONS_CANNOT_BE_NULL);
     requireNonNull(updateOptions, "update options cannot be null");
 
-    JsonObject encodedQuery = encodeKeyWhenUseObjectId(query);
+    JsonObject encodedQuery = deepEncodeKeyWhenUseObjectId(query);
 
     Bson bquery = wrap(encodedQuery);
     FindOneAndReplaceOptions foarOptions = new FindOneAndReplaceOptions();
@@ -472,7 +472,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(query, QUERY_CANNOT_BE_NULL);
     requireNonNull(findOptions, FIND_OPTIONS_CANNOT_BE_NULL);
 
-    JsonObject encodedQuery = encodeKeyWhenUseObjectId(query);
+    JsonObject encodedQuery = deepEncodeKeyWhenUseObjectId(query);
 
     Bson bquery = wrap(encodedQuery);
     FindOneAndDeleteOptions foadOptions = new FindOneAndDeleteOptions();
@@ -506,7 +506,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(collection, COLLECTION_CANNOT_BE_NULL);
     requireNonNull(query, QUERY_CANNOT_BE_NULL);
 
-    Bson bquery = wrap(encodeKeyWhenUseObjectId(query));
+    Bson bquery = wrap(deepEncodeKeyWhenUseObjectId(query));
     MongoCollection<JsonObject> coll = getCollection(collection);
     Promise<Long> promise = vertx.promise();
     Publisher<Long> countPublisher = countOptions != null
@@ -527,7 +527,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(query, QUERY_CANNOT_BE_NULL);
 
     MongoCollection<JsonObject> coll = getCollection(collection, writeOption);
-    Bson bquery = wrap(encodeKeyWhenUseObjectId(query));
+    Bson bquery = wrap(deepEncodeKeyWhenUseObjectId(query));
     Promise<DeleteResult> promise = vertx.promise();
     coll.deleteMany(bquery).subscribe(new SingleResultSubscriber<>(promise));
     return promise.future().map(Utils::toMongoClientDeleteResult);
@@ -544,7 +544,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(query, QUERY_CANNOT_BE_NULL);
 
     MongoCollection<JsonObject> coll = getCollection(collection, writeOption);
-    Bson bquery = wrap(encodeKeyWhenUseObjectId(query));
+    Bson bquery = wrap(deepEncodeKeyWhenUseObjectId(query));
     Promise<DeleteResult> promise = vertx.promise();
     coll.deleteOne(bquery).subscribe(new SingleResultSubscriber<>(promise));
     return promise.future().map(Utils::toMongoClientDeleteResult);
@@ -573,7 +573,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     for (BulkOperation bulkOperation : operations) {
       switch (bulkOperation.getType()) {
         case DELETE:
-          Bson bsonFilter = toBson(encodeKeyWhenUseObjectId(bulkOperation.getFilter()));
+          Bson bsonFilter = toBson(deepEncodeKeyWhenUseObjectId(bulkOperation.getFilter()));
           DeleteOptions deleteOptions = new DeleteOptions();
           if (bulkOperation.getHint() != null) {
             deleteOptions.hint(toBson(bulkOperation.getHint()));
@@ -591,7 +591,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
           }
           break;
         case INSERT:
-          result.add(new InsertOneModel<>(encodeKeyWhenUseObjectId(bulkOperation.getDocument())));
+          result.add(new InsertOneModel<>(deepEncodeKeyWhenUseObjectId(bulkOperation.getDocument())));
           break;
         case REPLACE:
           ReplaceOptions replaceOptions = new ReplaceOptions();
@@ -604,11 +604,11 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
           if (bulkOperation.getHintString() != null && !bulkOperation.getHintString().isEmpty()) {
             replaceOptions.hintString(bulkOperation.getHintString());
           }
-          result.add(new ReplaceOneModel<>(toBson(encodeKeyWhenUseObjectId(bulkOperation.getFilter())), bulkOperation.getDocument(),
+          result.add(new ReplaceOneModel<>(toBson(deepEncodeKeyWhenUseObjectId(bulkOperation.getFilter())), bulkOperation.getDocument(),
             replaceOptions.upsert(bulkOperation.isUpsert())));
           break;
         case UPDATE:
-          Bson filter = toBson(encodeKeyWhenUseObjectId(bulkOperation.getFilter()));
+          Bson filter = toBson(deepEncodeKeyWhenUseObjectId(bulkOperation.getFilter()));
           Bson document = toBson(encodeKeyWhenUseObjectId(bulkOperation.getDocument()));
           com.mongodb.client.model.UpdateOptions updateOptions = new com.mongodb.client.model.UpdateOptions()
             .upsert(bulkOperation.isUpsert());
@@ -874,7 +874,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     requireNonNull(fieldName, FIELD_NAME_CANNOT_BE_NULL);
     requireNonNull(query, QUERY_CANNOT_BE_NULL);
 
-    JsonObject encodedQuery = encodeKeyWhenUseObjectId(query);
+    JsonObject encodedQuery = deepEncodeKeyWhenUseObjectId(query);
 
     Bson bquery = wrap(encodedQuery);
 
@@ -907,16 +907,18 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     return aggregate;
   }
 
-  JsonArray encodeKeyWhenUseObjectId(JsonArray arr) {
+
+
+  JsonArray deepEncodeKeyWhenUseObjectId(JsonArray arr) {
     if(!useObjectId) return arr;
 
     JsonArray newArr = new JsonArray(new ArrayList<>(arr.size()));
 
     for (Object item : arr) {
       if (item instanceof JsonArray) {
-        newArr.add(encodeKeyWhenUseObjectId((JsonArray) item));
+        newArr.add(deepEncodeKeyWhenUseObjectId((JsonArray) item));
       } else if (item instanceof JsonObject) {
-        newArr.add(encodeKeyWhenUseObjectId((JsonObject) item));
+        newArr.add(deepEncodeKeyWhenUseObjectId((JsonObject) item));
       } else {
         newArr.add(item);
       }
@@ -926,7 +928,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     return newArr;
   }
 
-  JsonObject encodeKeyWhenUseObjectId(JsonObject json) {
+  JsonObject deepEncodeKeyWhenUseObjectId(JsonObject json) {
     if(!useObjectId) return json;
 
     JsonObject newJson = new JsonObject(new LinkedHashMap<>(json.size()));
@@ -939,9 +941,9 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
           && ObjectId.isValid((String) value)) {
         newJson.put(key, new JsonObject().put(JsonObjectCodec.OID_FIELD, value));
       } else if (value instanceof JsonObject) {
-        newJson.put(key, encodeKeyWhenUseObjectId((JsonObject) value));
+        newJson.put(key, deepEncodeKeyWhenUseObjectId((JsonObject) value));
       } else if (value instanceof JsonArray) {
-        newJson.put(key, encodeKeyWhenUseObjectId((JsonArray) value));
+        newJson.put(key, deepEncodeKeyWhenUseObjectId((JsonArray) value));
       } else {
         newJson.put(key, value);
       }
@@ -949,6 +951,18 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     }
 
     return newJson;
+  }
+
+  JsonObject encodeKeyWhenUseObjectId(JsonObject json) {
+    if (!useObjectId)
+      return json;
+
+    Object idString = json.getValue(ID_FIELD, null);
+    if (idString instanceof String && ObjectId.isValid((String) idString)) {
+      json.put(ID_FIELD, new JsonObject().put(JsonObjectCodec.OID_FIELD, idString));
+    }
+
+    return json;
   }
 
   private JsonObject decodeKeyWhenUseObjectId(JsonObject json) {
@@ -967,7 +981,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
 
   private FindPublisher<JsonObject> doFind(String collection, JsonObject query, FindOptions options) {
     MongoCollection<JsonObject> coll = getCollection(collection);
-    Bson bquery = wrap(encodeKeyWhenUseObjectId(query));
+    Bson bquery = wrap(deepEncodeKeyWhenUseObjectId(query));
     FindPublisher<JsonObject> find = coll.find(bquery, JsonObject.class);
     if (options.getLimit() != -1) {
       find.limit(options.getLimit());

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -908,7 +908,6 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
   }
 
 
-
   JsonArray deepEncodeKeyWhenUseObjectId(JsonArray arr) {
     if(!useObjectId) return arr;
 
@@ -917,12 +916,15 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
     for (Object item : arr) {
       if (item instanceof JsonArray) {
         newArr.add(deepEncodeKeyWhenUseObjectId((JsonArray) item));
+      } else if(item instanceof List) {
+        newArr.add(deepEncodeKeyWhenUseObjectId(new JsonArray((List) item)));
       } else if (item instanceof JsonObject) {
         newArr.add(deepEncodeKeyWhenUseObjectId((JsonObject) item));
+      } else if (item instanceof Map) {
+        newArr.add(deepEncodeKeyWhenUseObjectId(new JsonObject((Map) item)));
       } else {
         newArr.add(item);
       }
-      // we don't handle cases that value instanceof Map or List
     }
 
     return newArr;
@@ -942,12 +944,15 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
         newJson.put(key, new JsonObject().put(JsonObjectCodec.OID_FIELD, value));
       } else if (value instanceof JsonObject) {
         newJson.put(key, deepEncodeKeyWhenUseObjectId((JsonObject) value));
+      } else if (value instanceof Map) {
+        newJson.put(key, deepEncodeKeyWhenUseObjectId(new JsonObject((Map) value)));
       } else if (value instanceof JsonArray) {
         newJson.put(key, deepEncodeKeyWhenUseObjectId((JsonArray) value));
+      } else if (value instanceof List) {
+        newJson.put(key, deepEncodeKeyWhenUseObjectId(new JsonArray((List) value)));
       } else {
         newJson.put(key, value);
       }
-      // we don't handle cases that value instanceof Map or List
     }
 
     return newJson;

--- a/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/MongoClientImpl.java
@@ -591,7 +591,7 @@ public class MongoClientImpl implements io.vertx.ext.mongo.MongoClient, Closeabl
           }
           break;
         case INSERT:
-          result.add(new InsertOneModel<>(deepEncodeKeyWhenUseObjectId(bulkOperation.getDocument())));
+          result.add(new InsertOneModel<>(encodeKeyWhenUseObjectId(bulkOperation.getDocument())));
           break;
         case REPLACE:
           ReplaceOptions replaceOptions = new ReplaceOptions();

--- a/src/test/java/io/vertx/ext/mongo/MongoClientWithObjectIdTest.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoClientWithObjectIdTest.java
@@ -1,5 +1,6 @@
 package io.vertx.ext.mongo;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.bson.types.ObjectId;
 import org.junit.Test;
@@ -78,6 +79,32 @@ public class MongoClientWithObjectIdTest extends MongoClientTestBase {
   }
 
   @Test
+  public void testFindOneWithNestedQueryReturnsStringId() throws Exception {
+    String collection = randomCollection();
+    mongoClient.createCollection(collection).onComplete(onSuccess(res -> {
+      JsonObject orig = createDoc();
+      JsonObject doc = orig.copy();
+      String objectId = getObjectId(doc);
+      JsonObject query = JsonObject.of("$and", JsonArray.of(
+        JsonObject.of("foo", "bar"),
+        JsonObject.of("_id", objectId)));
+      mongoClient.insert(collection, doc).onComplete(onSuccess(id -> {
+        // no auto-generated objectId from mongo
+        assertNull(id);
+        mongoClient.findOne(collection, query, null).onComplete(onSuccess(obj -> {
+          assertTrue(obj.containsKey("_id"));
+          assertTrue(obj.getValue("_id") instanceof String);
+          obj.remove("_id");
+          // nested "_id" will not be modified when insert
+          assertEquals(orig, obj);
+          testComplete();
+        }));
+      }));
+    }));
+    await();
+  }
+
+  @Test
   public void testFindOneReturnsNothing() throws Exception {
     String collection = randomCollection();
     mongoClient.createCollection(collection).onComplete(onSuccess(res -> {
@@ -108,6 +135,35 @@ public class MongoClientWithObjectIdTest extends MongoClientTestBase {
           assertTrue(obj.containsKey("_id"));
           assertTrue(obj.getValue("_id") instanceof String);
           obj.remove("_id");
+          assertEquals(orig, obj);
+          testComplete();
+        }));
+      }));
+    }));
+    await();
+  }
+
+
+  @Test
+  public void testFindWithNestedQueryReturnsStringId() throws Exception {
+    String collection = randomCollection();
+    mongoClient.createCollection(collection).onComplete(onSuccess(res -> {
+      JsonObject orig = createDoc();
+      JsonObject doc = orig.copy();
+      String objectId = getObjectId(doc);
+      JsonObject query = JsonObject.of("$and", JsonArray.of(
+          JsonObject.of("foo", "bar"),
+          JsonObject.of("_id", objectId)));
+      mongoClient.insert(collection, doc).onComplete(onSuccess(id -> {
+        // no auto-generated objectId from mongo
+        assertNull(id);
+        mongoClient.find(collection, query).onComplete(onSuccess(list -> {
+          assertTrue(list.size() == 1);
+          JsonObject obj = list.get(0);
+          assertTrue(obj.containsKey("_id"));
+          assertTrue(obj.getValue("_id") instanceof String);
+          obj.remove("_id");
+          // nested "_id" will not be modified when insert
           assertEquals(orig, obj);
           testComplete();
         }));

--- a/src/test/java/io/vertx/ext/mongo/MongoTestBase.java
+++ b/src/test/java/io/vertx/ext/mongo/MongoTestBase.java
@@ -182,7 +182,14 @@ public abstract class MongoTestBase extends VertxTestBase {
         .put("myarr", new JsonArray()
           .add("blah")
           .add(true)
-          .add(312)));
+          .add(312)))
+      .put("nested_id1", new JsonObject()
+        .put("_id", new ObjectId().toHexString()))
+      .put("nested_id2", new JsonArray()
+        .add(new JsonObject()
+          .put("_id", new ObjectId().toHexString()))
+        .add(new JsonObject()
+          .put("_id", new ObjectId().toHexString())));
   }
 
   protected JsonObject createDoc(int num) {
@@ -208,6 +215,30 @@ public abstract class MongoTestBase extends VertxTestBase {
       .put("other", new JsonObject().put("quux", "flib")
       .put("myarr", new JsonArray().add("blah").add(true).add(312)))
       .put("longval", 123456789L).put("dblval", 1.23);
+  }
+
+  // WARN: try to getObjectId from doc will generate new objectId on doc if not exists
+  protected String getObjectId(JsonObject doc) {
+    Object idVal = doc.getValue("_id");
+
+    // auto generate when not exists
+    if(idVal == null) {
+      String _id = new ObjectId().toHexString();
+      doc.put("_id", JsonObject.of("$oid", _id));
+      return _id;
+    }
+
+    // return string
+    if(idVal instanceof String) {
+      return (String) idVal;
+    }
+
+    // return $oid from ObjectId object
+    if(idVal instanceof JsonObject) {
+      return ((JsonObject) idVal).getString("$oid");
+    }
+
+    return null;
   }
 
 }


### PR DESCRIPTION
Motivation:

If we give a query when "_id" field in a nested value like:

```json
{
   "$and":[
      {
         "_id":"an-id-field"
      },
      {
         "some":"other"
      }
   ]
}
```
then, the nested "_id" will not be encoded.
I added a deep version of this method for handling this, we should only need this in query or filter.

Please review this @tsegismont @vietj 👀 If this logic is acceptable, I will complete the test cases, thanks!
