### PR TITLE
Don't reuse Vert.x event loops with a native transport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
       <version>1.1.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-x86_64</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParser.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/config/MongoClientOptionsParser.java
@@ -92,9 +92,11 @@ public class MongoClientOptionsParser {
     //retryable settings
     applyRetryableSetting(options, connectionString, config);
 
-    options.transportSettings(TransportSettings.nettyBuilder()
-      .eventLoopGroup(((VertxInternal) vertx).nettyEventLoopGroup())
-      .build());
+    NettyTransportSettings.Builder nettyBuilder = TransportSettings.nettyBuilder();
+    if (!vertx.isNativeTransportEnabled()) {
+      nettyBuilder.eventLoopGroup(((VertxInternal) vertx).nettyEventLoopGroup());
+    }
+    options.transportSettings(nettyBuilder.build());
 
     this.settings = options.build();
   }

--- a/src/test/java/io/vertx/ext/mongo/tests/NativeTransportTest.java
+++ b/src/test/java/io/vertx/ext/mongo/tests/NativeTransportTest.java
@@ -1,0 +1,64 @@
+package io.vertx.ext.mongo.tests;
+
+import io.vertx.core.VertxBuilder;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.FindOptions;
+import io.vertx.ext.mongo.MongoClient;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+import static io.vertx.core.transport.Transport.EPOLL;
+
+public class NativeTransportTest extends MongoTestBase {
+
+  private MongoClient mongoClient;
+
+  @Override
+  protected VertxOptions getOptions() {
+    return super.getOptions().setPreferNativeTransport(true);
+  }
+
+  @Override
+  protected VertxBuilder createVertxBuilder(VertxOptions options) {
+    Assume.assumeTrue("EPOLL Transport not available", options.getPreferNativeTransport() && EPOLL.available());
+    return super.createVertxBuilder(options).withTransport(EPOLL);
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    JsonObject config = getConfig();
+    mongoClient = MongoClient.create(vertx, config);
+    CountDownLatch latch = new CountDownLatch(1);
+    dropCollections(mongoClient, latch);
+    awaitLatch(latch);
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    mongoClient.close();
+    super.tearDown();
+  }
+
+  @Test
+  public void testFind() {
+    int num = 10;
+    FindOptions options = new FindOptions();
+    String collection = randomCollection();
+    mongoClient.createCollection(collection).onComplete(onSuccess(res -> {
+      insertDocs(mongoClient, collection, num).onComplete(onSuccess(res2 -> {
+        mongoClient.findWithOptions(collection, new JsonObject(), options).onComplete(onSuccess(res3 -> {
+          this.assertEquals(num, res3.size());
+          for (JsonObject doc : res3) {
+            assertEquals(12, doc.size());
+          }
+          testComplete();
+        }));
+      }));
+    }));
+    await();
+  }
+}


### PR DESCRIPTION
See #322

Unfortunately, the Mongo driver Netty Transport settings expect a socket channel class instead of a channel factory. Consequently, to support the reuse of Vert.x event loops with a native transport, we'd have to inspect the transport implementation and lookup for socket channel class by name (and deal with ClassNotFoundException).

Until the Mongo driver accepts a channel factory in the transport settings, reuse of Vert.x event loops will be limited to the NIO transport.