### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,16 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>

--- a/src/main/java/examples/MongoClientExamples.java
+++ b/src/main/java/examples/MongoClientExamples.java
@@ -15,7 +15,6 @@
  */
 package examples;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Vertx;
 import io.vertx.core.file.AsyncFile;
 import io.vertx.core.json.JsonArray;

--- a/src/main/java/io/vertx/ext/mongo/impl/Utils.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/Utils.java
@@ -18,9 +18,6 @@ package io.vertx.ext.mongo.impl;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.MongoClientBulkWriteResult;
 import io.vertx.ext.mongo.MongoClientDeleteResult;
@@ -32,7 +29,6 @@ import org.bson.BsonValue;
 import org.bson.codecs.DecoderContext;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class Utils {


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

Use goal = spotless:apply to remove unused imports now.