### PR TITLE
ReadStream delivers more items than requested via fetch

### DIFF
--- a/src/main/java/io/vertx/ext/mongo/impl/PublisherAdapter.java
+++ b/src/main/java/io/vertx/ext/mongo/impl/PublisherAdapter.java
@@ -41,7 +41,8 @@ public class PublisherAdapter<T> implements ReadStream<T> {
   private Handler<Void> endHandler;
 
   private Subscriber subscriber;
-  private long demand;
+  // Buffers demand from pause/fetch calls that arrive before the subscriber is created
+  private long pendingDemand;
 
   public PublisherAdapter(Context context, Publisher<T> publisher, int batchSize) {
     Objects.requireNonNull(context, "context is null");
@@ -49,7 +50,7 @@ public class PublisherAdapter<T> implements ReadStream<T> {
     this.context = (ContextInternal) context;
     this.publisher = publisher;
     this.batchSize = batchSize;
-    this.demand = Long.MAX_VALUE;
+    this.pendingDemand = Long.MAX_VALUE;
   }
 
   @Override
@@ -72,13 +73,12 @@ public class PublisherAdapter<T> implements ReadStream<T> {
         handler = h;
         s = subscriber;
         subscriber = null;
-        demand = Long.MAX_VALUE;
+        pendingDemand = Long.MAX_VALUE;
       }
       if (s != null) {
         s.cancel();
       }
     } else {
-      long d;
       synchronized (this) {
         handler = h;
         s = subscriber;
@@ -87,9 +87,8 @@ public class PublisherAdapter<T> implements ReadStream<T> {
         }
         s = new Subscriber();
         subscriber = s;
-        d = demand;
-        if (d > 0L) {
-          s.fetch(d);
+        if (pendingDemand > 0L) {
+          s.fetch(pendingDemand);
         } else {
           s.pause();
         }
@@ -103,12 +102,13 @@ public class PublisherAdapter<T> implements ReadStream<T> {
   public ReadStream<T> pause() {
     Subscriber s;
     synchronized (this) {
-      demand = 0L;
       s = subscriber;
+      if (s == null) {
+        pendingDemand = 0L;
+        return this;
+      }
     }
-    if (s != null) {
-      s.pause();
-    }
+    s.pause();
     return this;
   }
 
@@ -118,26 +118,25 @@ public class PublisherAdapter<T> implements ReadStream<T> {
   }
 
   @Override
-  public synchronized ReadStream<T> fetch(long amount) {
+  public ReadStream<T> fetch(long amount) {
     if (amount < 0L) {
       throw new IllegalArgumentException();
     }
     if (amount == 0L) {
       return this;
     }
-    long d;
     Subscriber s;
     synchronized (this) {
-      demand += amount;
-      if (demand < 0L) {
-        demand = Long.MAX_VALUE;
-      }
-      d = demand;
       s = subscriber;
+      if (s == null) {
+        pendingDemand += amount;
+        if (pendingDemand < 0L) {
+          pendingDemand = Long.MAX_VALUE;
+        }
+        return this;
+      }
     }
-    if (s != null) {
-      s.fetch(d);
-    }
+    s.fetch(amount);
     return this;
   }
 

--- a/src/test/java/io/vertx/ext/mongo/tests/impl/PublisherAdapterTest.java
+++ b/src/test/java/io/vertx/ext/mongo/tests/impl/PublisherAdapterTest.java
@@ -120,6 +120,36 @@ public class PublisherAdapterTest {
   }
 
   @Test
+  public void testFetchOneByOneDeliversExactDemand() throws Exception {
+    int totalDocs = 20;
+    int fetchCount = 4;
+    MyPublisher<Integer> publisher = new MyPublisher<>();
+    PublisherAdapter<Integer> adapter = new PublisherAdapter<>(context, publisher, 256);
+    adapter.pause();
+    AtomicInteger received = new AtomicInteger();
+    AtomicInteger fetched = new AtomicInteger();
+    CountDownLatch latch = new CountDownLatch(1);
+    adapter.handler(item -> {
+      int r = received.incrementAndGet();
+      if (fetched.get() < fetchCount) {
+        fetched.incrementAndGet();
+        adapter.fetch(1);
+      }
+      if (r >= fetchCount) {
+        latch.countDown();
+      }
+    });
+    for (int i = 0; i < totalDocs; i++) {
+      publisher.subscriber.onNext(i);
+    }
+    fetched.incrementAndGet();
+    adapter.fetch(1);
+    assertTrue(latch.await(20, TimeUnit.SECONDS));
+    Thread.sleep(200);
+    assertEquals(fetchCount, received.get());
+  }
+
+  @Test
   public void testUnsubscribe() throws Exception {
     MyPublisher<Integer> publisher = new MyPublisher<>();
     PublisherAdapter<Integer> adapter = new PublisherAdapter<Integer>(context, publisher, 5);


### PR DESCRIPTION
See #331

The bug was introduced in the 5.0 rewrite, which replaced `InboundBuffer` with `InboundMessageQueue` and added a demand field to `PublisherAdapter` itself, creating dual demand tracking. The accumulated total was then passed to `InboundMessageQueue.fetch()`, which added it again to its own counter.

Refactor so that pause/fetch forward directly to the subscriber when it exists, and only buffer demand (renamed to `pendingDemand`) for calls that arrive before the subscriber is created.